### PR TITLE
added a space to the haproxy template

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ global
 
 defaults
     mode {{key "service/haproxy/mode"}}{{range ls "service/haproxy/timeouts"}}
-    timeout {{.Key}}{{.Value}}{{end}}
+    timeout {{.Key}} {{.Value}}{{end}}
 
 listen http-in
     bind *:8000{{range service "release.webapp"}}


### PR DESCRIPTION
without the space it was spitting out 

```
timeout connect50
```

instead of 

```
timeout connect 50
```
