### PR TITLE
Filter empty keys in 'tree' (folder nodes)

### DIFF
--- a/template.go
+++ b/template.go
@@ -139,7 +139,15 @@ func (t *Template) Execute(c *TemplateContext) ([]byte, error) {
 			return c.Services[d.Key()], nil
 		},
 		"tree": func(s string) []*util.KeyPair {
-			return c.KeyPrefixes[s]
+			var result []*util.KeyPair
+			// Filter empty keys (folder nodes)
+			for _, pair := range c.KeyPrefixes[s] {
+				parts := strings.Split(pair.Key, "/")
+				if parts[len(parts)-1] != "" {
+					result = append(result, pair)
+				}
+			}
+			return result
 		},
 
 		// Helper functions

--- a/template_test.go
+++ b/template_test.go
@@ -497,12 +497,24 @@ func TestExecute_rendersTree(t *testing.T) {
 		Value: "true",
 	}
 
+	emptyFolderConfig := &util.KeyPair{
+		Key:   "",
+		Value: "",
+	}
+
+	emptyChildFolderConfig := &util.KeyPair{
+		Key:   "user/",
+		Value: "",
+	}
+
 	context := &TemplateContext{
 		KeyPrefixes: map[string][]*util.KeyPair{
 			"service/redis/config": []*util.KeyPair{
 				minconnsConfig,
 				maxconnsConfig,
 				childConfig,
+				emptyFolderConfig,
+				emptyChildFolderConfig,
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #106.

@sethvargo this should work for the 99% case, but what I realized in doing this is that we eliminate the possibility of getting the values of "folder" nodes in both `ls` and `tree`. I thought maybe we should add an extra condition, which would include the "folder" key if it had a value, but not if it didn't. This complicates things a little more, and I'm not sure we would ever need it, so it's not part of this PR. Just something to think about.
