### PR TITLE
Add -max-stale and configurable -batch-size

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Usage
 | `ssl_no_verify` | | Ignore certificate warnings. Only used if `ssl` is enabled. |
 | `token`         | | The [Consul API token][Consul ACLs]. |
 | `template`      | _(required)_ | The input template, output path, and optional command separated by a colon (`:`). This option is additive and may be specified multiple times for multiple templates. |
+| `batch_size`    | | The size of the batch when polling multiple dependencies. |
 | `wait`          | | The `minimum(:maximum)` to wait before rendering a new template to disk and triggering a command, separated by a colon (`:`). If the optional maximum value is omitted, it is assumed to be 4x the required minimum value. |
 | `retry`         | | The amount of time to wait if Consul returns an error when communicating with the API. |
 | `config`        | | The path to a configuration file or directory on disk, relative to the current working directory. Values specified on the CLI take precedence over values specified in the configuration file |

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Usage
 | --------------- | ------------ |------------ |
 | `auth`         | | Specify a username (and password) for basic authentication. |
 | `consul`        | _(required)_ | The location of the Consul instance to query (may be an IP address or FQDN) with port. |
+| `max_stale`     | | The maximum staleness of a query. If specified, Consul will distribute work among all servers instead of just the leader. |
 | `ssl`           | | Use HTTPS while talking to Consul. Requires the Consul server to be configured to serve secure connections.
 | `ssl_no_verify` | | Ignore certificate warnings. Only used if `ssl` is enabled. |
 | `token`         | | The [Consul API token][Consul ACLs]. |

--- a/cli.go
+++ b/cli.go
@@ -74,6 +74,8 @@ func (cli *CLI) Run(args []string) int {
 		"ignore certificate warnings under https")
 	flags.StringVar(&auth, "auth", "",
 		"set basic auth username[:password]")
+	flags.DurationVar(&config.MaxStale, "max-stale", 0,
+		"the maximum time to wait for stale queries")
 	flags.Var((*configTemplateVar)(&config.ConfigTemplates), "template",
 		"new template declaration")
 	flags.StringVar(&config.Token, "token", "",
@@ -211,6 +213,9 @@ Options:
 
   -auth=<user[:pass]>      Set the basic authentication username (and password)
   -consul=<address>        Sets the address of the Consul instance
+  -max-stale=<duration>    Set the maximum staleness and allow stale queries to
+                           Consul which will distribute work among all servers
+                           instead of just the leader
   -ssl                     Use SSL when connecting to Consul
   -ssl-no-verify           Ignore certificate warnings when connecting via SSL
   -token=<token>           Sets the Consul API token

--- a/cli.go
+++ b/cli.go
@@ -80,6 +80,8 @@ func (cli *CLI) Run(args []string) int {
 		"new template declaration")
 	flags.StringVar(&config.Token, "token", "",
 		"a consul API token")
+	flags.IntVar(&config.BatchSize, "batch-size", 0,
+		"the size of the batch of dependencies")
 	flags.StringVar(&config.WaitRaw, "wait", "",
 		"the minimum(:maximum) to wait before rendering a new template")
 	flags.StringVar(&config.Path, "config", "",
@@ -221,11 +223,13 @@ Options:
   -token=<token>           Sets the Consul API token
 
   -template=<template>     Adds a new template to watch on disk in the format
-                           'templatePath:outputPath(:command)'.
+                           'templatePath:outputPath(:command)'
+  -batch-size=<size>       Set the size of the batch when polling multiple
+                           dependencies
   -wait=<duration>         Sets the 'minumum(:maximum)' amount of time to wait
                            before writing a template (and triggering a command)
   -retry=<duration>        The amount of time to wait if Consul returns an
-                           error when communicating with the API.
+                           error when communicating with the API
 
   -config=<path>           Sets the path to a configuration file on disk
 

--- a/config.go
+++ b/config.go
@@ -48,6 +48,9 @@ type Config struct {
 	// ConfigTemplates is a slice of the ConfigTemplate objects in the config.
 	ConfigTemplates []*ConfigTemplate `mapstructure:"template"`
 
+	// BatchSize is the size of the batch when polling multiple dependencies.
+	BatchSize int `mapstructure:"batch_size"`
+
 	// Retry is the duration of time to wait between Consul failures.
 	Retry    time.Duration `mapstructure:"-"`
 	RetryRaw string        `mapstructure:"retry" json:""`
@@ -100,6 +103,10 @@ func (c *Config) Merge(config *Config) {
 				Command:     template.Command,
 			})
 		}
+	}
+
+	if config.BatchSize != 0 {
+		c.BatchSize = config.BatchSize
 	}
 
 	if config.Retry != 0 {

--- a/config_test.go
+++ b/config_test.go
@@ -62,6 +62,7 @@ func TestMerge_complexConfig(t *testing.T) {
 		Retry:           5 * time.Second,
 		Token:           "abc123",
 		MaxStale:        3 * time.Second,
+		BatchSize:       100,
 		Wait:            &watch.Wait{Min: 5 * time.Second, Max: 10 * time.Second},
 	}
 	otherConfig := &Config{
@@ -78,6 +79,7 @@ func TestMerge_complexConfig(t *testing.T) {
 		Retry:           15 * time.Second,
 		Token:           "def456",
 		MaxStale:        3 * time.Second,
+		BatchSize:       100,
 		Wait:            &watch.Wait{Min: 25 * time.Second, Max: 50 * time.Second},
 	}
 
@@ -188,6 +190,7 @@ func TestParseConfig_correctValues(t *testing.T) {
     ssl = true
     ssl_no_verify = true
     token = "abcd1234"
+    batch_size = 100
     wait = "5s:10s"
     retry = "10s"
 
@@ -217,6 +220,7 @@ func TestParseConfig_correctValues(t *testing.T) {
 		SSL:         true,
 		SSLNoVerify: true,
 		Token:       "abcd1234",
+		BatchSize:   100,
 		Wait: &watch.Wait{
 			Min: time.Second * 5,
 			Max: time.Second * 10,

--- a/config_test.go
+++ b/config_test.go
@@ -61,6 +61,7 @@ func TestMerge_complexConfig(t *testing.T) {
 		ConfigTemplates: templates[:2],
 		Retry:           5 * time.Second,
 		Token:           "abc123",
+		MaxStale:        3 * time.Second,
 		Wait:            &watch.Wait{Min: 5 * time.Second, Max: 10 * time.Second},
 	}
 	otherConfig := &Config{
@@ -76,6 +77,7 @@ func TestMerge_complexConfig(t *testing.T) {
 		ConfigTemplates: templates,
 		Retry:           15 * time.Second,
 		Token:           "def456",
+		MaxStale:        3 * time.Second,
 		Wait:            &watch.Wait{Min: 25 * time.Second, Max: 50 * time.Second},
 	}
 
@@ -182,6 +184,7 @@ func TestParseConfig_mapstructureError(t *testing.T) {
 func TestParseConfig_correctValues(t *testing.T) {
 	configFile := test.CreateTempfile([]byte(`
     consul = "nyc1.demo.consul.io"
+    max_stale = "5s"
     ssl = true
     ssl_no_verify = true
     token = "abcd1234"
@@ -209,6 +212,8 @@ func TestParseConfig_correctValues(t *testing.T) {
 	expected := &Config{
 		Path:        configFile.Name(),
 		Consul:      "nyc1.demo.consul.io",
+		MaxStale:    time.Second * 5,
+		MaxStaleRaw: "5s",
 		SSL:         true,
 		SSLNoVerify: true,
 		Token:       "abcd1234",

--- a/dependency/datacenters_test.go
+++ b/dependency/datacenters_test.go
@@ -40,7 +40,7 @@ func TestDatacentersFetch_blocks(t *testing.T) {
 	select {
 	case <-dataCh:
 		t.Errorf("expected query to block")
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(50 * time.Millisecond):
 		// Test pases
 	}
 }

--- a/runner.go
+++ b/runner.go
@@ -730,13 +730,17 @@ func newAPIClient(config *Config) (*api.Client, error) {
 func newWatcher(config *Config, client *api.Client, once bool) (*watch.Watcher, error) {
 	log.Printf("[INFO] (runner) creating Watcher")
 
-	watcher, err := watch.NewWatcher(client, once)
+	watcher, err := watch.NewWatcher(&watch.WatcherConfig{
+		Client:   client,
+		Once:     once,
+		MaxStale: 0,
+		RetryFunc: func(current time.Duration) time.Duration {
+			return config.Retry
+		},
+		BatchSize: 24, // todo
+	})
 	if err != nil {
 		return nil, err
-	}
-
-	if config.Retry != 0 {
-		watcher.SetRetry(config.Retry)
 	}
 
 	return watcher, err

--- a/runner.go
+++ b/runner.go
@@ -733,11 +733,11 @@ func newWatcher(config *Config, client *api.Client, once bool) (*watch.Watcher, 
 	watcher, err := watch.NewWatcher(&watch.WatcherConfig{
 		Client:   client,
 		Once:     once,
-		MaxStale: 0,
+		MaxStale: config.MaxStale,
 		RetryFunc: func(current time.Duration) time.Duration {
 			return config.Retry
 		},
-		BatchSize: 24, // todo
+		BatchSize: config.BatchSize,
 	})
 	if err != nil {
 		return nil, err

--- a/runner_test.go
+++ b/runner_test.go
@@ -499,8 +499,8 @@ func TestRunner_quiescence(t *testing.T) {
 	config := &Config{
 		Consul: "demo.consul.io",
 		Wait: &watch.Wait{
-			Min: 500 * time.Millisecond,
-			Max: 1 * time.Second,
+			Min: 50 * time.Millisecond,
+			Max: 500 * time.Second,
 		},
 		ConfigTemplates: []*ConfigTemplate{
 			&ConfigTemplate{
@@ -518,8 +518,8 @@ func TestRunner_quiescence(t *testing.T) {
 	go runner.Start()
 	defer runner.Stop()
 
-	min := time.After(500 * time.Millisecond)
-	max := time.After(2 * time.Second)
+	min := time.After(100 * time.Millisecond)
+	max := time.After(1 * time.Second)
 	for {
 		select {
 		case <-min:

--- a/watch/view.go
+++ b/watch/view.go
@@ -74,7 +74,10 @@ func (v *View) poll(viewCh chan<- *View, errCh chan<- error) {
 			currentRetry = defaultRetry
 
 			log.Printf("[INFO] (view) %s received data from consul", v.display())
-			viewCh <- v
+			select {
+			case viewCh <- v:
+			case <-v.stopCh:
+			}
 
 			// If we are operating in once mode, do not loop - we received data at
 			// least once which is the API promise here.

--- a/watch/view.go
+++ b/watch/view.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/hashicorp/consul-template/dependency"
+	dep "github.com/hashicorp/consul-template/dependency"
 	"github.com/hashicorp/consul/api"
 )
 
@@ -22,15 +22,17 @@ const (
 // received from Consul.
 type View struct {
 	// Dependency is the dependency that is associated with this View
-	Dependency dependency.Dependency
+	Dependency dep.Dependency
+
+	// config is the configuration for the watcher that created this view and
+	// contains important information about how this view should behave when
+	// polling including retry functions and handling stale queries.
+	config *WatcherConfig
 
 	// Data is the most-recently-received data from Consul for this View
 	Data         interface{}
 	receivedData bool
 	lastIndex    uint64
-
-	// client is the Consul API client
-	client *api.Client
 
 	// stopCh is used to stop polling on this View
 	stopCh chan struct{}
@@ -38,18 +40,18 @@ type View struct {
 
 // NewView creates a new view object from the given Consul API client and
 // Dependency. If an error occurs, it will be returned.
-func NewView(client *api.Client, dep dependency.Dependency) (*View, error) {
-	if client == nil {
-		return nil, fmt.Errorf("view: missing Consul API client")
+func NewView(config *WatcherConfig, d dep.Dependency) (*View, error) {
+	if config == nil {
+		return nil, fmt.Errorf("view: missing config")
 	}
 
-	if dep == nil {
-		return nil, fmt.Errorf("view: missing Dependency")
+	if d == nil {
+		return nil, fmt.Errorf("view: missing dependency")
 	}
 
 	return &View{
-		Dependency: dep,
-		client:     client,
+		Dependency: d,
+		config:     config,
 		stopCh:     make(chan struct{}),
 	}, nil
 }
@@ -58,7 +60,7 @@ func NewView(client *api.Client, dep dependency.Dependency) (*View, error) {
 // accounts for interrupts on the interrupt channel. This allows the poll
 // function to be fired in a goroutine, but then halted even if the fetch
 // function is in the middle of a blocking query.
-func (v *View) poll(once bool, viewCh chan<- *View, errCh chan<- error, retryFunc RetryFunc) {
+func (v *View) poll(viewCh chan<- *View, errCh chan<- error) {
 	currentRetry := defaultRetry
 
 	for {
@@ -76,7 +78,7 @@ func (v *View) poll(once bool, viewCh chan<- *View, errCh chan<- error, retryFun
 
 			// If we are operating in once mode, do not loop - we received data at
 			// least once which is the API promise here.
-			if once {
+			if v.config.Once {
 				return
 			}
 		case err := <-fetchErrCh:
@@ -91,7 +93,9 @@ func (v *View) poll(once bool, viewCh chan<- *View, errCh chan<- error, retryFun
 			// }
 
 			// Sleep and retry
-			currentRetry = retryFunc(currentRetry)
+			if v.config.RetryFunc != nil {
+				currentRetry = v.config.RetryFunc(currentRetry)
+			}
 			time.Sleep(currentRetry)
 			continue
 		case <-v.stopCh:
@@ -109,12 +113,18 @@ func (v *View) poll(once bool, viewCh chan<- *View, errCh chan<- error, retryFun
 func (v *View) fetch(doneCh chan<- struct{}, errCh chan<- error) {
 	log.Printf("[DEBUG] (view) %s starting fetch", v.display())
 
+	var allowStale bool
+	if v.config.MaxStale != 0 {
+		allowStale = true
+	}
+
 	for {
 		options := &api.QueryOptions{
-			WaitTime:  defaultWaitTime,
-			WaitIndex: v.lastIndex,
+			AllowStale: allowStale,
+			WaitTime:   defaultWaitTime,
+			WaitIndex:  v.lastIndex,
 		}
-		data, qm, err := v.Dependency.Fetch(v.client, options)
+		data, qm, err := v.Dependency.Fetch(v.config.Client, options)
 		if err != nil {
 			errCh <- err
 			return
@@ -124,6 +134,16 @@ func (v *View) fetch(doneCh chan<- struct{}, errCh chan<- error) {
 			errCh <- fmt.Errorf("consul returned nil qm; this should never happen" +
 				"and is probably a bug in consul-template or consulapi")
 			return
+		}
+
+		if allowStale && qm.LastContact > v.config.MaxStale {
+			allowStale = false
+			log.Printf("[DEBUG] (view) %s stale data (last contact exceeded max_stale)", v.display())
+			continue
+		}
+
+		if v.config.MaxStale != 0 {
+			allowStale = true
 		}
 
 		if qm.LastIndex == v.lastIndex {


### PR DESCRIPTION
This adds a new option for `-max-stale` (config and CLI flag) that allows CT to query non-leaders. It also adds a new `-batch-size` option for the user to customize the size of the batch views are processed in.

/cc @mitchellh @armon 