### PR TITLE
Add helper function (iter) to iterate over a range of integers

### DIFF
--- a/template.go
+++ b/template.go
@@ -149,6 +149,7 @@ func (t *Template) Execute(c *TemplateContext) ([]byte, error) {
 		"toLower":    c.toLower,
 		"toTitle":    c.toTitle,
 		"toUpper":    c.toUpper,
+		"iter":       iter,
 	}).Parse(string(contents))
 
 	if err != nil {
@@ -191,6 +192,7 @@ func (t *Template) init() error {
 		"toLower":    t.noop,
 		"toTitle":    t.noop,
 		"toUpper":    t.noop,
+		"iter":       iter,
 	}).Parse(string(contents))
 
 	if err != nil {
@@ -374,6 +376,35 @@ func (c *TemplateContext) toUpper(s string) (string, error) {
 // replacement value.
 func (c *TemplateContext) replaceAll(f, t, s string) (string, error) {
 	return strings.Replace(s, f, t, -1), nil
+}
+
+// iter retrieves a range of 'size' integers starting at 'start'
+func iter(start, size interface{}) (stream chan int) {
+
+	var new_start, new_size int
+
+	switch v := start.(type) {
+	case float32, float64:
+		new_start = int(v.(float64))
+	default:
+		new_start = int(v.(int))
+	}
+
+	switch v := size.(type) {
+	case float32, float64:
+		new_size = int(v.(float64))
+	default:
+		new_size = int(v.(int))
+	}
+
+	stream = make(chan int)
+	go func() {
+		for i := new_start; i < new_start+new_size; i++ {
+			stream <- i
+		}
+		close(stream)
+	}()
+	return
 }
 
 // DependencyType is an enum type that says the kind of the dependency.

--- a/template_test.go
+++ b/template_test.go
@@ -841,3 +841,25 @@ func TestExecute_toUpper(t *testing.T) {
 		t.Fatalf("expected %q to be %q", contents, expected)
 	}
 }
+
+func TestExecute_iter(t *testing.T) {
+	// parseJSON uses float64 numbers so let iter be able to
+	// handle that case
+	inTemplate := test.CreateTempfile([]byte(`{{range $i := iter 0 10.0}}{{$i}}{{end}}`), t)
+	defer test.DeleteTempfile(inTemplate, t)
+
+	template, err := NewTemplate(inTemplate.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	contents, err := template.Execute(&TemplateContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := []byte("0123456789")
+	if !bytes.Equal(contents, expected) {
+		t.Errorf("expected %q to equal %q", contents, expected)
+	}
+}


### PR DESCRIPTION
Go template doesn't provide an out of the box function to iterate over a range of integers. For example, it could be used on a nginx-site configuration file to dynamically provision backends when those backends are local to node and thus, not registered with consul.

```
...
upstream example {
  {{with $s := key "/service/nginx/<this_node>/config" | parseJSON }}
  {{range $i := iter $s.socket_id $s.pool_size}}
  server unix:{{$s.socket_path}}_{{$i}}.sock{{end}} max_fails=3 slow_start=30s;
  {{end}}
}
...
```
