### PR TITLE
Add support for logging to syslog

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,22 @@ consul = "127.0.0.1:8500"
 token = "abcd1234"
 retry = "10s"
 
+auth {
+  enabled = true
+  username = "test"
+  password = "test"
+}
+
+ssl {
+  enabled = true
+  verify = false
+}
+
+syslog {
+  enabled = true
+  facility = "LOCAL5"
+}
+
 template {
   source = "/path/on/disk/to/template"
   destination = "/path/on/disk/where/template/will/render"
@@ -103,7 +119,7 @@ template {
 }
 
 template {
-  // Multiple definitions are supported
+  // Multiple template definitions are supported
 }
 ```
 

--- a/cli.go
+++ b/cli.go
@@ -144,6 +144,7 @@ func (cli *CLI) parseFlags(args []string) (*Config, bool, bool, bool, error) {
 	flags.Var((*watch.WaitVar)(config.Wait), "wait", "")
 	flags.DurationVar(&config.Retry, "retry", config.Retry, "")
 	flags.StringVar(&config.Path, "config", config.Path, "")
+	flags.StringVar(&config.LogLevel, "log-level", config.LogLevel, "")
 	flags.BoolVar(&once, "once", false, "")
 	flags.BoolVar(&dry, "dry", false, "")
 	flags.BoolVar(&version, "version", false, "")
@@ -225,6 +226,9 @@ Options:
                            error when communicating with the API
 
   -config=<path>           Sets the path to a configuration file on disk
+
+  -log-level=<level>       Set the logging level - valid values are "debug",
+                           "info", "warn" (default), and "err"
 
   -dry                     Dump generated templates to stdout
   -once                    Do not run the process as a daemon

--- a/cli.go
+++ b/cli.go
@@ -57,7 +57,6 @@ func (cli *CLI) Run(args []string) int {
 	cli.initLogger()
 
 	var version, dry, once bool
-	var auth string
 	var config = DefaultConfig()
 
 	// Parse the flags and options
@@ -72,7 +71,7 @@ func (cli *CLI) Run(args []string) int {
 		"use https while talking to consul")
 	flags.BoolVar(&config.SSLNoVerify, "ssl-no-verify", false,
 		"ignore certificate warnings under https")
-	flags.StringVar(&auth, "auth", "",
+	flags.Var((*authVar)(&config.Auth), "auth",
 		"set basic auth username[:password]")
 	flags.DurationVar(&config.MaxStale, "max-stale", 0,
 		"the maximum time to wait for stale queries")
@@ -106,19 +105,6 @@ func (cli *CLI) Run(args []string) int {
 		log.Printf("[DEBUG] (cli) version flag was given, exiting now")
 		fmt.Fprintf(cli.errStream, "%s v%s\n", Name, Version)
 		return ExitCodeOK
-	}
-
-	// Setup authentication
-	if auth != "" {
-		log.Printf("[DEBUG] (cli) detected -auth, parsing")
-		config.Auth = new(Auth)
-		if strings.Contains(auth, ":") {
-			split := strings.SplitN(auth, ":", 2)
-			config.Auth.Username = split[0]
-			config.Auth.Password = split[1]
-		} else {
-			config.Auth.Username = auth
-		}
 	}
 
 	// Parse the raw wait value into a Wait object

--- a/cli.go
+++ b/cli.go
@@ -9,7 +9,6 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/hashicorp/consul-template/watch"
 	"github.com/hashicorp/logutils"
@@ -133,25 +132,25 @@ func (cli *CLI) parseFlags(args []string) (*Config, bool, bool, bool, error) {
 	flags.Usage = func() {
 		fmt.Fprintf(cli.errStream, usage, Name)
 	}
-	flags.StringVar(&config.Consul, "consul", "", "")
-	flags.StringVar(&config.Token, "token", "", "")
+	flags.StringVar(&config.Consul, "consul", config.Consul, "")
+	flags.StringVar(&config.Token, "token", config.Token, "")
 	flags.Var((*authVar)(config.Auth), "auth", "")
-	flags.BoolVar(&config.SSL.Enabled, "ssl", false, "")
-	flags.BoolVar(&config.SSL.Verify, "ssl-verify", true, "")
-	flags.DurationVar(&config.MaxStale, "max-stale", 0, "")
+	flags.BoolVar(&config.SSL.Enabled, "ssl", config.SSL.Enabled, "")
+	flags.BoolVar(&config.SSL.Verify, "ssl-verify", config.SSL.Verify, "")
+	flags.DurationVar(&config.MaxStale, "max-stale", config.MaxStale, "")
 	flags.Var((*configTemplateVar)(&config.ConfigTemplates), "template", "")
-	flags.BoolVar(&config.Syslog.Enabled, "syslog", false, "")
-	flags.StringVar(&config.Syslog.Facility, "syslog-facility", "", "")
+	flags.BoolVar(&config.Syslog.Enabled, "syslog", config.Syslog.Enabled, "")
+	flags.StringVar(&config.Syslog.Facility, "syslog-facility", config.Syslog.Facility, "")
 	flags.Var((*watch.WaitVar)(config.Wait), "wait", "")
-	flags.StringVar(&config.Path, "config", "", "")
-	flags.DurationVar(&config.Retry, "retry", 5*time.Second, "")
+	flags.DurationVar(&config.Retry, "retry", config.Retry, "")
+	flags.StringVar(&config.Path, "config", config.Path, "")
 	flags.BoolVar(&once, "once", false, "")
 	flags.BoolVar(&dry, "dry", false, "")
 	flags.BoolVar(&version, "version", false, "")
 
 	// Deprecated options
 	var deprecatedSSLNoVerify bool
-	flags.BoolVar(&deprecatedSSLNoVerify, "ssl-no-verify", false, "")
+	flags.BoolVar(&deprecatedSSLNoVerify, "ssl-no-verify", !config.SSL.Verify, "")
 
 	// If there was a parser error, stop
 	if err := flags.Parse(args); err != nil {

--- a/cli.go
+++ b/cli.go
@@ -135,7 +135,7 @@ func (cli *CLI) parseFlags(args []string) (*Config, bool, bool, bool, error) {
 	flags.StringVar(&config.Consul, "consul", "", "")
 	flags.StringVar(&config.Token, "token", "", "")
 	flags.Var((*authVar)(config.Auth), "auth", "")
-	flags.BoolVar(&config.SSL.Enabled, "ssl", true, "")
+	flags.BoolVar(&config.SSL.Enabled, "ssl", false, "")
 	flags.BoolVar(&config.SSL.Verify, "ssl-verify", true, "")
 	flags.DurationVar(&config.MaxStale, "max-stale", 0, "")
 	flags.Var((*configTemplateVar)(&config.ConfigTemplates), "template", "")

--- a/cli.go
+++ b/cli.go
@@ -71,7 +71,7 @@ func (cli *CLI) Run(args []string) int {
 		"use https while talking to consul")
 	flags.BoolVar(&config.SSLNoVerify, "ssl-no-verify", false,
 		"ignore certificate warnings under https")
-	flags.Var((*authVar)(&config.Auth), "auth",
+	flags.Var((*authVar)(config.Auth), "auth",
 		"set basic auth username[:password]")
 	flags.DurationVar(&config.MaxStale, "max-stale", 0,
 		"the maximum time to wait for stale queries")

--- a/cli.go
+++ b/cli.go
@@ -230,7 +230,7 @@ Options:
                            Consul which will distribute work among all servers
                            instead of just the leader
   -ssl                     Use SSL when connecting to Consul
-  -ssl-verify              Ignore certificate warnings when connecting via SSL
+  -ssl-verify              Verify certificates when connecting via SSL
   -token=<token>           Sets the Consul API token
 
   -syslog                  Send the output to syslog instead of standard error

--- a/cli.go
+++ b/cli.go
@@ -149,9 +149,20 @@ func (cli *CLI) parseFlags(args []string) (*Config, bool, bool, bool, error) {
 	flags.BoolVar(&dry, "dry", false, "")
 	flags.BoolVar(&version, "version", false, "")
 
+	// Deprecated options
+	var deprecatedSSLNoVerify bool
+	flags.BoolVar(&deprecatedSSLNoVerify, "ssl-no-verify", false, "")
+
 	// If there was a parser error, stop
 	if err := flags.Parse(args); err != nil {
 		return nil, false, false, false, err
+	}
+
+	// Handle deprecations
+	if deprecatedSSLNoVerify {
+		log.Printf("[WARN] -ssl-no-verify is deprecated - please use " +
+			"-ssl-verify=false instead")
+		config.SSL.Verify = false
 	}
 
 	return config, once, dry, version, nil

--- a/cli.go
+++ b/cli.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/hashicorp/consul-template/watch"
 	"github.com/hashicorp/logutils"
@@ -143,7 +144,7 @@ func (cli *CLI) parseFlags(args []string) (*Config, bool, bool, bool, error) {
 	flags.StringVar(&config.Syslog.Facility, "syslog-facility", "", "")
 	flags.Var((*watch.WaitVar)(config.Wait), "wait", "")
 	flags.StringVar(&config.Path, "config", "", "")
-	flags.DurationVar(&config.Retry, "retry", 0, "")
+	flags.DurationVar(&config.Retry, "retry", 5*time.Second, "")
 	flags.BoolVar(&once, "once", false, "")
 	flags.BoolVar(&dry, "dry", false, "")
 	flags.BoolVar(&version, "version", false, "")

--- a/cli.go
+++ b/cli.go
@@ -58,7 +58,7 @@ func (cli *CLI) Run(args []string) int {
 
 	var version, dry, once bool
 	var auth string
-	var config = new(Config)
+	var config = DefaultConfig()
 
 	// Parse the flags and options
 	flags := flag.NewFlagSet(Name, flag.ContinueOnError)
@@ -80,6 +80,8 @@ func (cli *CLI) Run(args []string) int {
 		"new template declaration")
 	flags.StringVar(&config.Token, "token", "",
 		"a consul API token")
+	flags.BoolVar(&config.Syslog.Enabled, "syslog", false,
+		"enable syslog logging")
 	flags.StringVar(&config.WaitRaw, "wait", "",
 		"the minimum(:maximum) to wait before rendering a new template")
 	flags.StringVar(&config.Path, "config", "",
@@ -219,6 +221,10 @@ Options:
   -ssl                     Use SSL when connecting to Consul
   -ssl-no-verify           Ignore certificate warnings when connecting via SSL
   -token=<token>           Sets the Consul API token
+
+  -syslog                  Send the output to syslog instead of standard error
+                           and standard out. The syslog facility defaults to
+                           LOCAL0 and can be changed using a configuration file
 
   -template=<template>     Adds a new template to watch on disk in the format
                            'templatePath:outputPath(:command)'

--- a/cli_test.go
+++ b/cli_test.go
@@ -4,13 +4,330 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"reflect"
 	"strings"
 	"syscall"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/consul-template/test"
+	"github.com/hashicorp/consul-template/watch"
 )
+
+func TestParseFlags_consul(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-consul", "12.34.56.78",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "12.34.56.78"
+	if config.Consul != expected {
+		t.Errorf("expected %q to be %q", config.Consul, expected)
+	}
+}
+
+func TestParseFlags_token(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-token", "abcd1234",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "abcd1234"
+	if config.Token != expected {
+		t.Errorf("expected %q to be %q", config.Token, expected)
+	}
+}
+
+func TestParseFlags_authUsername(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-auth", "test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if config.Auth.Enabled != true {
+		t.Errorf("expected auth to be enabled")
+	}
+
+	expected := "test"
+	if config.Auth.Username != expected {
+		t.Errorf("expected %v to be %v", config.Auth.Username, expected)
+	}
+}
+
+func TestParseFlags_authUsernamePassword(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-auth", "test:test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if config.Auth.Enabled != true {
+		t.Errorf("expected auth to be enabled")
+	}
+
+	expected := "test"
+	if config.Auth.Username != expected {
+		t.Errorf("expected %v to be %v", config.Auth.Username, expected)
+	}
+	if config.Auth.Password != expected {
+		t.Errorf("expected %v to be %v", config.Auth.Password, expected)
+	}
+}
+
+func TestParseFlags_SSL(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-ssl",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := true
+	if config.SSL.Enabled != expected {
+		t.Errorf("expected %v to be %v", config.SSL.Enabled, expected)
+	}
+}
+
+func TestParseFlags_noSSL(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-ssl=false",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := false
+	if config.SSL.Enabled != expected {
+		t.Errorf("expected %v to be %v", config.SSL.Enabled, expected)
+	}
+}
+
+func TestParseFlags_SSLVerify(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-ssl-verify",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := true
+	if config.SSL.Verify != expected {
+		t.Errorf("expected %v to be %v", config.SSL.Verify, expected)
+	}
+}
+
+func TestParseFlags_noSSLVerify(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-ssl-verify=false",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := false
+	if config.SSL.Verify != expected {
+		t.Errorf("expected %v to be %v", config.SSL.Verify, expected)
+	}
+}
+
+func TestParseFlags_maxStale(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-max-stale", "10h",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := 10 * time.Hour
+	if config.MaxStale != expected {
+		t.Errorf("expected %q to be %q", config.MaxStale, expected)
+	}
+}
+
+func TestParseFlags_configTemplates(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-template", "in.ctmpl:out.txt:some command",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(config.ConfigTemplates) != 1 {
+		t.Fatal("expected 1 config template")
+	}
+
+	expected := &ConfigTemplate{
+		Source:      "in.ctmpl",
+		Destination: "out.txt",
+		Command:     "some command",
+	}
+	if !reflect.DeepEqual(config.ConfigTemplates[0], expected) {
+		t.Errorf("expected %q to be %q", config.ConfigTemplates[0], expected)
+	}
+}
+
+func TestParseFlags_syslog(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-syslog",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := true
+	if config.Syslog.Enabled != expected {
+		t.Errorf("expected %v to be %v", config.Syslog.Enabled, expected)
+	}
+}
+
+func TestParseFlags_syslogFacility(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-syslog-facility", "LOCAL5",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "LOCAL5"
+	if config.Syslog.Facility != expected {
+		t.Errorf("expected %v to be %v", config.Syslog.Facility, expected)
+	}
+}
+
+func TestParseFlags_wait(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-wait", "10h:11h",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := &watch.Wait{
+		Min: 10 * time.Hour,
+		Max: 11 * time.Hour,
+	}
+	if !reflect.DeepEqual(config.Wait, expected) {
+		t.Errorf("expected %v to be %v", config.Wait, expected)
+	}
+}
+
+func TestParseFlags_waitError(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	_, _, _, _, err := cli.parseFlags([]string{
+		"-wait", "watermelon:bacon",
+	})
+	if err == nil {
+		t.Fatal("expected error, but nothing was returned")
+	}
+
+	expected := "invalid value"
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("expected %q to contain %q", err.Error(), expected)
+	}
+}
+
+func TestParseFlags_config(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-config", "/path/to/file",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "/path/to/file"
+	if config.Path != expected {
+		t.Errorf("expected %v to be %v", config.Path, expected)
+	}
+}
+
+func TestParseFlags_retry(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-retry", "10h",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := 10 * time.Hour
+	if config.Retry != expected {
+		t.Errorf("expected %v to be %v", config.Retry, expected)
+	}
+}
+
+func TestParseFlags_once(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	_, once, _, _, err := cli.parseFlags([]string{
+		"-once",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if once != true {
+		t.Errorf("expected once to be true")
+	}
+}
+
+func TestParseFlags_dry(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	_, _, dry, _, err := cli.parseFlags([]string{
+		"-dry",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if dry != true {
+		t.Errorf("expected dry to be true")
+	}
+}
+
+func TestParseFlags_version(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	_, _, _, version, err := cli.parseFlags([]string{
+		"-version",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if version != true {
+		t.Errorf("expected version to be true")
+	}
+}
+
+func TestParseFlags_errors(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	_, _, _, _, err := cli.parseFlags([]string{
+		"-totally", "-not", "-valid",
+	})
+
+	if err == nil {
+		t.Fatal("expected error, but nothing was returned")
+	}
+}
 
 func TestRun_printsErrors(t *testing.T) {
 	outStream, errStream := new(bytes.Buffer), new(bytes.Buffer)
@@ -55,22 +372,6 @@ func TestRun_parseError(t *testing.T) {
 	}
 
 	expected := "flag provided but not defined: -bacon"
-	if !strings.Contains(errStream.String(), expected) {
-		t.Fatalf("expected %q to contain %q", errStream.String(), expected)
-	}
-}
-
-func TestRun_waitFlagError(t *testing.T) {
-	outStream, errStream := new(bytes.Buffer), new(bytes.Buffer)
-	cli := NewCLI(outStream, errStream)
-	args := strings.Split("consul-template -wait=watermelon:bacon", " ")
-
-	status := cli.Run(args)
-	if status != ExitCodeParseWaitError {
-		t.Errorf("expected %q to eq %q", status, ExitCodeParseWaitError)
-	}
-
-	expected := "time: invalid duration watermelon"
 	if !strings.Contains(errStream.String(), expected) {
 		t.Fatalf("expected %q to contain %q", errStream.String(), expected)
 	}

--- a/cli_test.go
+++ b/cli_test.go
@@ -318,6 +318,21 @@ func TestParseFlags_version(t *testing.T) {
 	}
 }
 
+func TestParseFlags_logLevel(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-log-level", "debug",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "debug"
+	if config.LogLevel != expected {
+		t.Errorf("expected %v to be %v", config.LogLevel, expected)
+	}
+}
+
 func TestParseFlags_errors(t *testing.T) {
 	cli := NewCLI(ioutil.Discard, ioutil.Discard)
 	_, _, _, _, err := cli.parseFlags([]string{

--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -62,6 +63,9 @@ type Config struct {
 	// Wait
 	Wait    *watch.Wait `mapstructure:"-"`
 	WaitRaw string      `mapstructure:"wait" json:""`
+
+	// LogLevel is the level with which to log for this config.
+	LogLevel string `mapstructure:"log_level"`
 }
 
 // Merge merges the values in config into this config object. Values in the
@@ -126,6 +130,10 @@ func (c *Config) Merge(config *Config) {
 			Max: config.Wait.Max,
 		}
 		c.WaitRaw = config.WaitRaw
+	}
+
+	if config.LogLevel != "" {
+		c.LogLevel = config.LogLevel
 	}
 }
 
@@ -223,6 +231,11 @@ func ParseConfig(path string) (*Config, error) {
 
 // DefaultConfig returns the default configuration struct.
 func DefaultConfig() *Config {
+	logLevel := os.Getenv("CONSUL_TEMPLATE_LOG")
+	if logLevel == "" {
+		logLevel = "WARN"
+	}
+
 	return &Config{
 		Auth: &Auth{
 			Enabled: false,
@@ -238,6 +251,7 @@ func DefaultConfig() *Config {
 		ConfigTemplates: []*ConfigTemplate{},
 		Retry:           5 * time.Second,
 		Wait:            &watch.Wait{},
+		LogLevel:        logLevel,
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -60,7 +60,7 @@ type Config struct {
 	Retry    time.Duration `mapstructure:"-"`
 	RetryRaw string        `mapstructure:"retry" json:""`
 
-	// Wait
+	// Wait is the quiescence timers.
 	Wait    *watch.Wait `mapstructure:"-"`
 	WaitRaw string      `mapstructure:"wait" json:""`
 

--- a/config_test.go
+++ b/config_test.go
@@ -226,11 +226,8 @@ func TestParseConfig_correctValues(t *testing.T) {
     token = "abcd1234"
     wait = "5s:10s"
     retry = "10s"
-
-    syslog {
-    	enabled = true
-    	facility = "LOCAL1"
-    }
+    syslog = true
+    syslog_facility = "LOCAL1"
 
     template {
       source = "nginx.conf.ctmpl"

--- a/config_test.go
+++ b/config_test.go
@@ -131,6 +131,24 @@ func TestMerge_BasicAuthOptions(t *testing.T) {
 	}
 }
 
+func TestMerge_SyslogOptions(t *testing.T) {
+	config := &Config{
+		Syslog: &Syslog{Enabled: false, Facility: "LOCAL0"},
+	}
+	otherConfig := &Config{
+		Syslog: &Syslog{Enabled: true, Facility: "LOCAL1"},
+	}
+	config.Merge(otherConfig)
+
+	if config.Syslog.Enabled != true {
+		t.Errorf("expected %q to be %q", config.Syslog.Enabled, true)
+	}
+
+	if config.Syslog.Facility != "LOCAL1" {
+		t.Errorf("expected %q to be %q", config.Syslog.Facility, "LOCAL1")
+	}
+}
+
 // Test that file read errors are propagated up
 func TestParseConfig_readFileError(t *testing.T) {
 	_, err := ParseConfig(path.Join(os.TempDir(), "config.json"))
@@ -209,6 +227,11 @@ func TestParseConfig_correctValues(t *testing.T) {
     wait = "5s:10s"
     retry = "10s"
 
+    syslog {
+    	enabled = true
+    	facility = "LOCAL1"
+    }
+
     template {
       source = "nginx.conf.ctmpl"
       destination  = "/etc/nginx/nginx.conf"
@@ -242,6 +265,10 @@ func TestParseConfig_correctValues(t *testing.T) {
 		WaitRaw:  "5s:10s",
 		Retry:    10 * time.Second,
 		RetryRaw: "10s",
+		Syslog: &Syslog{
+			Enabled:  true,
+			Facility: "LOCAL1",
+		},
 		ConfigTemplates: []*ConfigTemplate{
 			&ConfigTemplate{
 				Source:      "nginx.conf.ctmpl",

--- a/config_test.go
+++ b/config_test.go
@@ -63,12 +63,14 @@ func TestMerge_complexConfig(t *testing.T) {
 		Token:           "abc123",
 		MaxStale:        3 * time.Second,
 		Wait:            &watch.Wait{Min: 5 * time.Second, Max: 10 * time.Second},
+		LogLevel:        "WARN",
 	}
 	otherConfig := &Config{
 		ConfigTemplates: templates[2:],
 		Retry:           15 * time.Second,
 		Token:           "def456",
 		Wait:            &watch.Wait{Min: 25 * time.Second, Max: 50 * time.Second},
+		LogLevel:        "ERR",
 	}
 
 	config.Merge(otherConfig)
@@ -79,6 +81,7 @@ func TestMerge_complexConfig(t *testing.T) {
 		Token:           "def456",
 		MaxStale:        3 * time.Second,
 		Wait:            &watch.Wait{Min: 25 * time.Second, Max: 50 * time.Second},
+		LogLevel:        "ERR",
 	}
 
 	if !reflect.DeepEqual(config, expected) {
@@ -241,6 +244,7 @@ func TestParseConfig_correctValues(t *testing.T) {
     token = "abcd1234"
     wait = "5s:10s"
     retry = "10s"
+    log_level = "warn"
 
     auth {
     	enabled = true
@@ -321,6 +325,7 @@ func TestParseConfig_correctValues(t *testing.T) {
 		WaitRaw:  "5s:10s",
 		Retry:    10 * time.Second,
 		RetryRaw: "10s",
+		LogLevel: "warn",
 		ConfigTemplates: []*ConfigTemplate{
 			&ConfigTemplate{
 				Source:      "nginx.conf.ctmpl",

--- a/flags.go
+++ b/flags.go
@@ -26,13 +26,9 @@ func (ctv *configTemplateVar) String() string {
 }
 
 //
-type authVar *Auth
+type authVar Auth
 
 func (a *authVar) Set(value string) error {
-	if *a == nil {
-		*a = new(Auth)
-	}
-
 	if strings.Contains(value, ":") {
 		split := strings.SplitN(value, ":", 2)
 		a.Username = split[0]
@@ -42,4 +38,8 @@ func (a *authVar) Set(value string) error {
 	}
 
 	return nil
+}
+
+func (a *authVar) String() string {
+	return ""
 }

--- a/flags.go
+++ b/flags.go
@@ -1,5 +1,7 @@
 package main
 
+import "strings"
+
 // configTemplateVar implements the Flag.Value interface and allows the user
 // to specify multiple -template keys in the CLI where each option is parsed
 // as a template.
@@ -21,4 +23,23 @@ func (ctv *configTemplateVar) Set(value string) error {
 
 func (ctv *configTemplateVar) String() string {
 	return ""
+}
+
+//
+type authVar *Auth
+
+func (a *authVar) Set(value string) error {
+	if *a == nil {
+		*a = new(Auth)
+	}
+
+	if strings.Contains(value, ":") {
+		split := strings.SplitN(value, ":", 2)
+		a.Username = split[0]
+		a.Password = split[1]
+	} else {
+		a.Username = value
+	}
+
+	return nil
 }

--- a/flags.go
+++ b/flags.go
@@ -1,6 +1,9 @@
 package main
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // configTemplateVar implements the Flag.Value interface and allows the user
 // to specify multiple -template keys in the CLI where each option is parsed
@@ -25,10 +28,14 @@ func (ctv *configTemplateVar) String() string {
 	return ""
 }
 
-//
+// authVar implements the Flag.Value interface and allows the user to specify
+// authentication in the username[:password] form.
 type authVar Auth
 
+// Set sets the value for this authentication.
 func (a *authVar) Set(value string) error {
+	a.Enabled = true
+
 	if strings.Contains(value, ":") {
 		split := strings.SplitN(value, ":", 2)
 		a.Username = split[0]
@@ -40,6 +47,11 @@ func (a *authVar) Set(value string) error {
 	return nil
 }
 
+// String returns the string representation of this authentication.
 func (a *authVar) String() string {
-	return ""
+	if a.Password == "" {
+		return a.Username
+	}
+
+	return fmt.Sprintf("%s:%s", a.Username, a.Password)
 }

--- a/logging.go
+++ b/logging.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+
+	"github.com/hashicorp/go-syslog"
+	"github.com/hashicorp/logutils"
+)
+
+// Levels are the log levels we respond to=o.
+var Levels = []logutils.LogLevel{"DEBUG", "INFO", "WARN", "ERR"}
+
+// NewLogFilter returns a LevelFilter that is configured with the log levels that
+// we use.
+func NewLogFilter() *logutils.LevelFilter {
+	return &logutils.LevelFilter{
+		Levels:   Levels,
+		MinLevel: "WARN",
+		Writer:   ioutil.Discard,
+	}
+}
+
+// ValidateLevelFilter verifies that the log levels within the filter are valid.
+func ValidateLevelFilter(min logutils.LogLevel, filter *logutils.LevelFilter) bool {
+	for _, level := range filter.Levels {
+		if level == min {
+			return true
+		}
+	}
+	return false
+}
+
+/// ------------------------- ///
+
+// syslogPriorityMap is used to map a log level to a syslog priority level.
+var syslogPriorityMap = map[string]gsyslog.Priority{
+	"DEBUG": gsyslog.LOG_INFO,
+	"INFO":  gsyslog.LOG_NOTICE,
+	"WARN":  gsyslog.LOG_WARNING,
+	"ERR":   gsyslog.LOG_ERR,
+}
+
+// SyslogWrapper is used to cleaup log messages before writing them to a
+// Syslogger. Implements the io.Writer interface.
+type SyslogWrapper struct {
+	l    gsyslog.Syslogger
+	filt *logutils.LevelFilter
+}
+
+// Write is used to implement io.Writer.
+func (s *SyslogWrapper) Write(p []byte) (int, error) {
+	// Skip syslog if the log level doesn't apply
+	if !s.filt.Check(p) {
+		return 0, nil
+	}
+
+	// Extract log level
+	var level string
+	afterLevel := p
+	x := bytes.IndexByte(p, '[')
+	if x >= 0 {
+		y := bytes.IndexByte(p[x:], ']')
+		if y >= 0 {
+			level = string(p[x+1 : x+y])
+			afterLevel = p[x+y+2:]
+		}
+	}
+
+	// Each log level will be handled by a specific syslog priority.
+	priority, ok := syslogPriorityMap[level]
+	if !ok {
+		priority = gsyslog.LOG_NOTICE
+	}
+
+	// Attempt the write
+	err := s.l.WriteLevel(priority, afterLevel)
+	return len(p), err
+}

--- a/logging_test.go
+++ b/logging_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"runtime"
 	"testing"
 
@@ -12,6 +13,12 @@ func TestSyslogFilter(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.SkipNow()
 	}
+
+	// Travis does not support syslog for some reason
+	if travis := os.Getenv("TRAVIS"); travis != "" {
+		t.SkipNow()
+	}
+
 	l, err := gsyslog.NewLogger(gsyslog.LOG_NOTICE, "LOCAL0", "consul-template")
 	if err != nil {
 		t.Fatalf("err: %s", err)

--- a/logging_test.go
+++ b/logging_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/hashicorp/go-syslog"
+	"github.com/hashicorp/logutils"
+)
+
+func TestSyslogFilter(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.SkipNow()
+	}
+	l, err := gsyslog.NewLogger(gsyslog.LOG_NOTICE, "LOCAL0", "consul-template")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	filt := NewLogFilter()
+	filt.MinLevel = logutils.LogLevel("INFO")
+
+	s := &SyslogWrapper{l, filt}
+	n, err := s.Write([]byte("[INFO] test"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if n == 0 {
+		t.Fatalf("should have logged")
+	}
+
+	n, err = s.Write([]byte("[DEBUG] test"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if n != 0 {
+		t.Fatalf("should not have logged")
+	}
+}

--- a/runner.go
+++ b/runner.go
@@ -709,12 +709,12 @@ func newAPIClient(config *Config) (*api.Client, error) {
 		consulConfig.Token = config.Token
 	}
 
-	if config.SSL {
+	if config.SSL.Enabled {
 		log.Printf("[DEBUG] (runner) enabling SSL")
 		consulConfig.Scheme = "https"
 	}
 
-	if config.SSLNoVerify {
+	if !config.SSL.Verify {
 		log.Printf("[WARN] (runner) disabling SSL verification")
 		consulConfig.HttpClient.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{

--- a/watch/wait.go
+++ b/watch/wait.go
@@ -2,6 +2,7 @@ package watch
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 )
@@ -55,4 +56,26 @@ func ParseWait(s string) (*Wait, error) {
 	}
 
 	return &Wait{min, max}, nil
+}
+
+// WaitVar implements the Flag.Value interface and allows the user to specify
+// a watch interval using Go's flag parsing library.
+type WaitVar Wait
+
+// Set sets the value in the format min[:max] for a wait timer.
+func (w *WaitVar) Set(value string) error {
+	wait, err := ParseWait(value)
+	if err != nil {
+		return err
+	}
+
+	w.Min = wait.Min
+	w.Max = wait.Max
+
+	return nil
+}
+
+// String returns the string format for this wait variable
+func (w *WaitVar) String() string {
+	return fmt.Sprintf("%s:%s", w.Min, w.Max)
 }


### PR DESCRIPTION
```diff
diff --git a/CHANGELOG.md b/CHANGELOG.md
index 5a11759..f1f6380 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@ Consul Template Changelog

 ## 0.6.6.dev (Unreleased)

+BREAKING CHANGES:
+
+  * Remove `ssl` configuration option from templates - use an `ssl`
+    configuration block with `enabled = true` instead
+  * Remove `ssl_no_verify` configuration option from templates - use an `ssl`
+    configuration block with `verify = false` instead
+  * Restructure CLI `-ssl-no-verify` to `-ssl-verify` - to disable SSL
+    certification validation on the command line, use `-ssl-verify=false`
+  * Remove `auth` configuration option from templates - use an `auth`
+    configuration block with `enabled = true` combined with `username = ...` and
+    `password = ...` inside the block instead
+
 IMPROVEMENTS:

   * Use a default retry interval of 5s (GH-190) - this value has been (and will
@@ -11,8 +23,15 @@ IMPROVEMENTS:
   * Use a service's reported address if given (GH-185, GH-186)
   * Add new `NodeAddress` field to health services to always include the node's
     address
+  * Add support for logging to syslog (GH-163)
   * Return errors up the watcher's error channel so other libraries can
     determine what to do with the error instead of swallowing it (GH-196)
+  * Move SSL and authentication options into their own configuration blocks in
+    the HCL
+  * Add `log_level` as a configuration file option
+  * Add `-log-level` as a CLI option
+  * Add new `watch.WaitVar` for parsing Wait structs via Go's flag parsing
+    library.

 BUG FIXES:

@@ -22,9 +41,11 @@ BUG FIXES:
     not changed (GH-188)
   * Raise an error when specifying a non-existent option in the configuration
     file (GH-197)
+  * Use an RWLock when accessing information in the Brain to improve performance
   * Improve debugging output and consistency
   * Remove unused Brain functions
   * Remove unused documentation items
+  * Use the correct default values for `-ssl` and `-retry` on the CLI
```