### PR TITLE
make parseJSON to handle top level JSON arrays

### DIFF
--- a/template.go
+++ b/template.go
@@ -53,7 +53,7 @@ func DecodeString(s string) (interface{}, error) {
 		return map[string]interface{}{}, nil
 	}
 
-	var data map[string]interface{}
+	var data interface{}
 	if err := json.Unmarshal([]byte(s), &data); err != nil {
 		return nil, err
 	}
@@ -332,7 +332,7 @@ type TemplateContext struct {
 
 // decodeJSON returns a structure for valid JSON
 func (c *TemplateContext) decodeJSON(s string) (interface{}, error) {
-	var data map[string]interface{}
+	var data interface{}
 	if err := json.Unmarshal([]byte(s), &data); err != nil {
 		return nil, err
 	}

--- a/template_test.go
+++ b/template_test.go
@@ -601,6 +601,34 @@ func TestExecute_decodeJSON(t *testing.T) {
 	}
 }
 
+func TestExecute_decodeJSONArray(t *testing.T) {
+	inTemplate := test.CreateTempfile([]byte(`
+		{{with $d := file "data.json" | parseJSON}}
+		{{range $i := $d}}{{$i}}{{end}}
+		{{end}}
+	`), t)
+	defer test.DeleteTempfile(inTemplate, t)
+
+	template, err := NewTemplate(inTemplate.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	context := &TemplateContext{
+		File: map[string]string{
+			"data.json": `["1", "2", "3"]`,
+		},
+	}
+	data, err := template.Execute(context)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, expected := bytes.TrimSpace(data), []byte("123")
+	if !bytes.Equal(result, expected) {
+		t.Errorf("expected %q to equal %q", result, expected)
+	}
+}
+
 func TestExecute_decodeJSONDeep(t *testing.T) {
 	inTemplate := test.CreateTempfile([]byte(`
 		{{with $d := file "data.json" | parseJSON}}


### PR DESCRIPTION
It seems that parseJSON can't handle top level JSON arrays, forcing us to use a map to store a simple collection:

```
{"dummy": ["1", "2","3"]}
```
