### PR TITLE
Add "datacenters" template function to list datacenters

### DIFF
--- a/bridges.go
+++ b/bridges.go
@@ -150,3 +150,26 @@ func (d *serviceDependencyBridge) inContext(c *TemplateContext) bool {
 	_, ok := c.healthServices[d.Key()]
 	return ok
 }
+
+// datacentersDependencyBridge is a bridged interface with extra
+// helpers for adding and removing items from a TemplateContext
+type datacentersDependencyBridge struct{ *dependency.Datacenters }
+
+// addToContext accepts a TemplateContext and data. It coerces the interface{}
+// data into the correct format via type assertions, returning any errors that
+// occur. The data is then set on the TemplateContext
+func (d *datacentersDependencyBridge) addToContext(c *TemplateContext, data interface{}) error {
+	coerced, ok := data.([]string)
+	if !ok {
+		return fmt.Errorf("key prefix dependency: could not convert to Datacenters")
+	}
+
+	c.datacenters[d.Key()] = coerced
+	return nil
+}
+
+// inContext checks if the dependency is contained in the given TemplateContext.
+func (d *datacentersDependencyBridge) inContext(c *TemplateContext) bool {
+	_, ok := c.datacenters[d.Key()]
+	return ok
+}

--- a/dependency/datacenters.go
+++ b/dependency/datacenters.go
@@ -1,0 +1,45 @@
+package dependency
+
+import (
+	"github.com/hashicorp/consul/api"
+	"log"
+	"sort"
+	"time"
+)
+
+type Datacenters struct {
+}
+
+func (d *Datacenters) Fetch(client *api.Client, options *api.QueryOptions) (interface{}, *api.QueryMeta, error) {
+	log.Printf("[DEBUG] (%s) querying Consul with %+v", d.Display(), options)
+
+	catalog := client.Catalog()
+	dcs, err := catalog.Datacenters()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	log.Printf("[DEBUG] (%s) Consul returned %d datacenters", d.Display(), len(dcs))
+	sort.Strings(dcs)
+	return dcs, &api.QueryMeta{LastIndex: uint64(time.Now().Unix())}, nil
+}
+
+func (d *Datacenters) HashCode() string {
+	return "Datacenters"
+}
+
+func (d *Datacenters) Key() string {
+	return "datacenters"
+}
+
+func (d *Datacenters) Display() string {
+	return "datacenters"
+}
+
+// ParseDataCenters generates a service dependency from incoming strings
+//
+// Except that the data centers function doesn't take any arguments,
+// so it really just instantiates the dependency
+func ParseDatacenters() (*Datacenters, error) {
+	return &Datacenters{}, nil
+}

--- a/template_context.go
+++ b/template_context.go
@@ -18,6 +18,7 @@ type TemplateContext struct {
 	files            map[string]string
 	storeKeys        map[string]string
 	storeKeyPrefixes map[string][]*dependency.KeyPair
+	datacenters      map[string][]string
 }
 
 // NewTemplateContext creates a new TemplateContext with empty values for each
@@ -30,6 +31,7 @@ func NewTemplateContext() (*TemplateContext, error) {
 		files:            make(map[string]string),
 		storeKeys:        make(map[string]string),
 		storeKeyPrefixes: make(map[string][]*dependency.KeyPair),
+		datacenters:      make(map[string][]string),
 	}, nil
 }
 


### PR DESCRIPTION
This is decidedly imperfect (see in particular the synthesized `QueryMeta` in `Datacenters.Fetch` - I was mostly just looking for something that would make it run to see if it worked), but I'm curious whether there's interest in a cleaned up version of this function.

I suspect in practice the utility of a `datacenters` function will be limited by #64, but it seems like an element of the consul catalog that's noticeably missing from the current functionality. Thoughts?