### PR TITLE
Do not return an error when a template has no dependencies

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -107,7 +107,7 @@ func (w *Watcher) init() error {
 	}
 
 	if len(w.dependencies) == 0 {
-		return fmt.Errorf("watcher: must supply at least one Dependency")
+		log.Printf("[WARN] (watcher) no dependencies in template(s)")
 	}
 
 	// Setup the chans

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -23,13 +23,8 @@ func TestNewWatcher_noClient(t *testing.T) {
 
 func TestNewWatcher_noDependencies(t *testing.T) {
 	_, err := NewWatcher(&api.Client{}, nil)
-	if err == nil {
-		t.Fatal("expected error, but nothing was returned")
-	}
-
-	expected := "watcher: must supply at least one Dependency"
-	if !strings.Contains(err.Error(), expected) {
-		t.Errorf("expected %q to contain %q", err.Error(), expected)
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
This commit changes the behavior of Consul Template when a template is given that lists no dependencies. In the past, Consul Template would return an error, but after discussion, it was deemed better to show a warning and render the given template.

Fixes #31

/cc @mitchellh @danburke
