### PR TITLE
Add split/join functions to template

### DIFF
--- a/template.go
+++ b/template.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	dep "github.com/hashicorp/consul-template/dependency"
@@ -108,5 +109,9 @@ func funcMap(brain *Brain, used, missing map[string]dep.Dependency) template.Fun
 		"toLower":         toLower,
 		"toTitle":         toTitle,
 		"toUpper":         toUpper,
+		"split":           strings.Split,
+		"splitWith":       splitWith,
+		"join":            strings.Join,
+		"joinWith":        joinWith,
 	}
 }

--- a/template_functions.go
+++ b/template_functions.go
@@ -452,3 +452,13 @@ func addDependency(m map[string]dep.Dependency, d dep.Dependency) {
 		m[d.HashCode()] = d
 	}
 }
+
+// splitWith is a version of strings.Split that can be piped
+func splitWith(sep, s string) ([]string, error) {
+	return strings.Split(s, sep), nil
+}
+
+// joinWith is a version of strings.Join that can be piped
+func joinWith(sep string, a []string) (string, error) {
+	return strings.Join(a, sep), nil
+}

--- a/template_functions_test.go
+++ b/template_functions_test.go
@@ -1071,3 +1071,32 @@ func TestRegexMatch(t *testing.T) {
 		t.Errorf("expected %t to be %t", result, expected)
 	}
 }
+
+func TestSplitWith(t *testing.T) {
+	result, err := splitWith("\n", "foo bar\nbaz")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := make([]string, 2)
+	expected[0] = "foo bar"
+	expected[1] = "baz"
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected %q to be %q", result, expected)
+	}
+}
+
+func TestJoinWith(t *testing.T) {
+	src := make([]string, 2)
+	src[0] = "foo bar"
+	src[1] = "baz"
+	result, err := joinWith("_", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "foo bar_baz"
+	if result != expected {
+		t.Errorf("Expected %q to be %q", result, expected)
+	}
+}


### PR DESCRIPTION
This adds 4 standard functions to be used at template: `split`, `splitWith`, `join` and `joinWith`.
`split` and `join` are directly exposed `strings.Split` and `strings.Join`, but since it seems they cannot be intuitively piped, I also added local versions `splitWith` and `joinWith` with argument order reversed.

I will add updated documentation later, possibly waiting for an input first on weather this (or the two versions) are ok, bad idea, can be done with single functions (I'm new to Go) or some other concerns.

### Motivation
We store multiline values at some keys, and need to print the lines at the template with pre- or postfixes. Join was more of a complementary addition.

### Added functions

#### `split`
```liquid
{{range split (key "foo/options") "\n"}}
option {{.}};{{end}}
```
Results:
```text
option foo;
option bar;
```

#### `splitWith`
```liquid
{{range key "foo/options" | splitWith "\n"}}
option {{.}};{{end}}
```
Results:
```text
option foo;
option bar;
```

#### `join`
```liquid
{{join $items ";"}}
```
Results:
```text
foo;bar
```

### `joinWith`
```liquid
{{$items | joinWith ";"}}
```
Results:
```text
foo;bar
```
