### PR TITLE
Account for empty strings when splitting

### DIFF
--- a/template_functions.go
+++ b/template_functions.go
@@ -424,6 +424,10 @@ func regexMatch(re, s string) (bool, error) {
 
 // split is a version of strings.Split that can be piped
 func split(sep, s string) ([]string, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return []string{}, nil
+	}
 	return strings.Split(s, sep), nil
 }
 

--- a/template_functions_test.go
+++ b/template_functions_test.go
@@ -1017,9 +1017,19 @@ func TestSplit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := make([]string, 2)
-	expected[0] = "foo bar"
-	expected[1] = "baz"
+	expected := []string{"foo bar", "baz"}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("expected %q to be %q", result, expected)
+	}
+}
+
+func TestSplit_emptyString(t *testing.T) {
+	result, err := split("", "\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := []string{}
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("expected %q to be %q", result, expected)
 	}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/consul-template/issues/288