### PR TITLE
Fix service filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,30 +250,38 @@ By default only healthy services are returned. If you want to get all services, 
 
 This will return all services registered to the agent, regardless of their status.
 
-If you want to filter services by a specific health, you can specify a comma-separated list of health check statuses:
+If you want to filter services by a specific health or health(s), you can specify a comma-separated list of health check statuses:
 
 ```liquid
-{{service "webapp" "passing, warning, critical"}}
+{{service "webapp" "passing, warning"}}
 ```
+
+This will returns services which are deemed "passing" or "warning" according to their node and service-level checks defined in Consul. Please note that the comma implies an "or", not an "and".
 
 Specifying more than one status filter while "any" is used will return an error, since "any" is the superset of all status filters.
 
-The comma should be read as "or", not "and". For example:
-
-```liquid
-{{service "webapp" "critical, unknown"}}
-```
-
-should be read as "all webpp services that are either critical or unknown".
-
-There is fundamental difference between the following:
+There is an architectural difference between the following:
 
 ```liquid
 {{service "webapp"}}
 {{service "webapp" "passing"}}
 ```
 
-The former will return all services which Consul considers "healthy" and passing. The latter will return all services registered with the Consul agent that have _at least_ one passing check. As a general rule, you should not use the "passing" argument if you want only healthy services - simply omit the second argument instead.
+The former will return all services which Consul considers "healthy" and passing. The latter will return all services registered with the Consul agent and perform client-side filtering. As a general rule, you should not use the "passing" argument alone if you want only healthy services - simply omit the second argument instead. However, the extra argument is useful if you want "passing or warning" services like:
+
+```liquid
+{{service "webapp" "passing, warning"}}
+```
+
+The service's status is also exposed if you need to do additional filtering:
+
+```liquid
+{{range service "webapp" "any"}}
+{{if eq .Status "critical"}}
+// Critical state!{{end}}
+{{if eq .Status "passing"}}
+// Ok{{end}}
+```
 
 ##### `services`
 Query Consul for all services in the catalog. Services are queried using the following syntax:

--- a/README.md
+++ b/README.md
@@ -242,15 +242,29 @@ server nyc_web_01 123.456.789.10:8080
 server nyc_web_02 456.789.101.213:8080
 ```
 
-By default only healthy services are returned.
-If you want to get all services, in specific healths, then you can specify a comma-separated list of health check statuses.
-Currently supported are `"any"`, `"passing"`, `"warning"` and `"critical"`.
+By default only healthy services are returned. If you want to get all services, you can pass the "any" option:
 
 ```liquid
 {{service "webapp" "any"}}
-{{service "webapp" "passing"}}
+```
+
+This will return all services registered to the agent, regardless of their status.
+
+If you want to filter services by a specific health, you can specify a comma-separated list of health check statuses:
+
+```liquid
 {{service "webapp" "passing, warning, critical"}}
 ```
+
+Specifying more than one status filter while "any" is used will return an error, since "any" is the superset of all status filters.
+
+The comma should be read as "or", not "and". For example:
+
+```liquid
+{{service "webapp" "critical, unknown"}}
+```
+
+should be read as "all webpp services that are either critical or unknown".
 
 ##### `services`
 Query Consul for all services in the catalog. Services are queried using the following syntax:

--- a/README.md
+++ b/README.md
@@ -266,6 +266,15 @@ The comma should be read as "or", not "and". For example:
 
 should be read as "all webpp services that are either critical or unknown".
 
+There is fundamental difference between the following:
+
+```liquid
+{{service "webapp"}}
+{{service "webapp" "passing"}}
+```
+
+The former will return all services which Consul considers "healthy" and passing. The latter will return all services registered with the Consul agent that have _at least_ one passing check. As a general rule, you should not use the "passing" argument if you want only healthy services - simply omit the second argument instead.
+
 ##### `services`
 Query Consul for all services in the catalog. Services are queried using the following syntax:
 

--- a/dependency/health_service.go
+++ b/dependency/health_service.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/go-multierror"
 )
 
 // Ripped from https://github.com/hashicorp/consul/blob/master/consul/structs/structs.go#L31
@@ -52,7 +53,7 @@ func (d *HealthServices) Fetch(client *api.Client, options *api.QueryOptions) (i
 	log.Printf("[DEBUG] (%s) querying Consul with %+v", d.Display(), options)
 
 	health := client.Health()
-	entries, qm, err := health.Service(d.Name, d.Tag, d.Status.onlyAllowPassing(), options)
+	entries, qm, err := health.Service(d.Name, d.Tag, d.Status.passingOnly(), options)
 	if err != nil {
 		return nil, qm, err
 	}
@@ -62,7 +63,7 @@ func (d *HealthServices) Fetch(client *api.Client, options *api.QueryOptions) (i
 	services := make([]*HealthService, 0, len(entries))
 
 	for _, entry := range entries {
-		if !d.Status.accept(entry.Checks) {
+		if !d.Status.Accept(entry.Checks) {
 			continue
 		}
 
@@ -113,31 +114,22 @@ func (d *HealthServices) Display() string {
 //
 // If no health_check is provided then its the same as "passing".
 func ParseHealthServices(s ...string) (*HealthServices, error) {
-	var (
-		query  string
-		status ServiceStatusFilter
-	)
+	var query string
+	var status ServiceStatusFilter
+	var err error
 
 	switch len(s) {
 	case 1:
 		query = s[0]
-		status = ServiceStatusFilter{HealthPassing}
+		status, err = NewServiceStatusFilter("")
+		if err != nil {
+			return nil, err
+		}
 	case 2:
 		query = s[0]
-		rawStatuses := strings.Split(s[1], ",")
-		status = make(ServiceStatusFilter, len(rawStatuses))
-
-		for i, rawStatus := range rawStatuses {
-			rawStatus = strings.TrimSpace(rawStatus)
-			if rawStatus == HealthAny {
-				status = ServiceStatusFilter{}
-				break
-			} else if rawStatus == HealthPassing || rawStatus == HealthWarning || rawStatus == HealthCritical {
-				status[i] = rawStatus
-			} else {
-				return nil, fmt.Errorf("expected some of %q as health status",
-					strings.Join([]string{HealthAny, HealthPassing, HealthWarning, HealthCritical}, ", "))
-			}
+		status, err = NewServiceStatusFilter(s[1])
+		if err != nil {
+			return nil, err
 		}
 	default:
 		return nil, fmt.Errorf("expected 1 or 2 arguments, got %d", len(s))
@@ -197,44 +189,107 @@ func ParseHealthServices(s ...string) (*HealthServices, error) {
 // ServiceStatusFilter is used to specify a list of service statuses that you want filter by.
 type ServiceStatusFilter []string
 
+// String returns the string representation of this status filter
 func (f ServiceStatusFilter) String() string {
-	if len(f) < 1 {
-		return fmt.Sprintf("[%s]", HealthAny)
-	}
 	return fmt.Sprintf("[%s]", strings.Join(f, ","))
 }
 
-// onlyAllowPassing allows us to use the passingOnly argumeny in the health service
-func (f ServiceStatusFilter) onlyAllowPassing() bool {
-	if len(f) < 1 {
-		return false
+// NewServiceStatusFilter creates a status filter from the given string in the
+// format `[key[,key[,key...]]]`. Each status is split on the comma character
+// and must match one of the valid status names.
+//
+// If the empty string is given, it is assumed only "passing" statuses are to
+// be returned.
+//
+// If the user specifies "any" with other keys, an error will be returned.
+func NewServiceStatusFilter(s string) (ServiceStatusFilter, error) {
+	// If no statuses were given, use the default status of "passing".
+	if len(s) == 0 {
+		return ServiceStatusFilter{HealthPassing}, nil
 	}
-	for _, status := range f {
-		if status != HealthPassing {
-			return false
+
+	var errs *multierror.Error
+	var hasAny bool
+
+	raw := strings.Split(s, ",")
+	trimmed := make(ServiceStatusFilter, 0, len(raw))
+	for _, r := range raw {
+		trim := strings.TrimSpace(r)
+
+		// Ignore the empty string.
+		if len(trim) == 0 {
+			continue
 		}
+
+		// Record the case where we have the "any" status - it will be used later.
+		if trim == HealthAny {
+			hasAny = true
+		}
+
+		// Validate that the service is actually a valid name.
+		if trim != HealthAny &&
+			trim != HealthUnknown &&
+			trim != HealthPassing &&
+			trim != HealthWarning &&
+			trim != HealthCritical {
+			errs = multierror.Append(errs, fmt.Errorf("service filter: invalid filter %q", trim))
+		}
+		trimmed = append(trimmed, trim)
 	}
-	return true
+
+	// If the user specified "any" with additional keys, that is invalid.
+	if hasAny && len(trimmed) != 1 {
+		errs = multierror.Append(errs, fmt.Errorf("service filter: cannot specify extra keys when using %q", "any"))
+	}
+
+	return trimmed, errs.ErrorOrNil()
 }
 
-// accept allows us to check if a slice of health checks pass this filter.
-func (f ServiceStatusFilter) accept(checks []*api.HealthCheck) bool {
-	if len(f) < 1 {
+// Accept allows us to check if a slice of health checks pass this filter.
+func (f ServiceStatusFilter) Accept(checks []*api.HealthCheck) bool {
+	// If the any filter is activated, pass everything.
+	if f.any() {
 		return true
 	}
-	for _, check := range checks {
-		accept := false
-		for _, status := range f {
-			if status == check.Status {
-				accept = true
-				break
+
+	// If ONLY the passing filter is activated, ensure all checks are passing and
+	// return. If more than one filter is given (like "passing, unknown"), then
+	// this conditional will not fire.
+	if f.passingOnly() {
+		for _, check := range checks {
+			if check.Status != HealthPassing {
+				return false
 			}
 		}
-		if !accept {
-			return false
+		return true
+	}
+
+	// Iterate over each status and see if ANY of the checks have that status.
+	for _, status := range f {
+		for _, check := range checks {
+			if status == check.Status {
+				return true
+			}
 		}
 	}
-	return true
+
+	return false
+}
+
+// any is a helper method to determine if this is an "any" service status
+// filter. If "any" was given, it must be the only item in the list.
+func (f ServiceStatusFilter) any() bool {
+	return len(f) == 1 && f[0] == HealthAny
+}
+
+// onlyPassing returns true if the filter contains only a "passing" service
+// status filter.
+//
+// NOTE: If there is more than one filter, this will return false, even if one
+// of the filters is "passing". This is because "passingOnly" is used to alter
+// the type of query made to Consul.
+func (f ServiceStatusFilter) passingOnly() bool {
+	return len(f) == 1 && f[0] == HealthPassing
 }
 
 // ServiceTags is a slice of tags assigned to a Service

--- a/dependency/health_service.go
+++ b/dependency/health_service.go
@@ -253,14 +253,9 @@ func (t ServiceTags) Contains(s string) bool {
 // HealthServiceList is a sortable slice of Service
 type HealthServiceList []*HealthService
 
-func (s HealthServiceList) Len() int {
-	return len(s)
-}
-
-func (s HealthServiceList) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
+// Len, Swap, and Less are used to implement the sort.Sort interface.
+func (s HealthServiceList) Len() int      { return len(s) }
+func (s HealthServiceList) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s HealthServiceList) Less(i, j int) bool {
 	if s[i].Node < s[j].Node {
 		return true

--- a/dependency/health_service.go
+++ b/dependency/health_service.go
@@ -22,7 +22,7 @@ const (
 	HealthCritical = "critical"
 )
 
-// HealthService is a service entry in Consul
+// HealthService is a service entry in Consul.
 type HealthService struct {
 	Node        string
 	NodeAddress string
@@ -33,7 +33,8 @@ type HealthService struct {
 	Port        uint64
 }
 
-// from inside a template.
+// HealthServices is the struct that is formed from the dependency inside a
+// template.
 type HealthServices struct {
 	rawKey     string
 	Name       string

--- a/dependency/health_service.go
+++ b/dependency/health_service.go
@@ -228,14 +228,12 @@ func NewServiceStatusFilter(s string) (ServiceStatusFilter, error) {
 		}
 
 		// Validate that the service is actually a valid name.
-		if trim != HealthAny &&
-			trim != HealthUnknown &&
-			trim != HealthPassing &&
-			trim != HealthWarning &&
-			trim != HealthCritical {
+		switch trim {
+		case HealthAny, HealthUnknown, HealthPassing, HealthWarning, HealthCritical:
+			trimmed = append(trimmed, trim)
+		default:
 			errs = multierror.Append(errs, fmt.Errorf("service filter: invalid filter %q", trim))
 		}
-		trimmed = append(trimmed, trim)
 	}
 
 	// If the user specified "any" with additional keys, that is invalid.

--- a/dependency/health_service_test.go
+++ b/dependency/health_service_test.go
@@ -69,58 +69,6 @@ func TestHealthServiceList_sorts(t *testing.T) {
 	}
 }
 
-func TestServiceStatusFilter_acceptOnlyReturnsTrueForItemsInFilter(t *testing.T) {
-	f1 := &ServiceStatusFilter{HealthPassing}
-	f2 := &ServiceStatusFilter{HealthPassing, HealthWarning}
-	c1 := []*api.HealthCheck{
-		&api.HealthCheck{
-			Status: HealthPassing,
-		},
-	}
-	c2 := []*api.HealthCheck{
-		&api.HealthCheck{
-			Status: HealthWarning,
-		},
-	}
-	c3 := []*api.HealthCheck{
-		&api.HealthCheck{
-			Status: HealthPassing,
-		},
-		&api.HealthCheck{
-			Status: HealthWarning,
-		},
-	}
-	c4 := []*api.HealthCheck{
-		&api.HealthCheck{
-			Status: HealthCritical,
-		},
-	}
-	if !f1.Accept(c1) {
-		t.Fatal("Expecting f1 to accept c1.")
-	}
-	if f1.Accept(c2) {
-		t.Fatal("Expecting f1 to not accept c2.")
-	}
-	if f1.Accept(c3) {
-		t.Fatal("Expecting f1 to not accept c3.")
-	}
-	if f1.Accept(c4) {
-		t.Fatal("Expecting f1 to not accept c4.")
-	}
-	if !f2.Accept(c1) {
-		t.Fatal("Expecting f2 to accept c1.")
-	}
-	if !f2.Accept(c2) {
-		t.Fatal("Expecting f2 to accept c2.")
-	}
-	if !f2.Accept(c3) {
-		t.Fatal("Expecting f2 to accept c3.")
-	}
-	if f2.Accept(c4) {
-		t.Fatal("Expecting f2 to not accept c4.")
-	}
-}
-
 func TestServiceDependencyHashCode_isUnique(t *testing.T) {
 	dep1 := &HealthServices{rawKey: "redis@nyc1"}
 	dep2 := &HealthServices{rawKey: "redis@nyc2"}
@@ -148,9 +96,9 @@ func TestParseHealthServices_name(t *testing.T) {
 	}
 
 	expected := &HealthServices{
-		rawKey: "webapp [passing]",
+		rawKey: "webapp [healthy]",
 		Name:   "webapp",
-		Status: ServiceStatusFilter{HealthPassing},
+		Status: ServiceStatusFilter{Healthy},
 	}
 	if !reflect.DeepEqual(sd, expected) {
 		t.Errorf("expected %#v to equal %#v", sd, expected)
@@ -180,9 +128,9 @@ func TestParseHealthServices_slashName(t *testing.T) {
 	}
 
 	expected := &HealthServices{
-		rawKey: "web/app [passing]",
+		rawKey: "web/app [healthy]",
 		Name:   "web/app",
-		Status: ServiceStatusFilter{HealthPassing},
+		Status: ServiceStatusFilter{Healthy},
 	}
 	if !reflect.DeepEqual(sd, expected) {
 		t.Errorf("expected %#v to equal %#v", sd, expected)
@@ -196,9 +144,9 @@ func TestParseHealthServices_underscoreName(t *testing.T) {
 	}
 
 	expected := &HealthServices{
-		rawKey: "web_app [passing]",
+		rawKey: "web_app [healthy]",
 		Name:   "web_app",
-		Status: ServiceStatusFilter{HealthPassing},
+		Status: ServiceStatusFilter{Healthy},
 	}
 	if !reflect.DeepEqual(sd, expected) {
 		t.Errorf("expected %#v to equal %#v", sd, expected)
@@ -212,10 +160,10 @@ func TestParseHealthServices_dotTag(t *testing.T) {
 	}
 
 	expected := &HealthServices{
-		rawKey: "first.release.webapp [passing]",
+		rawKey: "first.release.webapp [healthy]",
 		Name:   "webapp",
 		Tag:    "first.release",
-		Status: ServiceStatusFilter{HealthPassing},
+		Status: ServiceStatusFilter{Healthy},
 	}
 	if !reflect.DeepEqual(sd, expected) {
 		t.Errorf("expected %#v to equal %#v", sd, expected)
@@ -229,10 +177,10 @@ func TestParseHealthServices_nameTag(t *testing.T) {
 	}
 
 	expected := &HealthServices{
-		rawKey: "release.webapp [passing]",
+		rawKey: "release.webapp [healthy]",
 		Name:   "webapp",
 		Tag:    "release",
-		Status: ServiceStatusFilter{HealthPassing},
+		Status: ServiceStatusFilter{Healthy},
 	}
 
 	if !reflect.DeepEqual(sd, expected) {
@@ -247,11 +195,11 @@ func TestParseHealthServices_nameTagDataCenter(t *testing.T) {
 	}
 
 	expected := &HealthServices{
-		rawKey:     "release.webapp@nyc1 [passing]",
+		rawKey:     "release.webapp@nyc1 [healthy]",
 		Name:       "webapp",
 		Tag:        "release",
 		DataCenter: "nyc1",
-		Status:     ServiceStatusFilter{HealthPassing},
+		Status:     ServiceStatusFilter{Healthy},
 	}
 
 	if !reflect.DeepEqual(sd, expected) {
@@ -266,12 +214,12 @@ func TestParseHealthServices_nameTagDataCenterPort(t *testing.T) {
 	}
 
 	expected := &HealthServices{
-		rawKey:     "release.webapp@nyc1:8500 [passing]",
+		rawKey:     "release.webapp@nyc1:8500 [healthy]",
 		Name:       "webapp",
 		Tag:        "release",
 		DataCenter: "nyc1",
 		Port:       8500,
-		Status:     ServiceStatusFilter{HealthPassing},
+		Status:     ServiceStatusFilter{Healthy},
 	}
 
 	if !reflect.DeepEqual(sd, expected) {
@@ -298,10 +246,10 @@ func TestParseHealthServices_nameAndPort(t *testing.T) {
 	}
 
 	expected := &HealthServices{
-		rawKey: "webapp:8500 [passing]",
+		rawKey: "webapp:8500 [healthy]",
 		Name:   "webapp",
 		Port:   8500,
-		Status: ServiceStatusFilter{HealthPassing},
+		Status: ServiceStatusFilter{Healthy},
 	}
 
 	if !reflect.DeepEqual(sd, expected) {
@@ -316,10 +264,10 @@ func TestParseHealthServices_nameAndDataCenter(t *testing.T) {
 	}
 
 	expected := &HealthServices{
-		rawKey:     "webapp@nyc1 [passing]",
+		rawKey:     "webapp@nyc1 [healthy]",
 		Name:       "webapp",
 		DataCenter: "nyc1",
-		Status:     ServiceStatusFilter{HealthPassing},
+		Status:     ServiceStatusFilter{Healthy},
 	}
 
 	if !reflect.DeepEqual(sd, expected) {
@@ -356,7 +304,7 @@ func TestNewServiceStatusFilter_emptyString(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := ServiceStatusFilter{HealthPassing}
+	expected := ServiceStatusFilter{Healthy}
 	if !reflect.DeepEqual(filter, expected) {
 		t.Errorf("expected %#v to be %#v", filter, expected)
 	}
@@ -380,6 +328,18 @@ func TestNewServiceStatusFilter_statuses(t *testing.T) {
 		if !reflect.DeepEqual(filter, expected) {
 			t.Errorf("expected %#v to be %#v", filter, expected)
 		}
+	}
+
+	// The user should not be able to specify "healthy" themselves as that is an
+	// internal state.
+	_, err := NewServiceStatusFilter(Healthy)
+	if err == nil {
+		t.Fatal("expected error, but nothing was returned")
+	}
+
+	expected := fmt.Sprintf("invalid filter %q", "healthy")
+	if !strings.Contains(err.Error(), expected) {
+		t.Fatalf("expected %q to include %q", err.Error(), expected)
 	}
 }
 
@@ -444,29 +404,6 @@ func TestAccept_any(t *testing.T) {
 	}
 	if !filter.Accept(checks) {
 		t.Fatal("expected all checks to be accepted")
-	}
-}
-
-func TestAccept_passing(t *testing.T) {
-	filter, err := NewServiceStatusFilter("passing")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	checks := []*api.HealthCheck{
-		&api.HealthCheck{Status: "passing"},
-		&api.HealthCheck{Status: "warning"},
-		&api.HealthCheck{Status: "critical"},
-	}
-	if filter.Accept(checks) {
-		t.Fatal("expected filter to not accept non-passing checks")
-	}
-
-	for _, check := range checks {
-		check.Status = "passing"
-	}
-	if !filter.Accept(checks) {
-		t.Fatal("expected all passing checks to be accepted")
 	}
 }
 


### PR DESCRIPTION
This fixes a pretty critical bug in how we filter services, specifically around how we handle "any" vs "passing" vs "(other things)".

"any" is a special case in that it cannot and should not be specified with other status filters. In the past, it was permitted to do this:

```liquid
{{ range services "nginx" "any, passing" }}{{ end }}
```

This led to user confusion. Users thought this meant "give me any service that is passing", but it really means "give me a service that has any status or services that are passing", but since passing services are a subset of any service it was really "give me all services regardless of their status". This was especially confusing for new users and the documentation was a bit unclear. Consul Template now returns an error when you specify additional filters using "any":

```text
* service filter: cannot specify extra keys when using "any"
```

Hopefully this will help eliminate some of the confusion around the behavior of "any". I have additionally updated the documentation.

"passing" is also a special case that was improperly handled before. "passing" actually has a dual meaning - when we query Consul, we have the option to return only passing services. When we filter services on Consul Template's end, we also have the option to filter _only_ passing services. Furthermore, there is a fundamental difference between:

```liquid
{{ range services "nginx" "passing" }}
```

and

```liquid
{{ range services "nginx" "passing, unknown" }}
```

The former says "give me all nginx services which have all checks passing". The latter says "give me all nginx services which has at least one check that is passing or at least one check that is unknown". Previously, we did not differentiate between these two cases. This PR changes Consul Template to handle "passing" vs "passing, (other)" differently.

Finally, this PR adds an additional check to the status filter parsing to ignore empty statuses, for example:

```liquid
{{ range services "nginx" "unknown,   , critical" }}
```

This is useful if the user is building the filter from the result of a subquery where they are dynamically building the list of acceptable status filters.

- Fixes https://github.com/hashicorp/consul-template/issues/210