### PR TITLE
Diff missing dependencies with unwatched dependencies

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -79,7 +79,7 @@ type Runner struct {
 // NewRunner accepts a slice of ConfigTemplates and returns a pointer to the new
 // Runner and any error that occurred during creation.
 func NewRunner(config *Config, dry, once bool) (*Runner, error) {
-	log.Printf("[INFO] (runner) creating new runner (dry: %b, once: %b)", dry, once)
+	log.Printf("[INFO] (runner) creating new runner (dry: %s, once: %s)", dry, once)
 
 	runner := &Runner{
 		config: config,

--- a/runner.go
+++ b/runner.go
@@ -234,11 +234,20 @@ func (r *Runner) Run() error {
 			}
 		}
 
-		// If there are missing dependencies, start the watcher and move onto the
+		// Diff any missing dependencies the template reported with dependencies
+		// the watcher is watching.
+		var unwatched []dep.Dependency
+		for _, d := range missing {
+			if !r.watcher.Watching(d) {
+				unwatched = append(unwatched, d)
+			}
+		}
+
+		// If there are unwatched dependencies, start the watcher and move onto the
 		// next one.
-		if len(missing) > 0 {
-			log.Printf("[INFO] (runner) was missing %d dependencies", len(missing))
-			for _, dep := range missing {
+		if len(unwatched) > 0 {
+			log.Printf("[INFO] (runner) was not watching %d dependencies", len(unwatched))
+			for _, dep := range unwatched {
 				r.watcher.Add(dep)
 			}
 			continue

--- a/watch/watcher.go
+++ b/watch/watcher.go
@@ -150,7 +150,7 @@ func (w *Watcher) Stop() {
 	log.Printf("[INFO] (watcher) stopping all views")
 
 	for _, view := range w.depViewMap {
-		log.Printf("[DEBUG] (watcher) stopping %+v", view)
+		log.Printf("[DEBUG] (watcher) stopping %s", view.Dependency.Display())
 		view.stop()
 	}
 


### PR DESCRIPTION
As reported in #168, there is a fun data race where Consul Template loops indefinitely when a template reports missing dependencies but the watcher is already watching the dependencies (but has not yet returned data).

This diffs the watcher's list of watches with the dependencies a template is reporting as missing and only restarts the loop if there are unwatched dependencies (not just ones that have not returned data yet).