### PR TITLE
added orkey for key precedence functionality

### DIFF
--- a/template.go
+++ b/template.go
@@ -89,6 +89,7 @@ func funcMap(brain *Brain, used, missing map[string]dep.Dependency) template.Fun
 		"file":        fileFunc(brain, used, missing),
 		"key":         keyFunc(brain, used, missing),
 		"ls":          lsFunc(brain, used, missing),
+		"merge":       mergeFunc(brain, used, missing),
 		"nodes":       nodesFunc(brain, used, missing),
 		"service":     serviceFunc(brain, used, missing),
 		"services":    servicesFunc(brain, used, missing),


### PR DESCRIPTION
This achieves key precedence. We needed to overwrite values based on our production configuration using 'or' would make templates hard to understand - think of nesting 3 or more keys with or, so we created a shorthand for that functionality.