### PR TITLE
Add options for enabling HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Usage
 | ------ | -------- |------------ |
 | `consul`    | _(required)_ | The location of the Consul instance to query (may be an IP address or FQDN) with port. |
 | `template`  | _(required)_ | The input template, output path, and optional command separated by a colon (`:`). This option is additive and may be specified multiple times for multiple templates. |
-| `https`     | | Use HTTPS while talking to Consul. Requires the Consul server to be configured to serve secure connections.
-| `insecure`  | | Ignore certificate warnings. Only used if `https` is enabled.
+| `ssl`       | | Use HTTPS while talking to Consul. Requires the Consul server to be configured to serve secure connections.
+| `ssl_no_verify` | | Ignore certificate warnings. Only used if `ssl` is enabled.
 | `token`     | | The [Consul API token][Consul ACLs]. |
 | `config`    | | The path to a configuration file or directory on disk, relative to the current working directory. Values specified on the CLI take precedence over values specified in the configuration file |
 | `wait`      | | The `minimum(:maximum)` to wait before rendering a new template to disk and triggering a command, separated by a colon (`:`). If the optional maximum value is omitted, it is assumed to be 4x the required minimum value. |

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Usage
 | ------ | -------- |------------ |
 | `consul`    | _(required)_ | The location of the Consul instance to query (may be an IP address or FQDN) with port. |
 | `template`  | _(required)_ | The input template, output path, and optional command separated by a colon (`:`). This option is additive and may be specified multiple times for multiple templates. |
+| `https`     | | Use HTTPS while talking to Consul. Requires the Consul server to be configured to serve secure connections.
+| `insecure`  | | Ignore certificate warnings. Only used if `https` is enabled.
 | `token`     | | The [Consul API token][Consul ACLs]. |
 | `config`    | | The path to a configuration file or directory on disk, relative to the current working directory. Values specified on the CLI take precedence over values specified in the configuration file |
 | `wait`      | | The `minimum(:maximum)` to wait before rendering a new template to disk and triggering a command, separated by a colon (`:`). If the optional maximum value is omitted, it is assumed to be 4x the required minimum value. |

--- a/cli.go
+++ b/cli.go
@@ -67,9 +67,9 @@ func (cli *CLI) Run(args []string) int {
 	}
 	flags.StringVar(&config.Consul, "consul", "",
 		"address of the Consul instance")
-	flags.BoolVar(&config.HTTPS, "https", false,
+	flags.BoolVar(&config.UseSSL, "ssl", false,
 		"use https while talking to consul")
-	flags.BoolVar(&config.Insecure, "insecure", false,
+	flags.BoolVar(&config.SSLNoVerify, "ssl-no-verify", false,
 		"ignore certificate warnings under https")
 	flags.Var((*configTemplateVar)(&config.ConfigTemplates), "template",
 		"new template declaration")
@@ -269,10 +269,10 @@ func bootstrap(config *Config, dry bool, once bool) (*Runner, *watch.Watcher, er
 	if config.Token != "" {
 		consulConfig.Token = config.Token
 	}
-	if config.HTTPS {
+	if config.UseSSL {
 		consulConfig.Scheme = "https"
 	}
-	if config.Insecure {
+	if config.SSLNoVerify {
 		consulConfig.HttpClient.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,

--- a/cli.go
+++ b/cli.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"bytes"
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -65,6 +67,10 @@ func (cli *CLI) Run(args []string) int {
 	}
 	flags.StringVar(&config.Consul, "consul", "",
 		"address of the Consul instance")
+	flags.BoolVar(&config.HTTPS, "https", false,
+		"use https while talking to consul")
+	flags.BoolVar(&config.Insecure, "insecure", false,
+		"ignore certificate warnings under https")
 	flags.Var((*configTemplateVar)(&config.ConfigTemplates), "template",
 		"new template declaration")
 	flags.StringVar(&config.Token, "token", "",
@@ -262,6 +268,16 @@ func bootstrap(config *Config, dry bool, once bool) (*Runner, *watch.Watcher, er
 	}
 	if config.Token != "" {
 		consulConfig.Token = config.Token
+	}
+	if config.HTTPS {
+		consulConfig.Scheme = "https"
+	}
+	if config.Insecure {
+		consulConfig.HttpClient.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		}
 	}
 	client, err := api.NewClient(consulConfig)
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -28,6 +28,13 @@ type Config struct {
 	// address or FQDN) with port.
 	Consul string `mapstructure:"consul"`
 
+	// HTTPS indicates we should use a secure connection while talking to
+	// Consul. This requires Consul to be configured to serve HTTPS.
+	HTTPS bool `mapstructure:"https"`
+
+	// Insecure determines if we should skip certificate warnings when using SSL
+	Insecure bool `mapstructure:"insecure"`
+
 	// ConfigTemplates is a slice of the ConfigTemplate objects in the config.
 	ConfigTemplates []*ConfigTemplate `mapstructure:"template"`
 
@@ -48,6 +55,14 @@ type Config struct {
 func (c *Config) Merge(config *Config) {
 	if config.Consul != "" {
 		c.Consul = config.Consul
+	}
+
+	if config.HTTPS {
+		c.HTTPS = true
+	}
+
+	if config.Insecure {
+		c.Insecure = true
 	}
 
 	if len(config.ConfigTemplates) > 0 {

--- a/config.go
+++ b/config.go
@@ -28,12 +28,12 @@ type Config struct {
 	// address or FQDN) with port.
 	Consul string `mapstructure:"consul"`
 
-	// HTTPS indicates we should use a secure connection while talking to
+	// UseSSL indicates we should use a secure connection while talking to
 	// Consul. This requires Consul to be configured to serve HTTPS.
-	HTTPS bool `mapstructure:"https"`
+	UseSSL bool `mapstructure:"ssl"`
 
-	// Insecure determines if we should skip certificate warnings when using SSL
-	Insecure bool `mapstructure:"insecure"`
+	// SSLNoVerify determines if we should skip certificate warnings
+	SSLNoVerify bool `mapstructure:"ssl_no_verify"`
 
 	// ConfigTemplates is a slice of the ConfigTemplate objects in the config.
 	ConfigTemplates []*ConfigTemplate `mapstructure:"template"`
@@ -57,12 +57,12 @@ func (c *Config) Merge(config *Config) {
 		c.Consul = config.Consul
 	}
 
-	if config.HTTPS {
-		c.HTTPS = true
+	if config.UseSSL {
+		c.UseSSL = true
 	}
 
-	if config.Insecure {
-		c.Insecure = true
+	if config.SSLNoVerify {
+		c.SSLNoVerify = true
 	}
 
 	if len(config.ConfigTemplates) > 0 {

--- a/config_test.go
+++ b/config_test.go
@@ -89,15 +89,15 @@ func TestMerge_HttpsOptions(t *testing.T) {
 	{
 		// True merges over false
 		config := &Config{
-			HTTPS:    false,
-			Insecure: false,
+			UseSSL:      false,
+			SSLNoVerify: false,
 		}
 		otherConfig := &Config{
-			HTTPS:    true,
-			Insecure: true,
+			UseSSL:      true,
+			SSLNoVerify: true,
 		}
 		config.Merge(otherConfig)
-		if !config.HTTPS || !config.Insecure {
+		if !config.UseSSL || !config.SSLNoVerify {
 			t.Fatalf("bad: %#v", config)
 		}
 	}
@@ -105,15 +105,15 @@ func TestMerge_HttpsOptions(t *testing.T) {
 	{
 		// False does not merge over true
 		config := &Config{
-			HTTPS:    true,
-			Insecure: true,
+			UseSSL:      true,
+			SSLNoVerify: true,
 		}
 		otherConfig := &Config{
-			HTTPS:    false,
-			Insecure: false,
+			UseSSL:      false,
+			SSLNoVerify: false,
 		}
 		config.Merge(otherConfig)
-		if !config.HTTPS || !config.Insecure {
+		if !config.UseSSL || !config.SSLNoVerify {
 			t.Fatalf("bad: %#v", config)
 		}
 	}
@@ -172,8 +172,8 @@ func TestParseConfig_mapstructureError(t *testing.T) {
 func TestParseConfig_correctValues(t *testing.T) {
 	configFile := test.CreateTempfile([]byte(`
     consul = "nyc1.demo.consul.io"
-    https = true
-    insecure = true
+    ssl = true
+    ssl_no_verify = true
     token = "abcd1234"
     wait = "5s:10s"
     retry = "10s"
@@ -197,11 +197,11 @@ func TestParseConfig_correctValues(t *testing.T) {
 	}
 
 	expected := &Config{
-		Path:     configFile.Name(),
-		Consul:   "nyc1.demo.consul.io",
-		HTTPS:    true,
-		Insecure: true,
-		Token:    "abcd1234",
+		Path:        configFile.Name(),
+		Consul:      "nyc1.demo.consul.io",
+		UseSSL:      true,
+		SSLNoVerify: true,
+		Token:       "abcd1234",
 		Wait: &watch.Wait{
 			Min: time.Second * 5,
 			Max: time.Second * 10,


### PR DESCRIPTION
Adds the `https` and `insecure` bool config options for talking to an HTTPS consul instance.
Fixes #143.

/cc @sethvargo