### PR TITLE
Add a Contains method to Service.Tags

### DIFF
--- a/util/dependency.go
+++ b/util/dependency.go
@@ -412,8 +412,21 @@ type Service struct {
 	Address string
 	ID      string
 	Name    string
-	Tags    []string
+	Tags    ServiceTags
 	Port    uint64
+}
+
+// ServiceTags is a slice of tags assigned to a Service
+type ServiceTags []string
+
+// Contains returns true if the tags exists in the ServiceTags slice.
+func (t ServiceTags) Contains(s string) bool {
+	for _, v := range t {
+		if v == s {
+			return true
+		}
+	}
+	return false
 }
 
 // ServiceList is a sortable slice of Service

--- a/util/dependency_test.go
+++ b/util/dependency_test.go
@@ -449,3 +449,23 @@ func TestParseKeyPrefixDependency_dataCenter(t *testing.T) {
 		t.Errorf("expected %#v to equal %#v", kpd, expected)
 	}
 }
+
+func TestServiceTagsContains(t *testing.T) {
+	s := &Service{
+		Node:    "node",
+		Address: "127.0.0.1",
+		ID:      "id",
+		Name:    "name",
+		Tags:    []string{"foo", "baz"},
+		Port:    1234,
+	}
+	if !s.Tags.Contains("foo") {
+		t.Error("expected Contains to return true for foo.")
+	}
+	if s.Tags.Contains("bar") {
+		t.Error("expected Contains to return false for bar.")
+	}
+	if !s.Tags.Contains("baz") {
+		t.Error("expected Contains to return true for baz.")
+	}
+}


### PR DESCRIPTION
Handy when you want to put a bit more logic into your templates around what tags have been assigned to a service.
