### PR TITLE
Add byKey function for grouping the results of tree by its top key

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,35 @@ If you omit the datacenter attribute on `tree`, the local Consul datacenter will
 
 #### Helper Functions
 
+##### `byKey`
+Takes the list of key pairs returned from a [`tree`](#tree) function and creates a map that groups pairs by their top-level directory. For example, if the Consul KV store contained the following structure:
+
+```text
+configs/elasticsearch/a //=> "1"
+configs/elasticsearch/b //=> "2"
+configs/redis/a/b //=> "3"
+```
+
+With the following template:
+
+```liquid
+{{range $key, $pairs := tree "configs" | byKey}}{{$key}}:
+{{range $pairs}}  {{.Key}}={{.Value}}
+{{end}}{{end}}
+```
+
+The result would be:
+
+```text
+elasticsearch:
+  a=1
+  b=2
+redis
+  a/b=3
+```
+
+Note that the top-most key is stripped from the Key value. Keys that have no prefix after stripping are removed from the list.
+
 ##### `byTag`
 Takes the list of services returned by the [`service`](#service) function and creates a map that groups services by tag.
 

--- a/template.go
+++ b/template.go
@@ -117,6 +117,7 @@ func funcMap(brain *Brain, used, missing map[string]dep.Dependency) template.Fun
 		"tree":        treeFunc(brain, used, missing),
 
 		// Helper functions
+		"byKey":           byKey,
 		"byTag":           byTag,
 		"env":             env,
 		"parseJSON":       parseJSON,

--- a/template_functions_test.go
+++ b/template_functions_test.go
@@ -723,6 +723,42 @@ func TestByTag_GroupsList(t *testing.T) {
 	}
 }
 
+func TestByKey_emptyList(t *testing.T) {
+	result, err := byKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := map[string][]*dep.KeyPair{}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("expected %#v to be %#v", result, expected)
+	}
+}
+
+func TestByKey_topLevel(t *testing.T) {
+	result, err := byKey([]*dep.KeyPair{
+		&dep.KeyPair{Key: "elasticsearch/a", Value: "1"},
+		&dep.KeyPair{Key: "elasticsearch/b", Value: "2"},
+		&dep.KeyPair{Key: "redis/a/b", Value: "3"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := map[string][]*dep.KeyPair{
+		"elasticsearch": []*dep.KeyPair{
+			&dep.KeyPair{Key: "a", Value: "1"},
+			&dep.KeyPair{Key: "b", Value: "2"},
+		},
+		"redis": []*dep.KeyPair{
+			&dep.KeyPair{Key: "a/b", Value: "3"},
+		},
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("expected %#v to be %#v", result, expected)
+	}
+}
+
 func TestEnv(t *testing.T) {
 	if err := os.Setenv("foo", "bar"); err != nil {
 		t.Fatal(err)

--- a/template_test.go
+++ b/template_test.go
@@ -222,6 +222,9 @@ func TestExecute_renders(t *testing.T) {
 
 		Helper Functions
 		----------------
+		byKey:{{ range $key, $pairs := tree "config/redis" | byKey }}
+			{{$key}}:{{ range $pairs }}
+				{{.Key}}={{.Value}}{{ end }}{{ end }}
 		byTag:{{ range $tag, $services := service "webapp" | byTag }}
 			{{$tag}}:{{ range $services }}
 				{{.Address}}{{ end }}{{ end }}
@@ -380,6 +383,9 @@ func TestExecute_renders(t *testing.T) {
 
 		Helper Functions
 		----------------
+		byKey:
+			admin:
+				port=1134
 		byTag:
 			production:
 				5.6.7.8


### PR DESCRIPTION
This adds a new `byKey` function for the template that accepts a list of KV pairs (most likely from `tree`) and "groups" them by the top-most key. You can see the comment in template_functions.go for a more concrete example of what that might look like.

- Fixes https://github.com/hashicorp/consul-template/issues/207

/cc @ryanuber @armon 