### PR TITLE
Check os.Rename on Windows

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -334,6 +334,16 @@ func (r *Runner) atomicWrite(path string, contents []byte) error {
 		}
 	}
 
+	// Remove the file if we are running on Windows. There is a bug in Go on
+	// Windows such that Go uses MoveFile which raises an exception if the file
+	// already exists.
+	//
+	// See: http://grokbase.com/t/gg/golang-nuts/13aab5f210/go-nuts-atomic-replacement-of-files-on-windows
+	// for more information.
+	if runtime.GOOS == "windows" {
+		os.Remove(path)
+	}
+
 	if err := os.Rename(f.Name(), path); err != nil {
 		return err
 	}


### PR DESCRIPTION
From @armon on https://github.com/hashicorp/consul-template/commit/aee3952e332e54e7042df0c878e44eb69b8a8d0e: 

> I think on windows the Rename fails if the destination already exists. *NIX just overwrites the file. So we may need to delete the target file before the rename.

We should test this and handle it appropriately before the first release.
