### PR TITLE
Feature/getenv

### DIFF
--- a/template.go
+++ b/template.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-  "os"
+	"os"
 	"strings"
 	"text/template"
 
@@ -137,7 +137,7 @@ func (t *Template) Execute(c *TemplateContext) ([]byte, error) {
 
 		// Helper functions
 		"byTag":      c.groupByTag,
-    "getenv":     c.getenv,
+		"getenv":     c.getenv,
 		"parseJSON":  c.decodeJSON,
 		"replaceAll": c.replaceAll,
 		"toLower":    c.toLower,
@@ -180,7 +180,7 @@ func (t *Template) init() error {
 
 		// Helper functions
 		"byTag":      t.noop,
-    "getenv":     t.noop,
+		"getenv":     t.noop,
 		"parseJSON":  t.noop,
 		"replaceAll": t.noop,
 		"toLower":    t.noop,
@@ -350,10 +350,10 @@ func (c *TemplateContext) groupByTag(in []*util.Service) map[string][]*util.Serv
 	return m
 }
 
-// returns the value of the environment variable set  
+// returns the value of the environment variable set
 
 func (c *TemplateContext) getenv(s string) (string, error) {
-  return os.Getenv(s), nil
+	return os.Getenv(s), nil
 }
 
 // toLower converts the given string (usually by a pipe) to lowercase.

--- a/template_test.go
+++ b/template_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"bytes"
-  "os"
+	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -804,24 +804,24 @@ func TestExecute_serviceTagsContains(t *testing.T) {
 }
 
 func TestExecute_getenv(t *testing.T) {
-  inTemplate := test.CreateTempfile([]byte(`{{getenv "CONSUL_TEMPLATE_TESTVAR"}}`), t)
+	inTemplate := test.CreateTempfile([]byte(`{{getenv "CONSUL_TEMPLATE_TESTVAR"}}`), t)
 	defer test.DeleteTempfile(inTemplate, t)
 
-  template, err := NewTemplate(inTemplate.Name())
-  if err != nil {
-   t.Fatal(err)
-  }
-  
-  os.Setenv("CONSUL_TEMPLATE_TESTVAR", "F0F0F0") 
-  contents, err := template.Execute(&TemplateContext{})
-  if err != nil { 
-   t.Fatal(err)
-  }
-  
-  expected := []byte("F0F0F0") 
-  if !bytes.Equal(contents, expected) {
-    t.Fatalf("expected %q to be %q", contents, expected)
-  }
+	template, err := NewTemplate(inTemplate.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	os.Setenv("CONSUL_TEMPLATE_TESTVAR", "F0F0F0")
+	contents, err := template.Execute(&TemplateContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := []byte("F0F0F0")
+	if !bytes.Equal(contents, expected) {
+		t.Fatalf("expected %q to be %q", contents, expected)
+	}
 
 }
 


### PR DESCRIPTION
This adds a "getenv" function to the template. This allows a template to reference values that are passed at runtime (as in during the launch of a container). 

Note, due to https://github.com/hashicorp/consul-template/issues/64, these variables cannot be used to query consul at this time. 

Example: 

```
cluster_id: {{ getenv "CLUSTER_ID | toLower}}

```
