### PR TITLE
Support Windows drive letters

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"regexp"
 	"strings"
 	"time"
 
@@ -12,6 +13,9 @@ import (
 	"github.com/hashicorp/hcl"
 	"github.com/mitchellh/mapstructure"
 )
+
+// The pattern to split the config template syntax on
+var configTemplateRe = regexp.MustCompile("([a-zA-Z]:)?([^:]+)")
 
 // Config is used to configure Consul Template
 type Config struct {
@@ -131,7 +135,7 @@ func ParseConfigTemplate(s string) (*ConfigTemplate, error) {
 	}
 
 	var source, destination, command string
-	parts := strings.Split(s, ":")
+	parts := configTemplateRe.FindAllString(s, -1)
 
 	switch len(parts) {
 	case 1:

--- a/config_test.go
+++ b/config_test.go
@@ -223,6 +223,24 @@ func TestParseConfigurationTemplate_tooManyArgs(t *testing.T) {
 	}
 }
 
+// Test that we properly parse Windows drive paths
+func TestParseConfigurationTemplate_windowsDrives(t *testing.T) {
+	ct, err := ParseConfigTemplate(`C:\abc\123:D:\xyz\789:some command`)
+	if err != nil {
+		t.Fatalf("failed parsing windows drive letters: %s", err)
+	}
+
+	expected := &ConfigTemplate{
+		Source:      `C:\abc\123`,
+		Destination: `D:\xyz\789`,
+		Command:     "some command",
+	}
+
+	if !reflect.DeepEqual(ct, expected) {
+		t.Fatalf("unexpected result parsing windows drives: %#v", ct)
+	}
+}
+
 // Test that a source value is correctly used
 func TestParseConfigurationTemplate_source(t *testing.T) {
 	source := "/tmp/config.ctmpl"


### PR DESCRIPTION
This allows specifying Windows drive letters in the config template syntax. Previously this was disallowed by the config parser, which just split the whole template config on the `:` character. Fixes #78.

/cc @sethvargo @armon @mitchellh @cixelsyd
