### PR TITLE
Fix runner scope during SIGHUP handling. Fixes #175.

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -158,7 +158,7 @@ func (cli *CLI) Run(args []string) int {
 			case syscall.SIGHUP:
 				fmt.Fprintf(cli.errStream, "Received HUP, reloading configuration...\n")
 				runner.Stop()
-				runner, err := NewRunner(config, dry, once)
+				runner, err = NewRunner(config, dry, once)
 				if err != nil {
 					return cli.handleError(err, ExitCodeRunnerError)
 				}


### PR DESCRIPTION
Fixes an issue where SIGHUP would try to reload, but end up stopping consul-template.

@sethvargo can you take a look?