### PR TITLE
Listen for a signal to prevent a deadlock

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -107,7 +107,6 @@ func TestRun_onceFlag(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Errorf("expected data, but nothing was returned")
 	}
-
 }
 
 func TestQuiescence(t *testing.T) {


### PR DESCRIPTION
If the user does not specify any dependencies, the watcher has no data to return, which results in a deadlock. This prevents such a case by  adding a signal channel listener.

/cc @armon @mitchellh @ryanuber 
