### PR TITLE
Ignore empty keys during 'ls'. Fixes #54

### DIFF
--- a/template.go
+++ b/template.go
@@ -107,9 +107,9 @@ func (t *Template) Execute(c *TemplateContext) ([]byte, error) {
 		},
 		"ls": func(s string) []*util.KeyPair {
 			result := make([](*util.KeyPair), 0)
-			// Only return top-level keys
+			// Only return non-empty top-level keys
 			for _, pair := range c.KeyPrefixes[s] {
-				if !strings.Contains(pair.Key, "/") {
+				if pair.Key != "" && !strings.Contains(pair.Key, "/") {
 					result = append(result, pair)
 				}
 			}

--- a/template_test.go
+++ b/template_test.go
@@ -295,7 +295,7 @@ func TestExecute_rendersKeys(t *testing.T) {
 func TestExecute_rendersLs(t *testing.T) {
 	inTemplate := test.CreateTempfile([]byte(`
     {{ range ls "service/redis/config" }}
-    {{.Key}} {{.Value}}{{ end }}
+    {{.Key}} = {{.Value}}{{ end }}
   `), t)
 	defer test.DeleteTempfile(inTemplate, t)
 
@@ -314,6 +314,11 @@ func TestExecute_rendersLs(t *testing.T) {
 		Value: "11",
 	}
 
+	emptyFolderConfig := &util.KeyPair{
+		Key:   "",
+		Value: "",
+	}
+
 	childConfig := &util.KeyPair{
 		Key:   "user/sethvargo",
 		Value: "true",
@@ -322,6 +327,7 @@ func TestExecute_rendersLs(t *testing.T) {
 	context := &TemplateContext{
 		KeyPrefixes: map[string][]*util.KeyPair{
 			"service/redis/config": []*util.KeyPair{
+				emptyFolderConfig,
 				minconnsConfig,
 				maxconnsConfig,
 				childConfig,
@@ -335,8 +341,8 @@ func TestExecute_rendersLs(t *testing.T) {
 	}
 
 	expected := bytes.TrimSpace([]byte(`
-    minconns 2
-    maxconns 11
+    minconns = 2
+    maxconns = 11
   `))
 	if !bytes.Equal(bytes.TrimSpace(contents), expected) {
 		t.Errorf("expected \n%q\n to equal \n%q\n", bytes.TrimSpace(contents), expected)


### PR DESCRIPTION
Ignore empty keys during `ls` template function.

/cc @sethvargo @mattupstate
