### PR TITLE
Sort services by node name

### DIFF
--- a/dependency.go
+++ b/dependency.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"sort"
 	"strconv"
 
 	api "github.com/armon/consul-api"
@@ -60,6 +61,8 @@ func (d *ServiceDependency) Fetch(client *api.Client, options *api.QueryOptions)
 			Port:    uint64(entry.Service.Port),
 		})
 	}
+
+	sort.Stable(ServiceList(services))
 
 	return services, qm, nil
 }

--- a/template.go
+++ b/template.go
@@ -237,6 +237,27 @@ func (s *Service) GoString() string {
 
 /// ------------------------- ///
 
+type ServiceList []*Service
+
+func (s ServiceList) Len() int {
+	return len(s)
+}
+
+func (s ServiceList) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s ServiceList) Less(i, j int) bool {
+	if s[i].Name < s[j].Name {
+		return true
+	} else if s[i].Name == s[j].Name {
+		return s[i].ID <= s[j].ID
+	}
+	return false
+}
+
+/// ------------------------- ///
+
 type KeyPair struct {
 	Key   string
 	Value string

--- a/template_test.go
+++ b/template_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -335,5 +337,45 @@ func TestHashCode_returnsValue(t *testing.T) {
 	expected := "Template|/foo/bar/blitz.ctmpl"
 	if template.HashCode() != expected {
 		t.Errorf("expected %q to equal %q", template.HashCode(), expected)
+	}
+}
+
+func TestServiceList_sorts(t *testing.T) {
+	a := ServiceList{
+		&Service{Name: "a", ID: "b"},
+		&Service{Name: "a", ID: "c"},
+		&Service{Name: "b", ID: "a"},
+	}
+	b := ServiceList{
+		&Service{Name: "a", ID: "c"},
+		&Service{Name: "a", ID: "b"},
+		&Service{Name: "b", ID: "a"},
+	}
+	c := ServiceList{
+		&Service{Name: "b", ID: "a"},
+		&Service{Name: "a", ID: "b"},
+		&Service{Name: "a", ID: "c"},
+	}
+
+	sort.Stable(a)
+	sort.Stable(b)
+	sort.Stable(c)
+
+	expected := ServiceList{
+		&Service{Name: "a", ID: "b"},
+		&Service{Name: "a", ID: "c"},
+		&Service{Name: "b", ID: "a"},
+	}
+
+	if !reflect.DeepEqual(a, expected) {
+		t.Fatal("invalid sort")
+	}
+
+	if !reflect.DeepEqual(b, expected) {
+		t.Fatal("invalid sort")
+	}
+
+	if !reflect.DeepEqual(c, expected) {
+		t.Fatal("invalid sort")
 	}
 }


### PR DESCRIPTION
This prevents Consul Template from triggered a reload when Consul returns the
same results but in a different order
