### PR TITLE
new shell script to build static binary

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -6,7 +6,6 @@ case $1 in
 
 runbuild)
         echo "BUILDING consul-template"
-        # CGO_ENABLED=0 godep go build -a -ldflags '-s' -o run/enterpriseManager
         go get -d ./...
         go build -ldflags '-linkmode external -extldflags "-static" ' -o bin/$NAME
 ;;
@@ -15,8 +14,6 @@ runbuild)
         echo "RUNNING BUILD IN DOCKER CONTAINER"
         docker run --rm -it -v "$(pwd)":/usr/src/myapp -w /usr/src/myapp golang:1.3.3 ./make.sh runbuild
 
-        # cd run
-        # docker build --tag ionic/consultemplate .
 ;;
 
 esac


### PR DESCRIPTION
This is a new script that makes it easy to build consul-template as a static binary using the golang:1.3.3 library container.  The idea is to create a very small footprint binary that can be included in any docker image like busybox etc.  

I'm using this to create a docker image called "service proxy" that contains consul-template and haproxy working together
