### PR TITLE
Describe parseJSON bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,8 @@ Takes the given input (usually the value from a key) and parses the result as JS
 {{with $d := key "user/info" | parseJSON}}{{$d.name}}{{end}}
 ```
 
+Note: consul-template evaluates the template multiple times, and on the first evaluation the value of the key will be empty (because consul template had no chance to preload the value yet). This means that you have to be prepared empty response from parseJSON. It just works for simple keys. But fails if you want to iterate over keys or use `index` function. Wrapping code that access object with `{{ if $d }}...{{end}}` is good enough.
+
 Alternatively you can read data from a local JSON file:
 
 ```liquid


### PR DESCRIPTION
The using parseJSON is kinda ugly. I.e. the following fails most of the time (but I'm not sure if it always fail):
```
{{ $config := parseJSON (key "config") }}
{{ range $config.items }}
{{ end }}
```
Which is fixed by:
```
{{ $config := parseJSON (key "config") }}
{{ if $config }}
  {{ range $config.items }}
  {{ end }}
{{ end }}
```
Hopefully my explanation is clear enough.