### PR TITLE
comment causes make to fail

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-package main // import "github.com/hashicorp/consul-template"
+package main 
 
 import (
 	"os"


### PR DESCRIPTION
The comment in line 1 causes go list to try to import itself causing the error below and the make to fail

$ go list -f .
can't load package: package consul-template: code in directory /home/chris/Code/go/src/consul-template expects import "github.com/hashicorp/consul-template"
