### PR TITLE
add fqdnRandservice

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-package main // import "github.com/hashicorp/consul-template"
+package main 
 
 import (
 	"os"

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-package main 
+package main // import "github.com/hashicorp/consul-template"
 
 import (
 	"os"

--- a/template.go
+++ b/template.go
@@ -102,6 +102,7 @@ func funcMap(brain *Brain, used, missing map[string]dep.Dependency) template.Fun
 		"loop":            loop,
 		"join":            join,
 		"parseJSON":       parseJSON,
+		"fqdnRandService": fqdnRandService,
 		"regexReplaceAll": regexReplaceAll,
 		"regexMatch":      regexMatch,
 		"replaceAll":      replaceAll,

--- a/template_functions.go
+++ b/template_functions.go
@@ -175,12 +175,13 @@ func randElements(hashSalt string, slen int, numElems int) ([]int, error) {
 	return randElems, nil
 }
 
-// hashes the hostname and returns an service IP 
-func fqdnRandService(ray []*dep.HealthService) ([]*dep.HealthService, error) {
+// selects hashed services and truncates
+// {{ range service "consul" | fqdnRandService 1 }}
+func fqdnRandService(count int, ray []*dep.HealthService) ([]*dep.HealthService, error) {
 	var res []*dep.HealthService
 	if len(ray) > 1 {
 		p, _ := os.Hostname()
-		q, _ := randElements(p, len(ray), 2) 
+		q, _ := randElements(p, len(ray), count) 
 		for i, _ := range q {
 			res = append(res, ray[i])
 		}

--- a/template_functions_test.go
+++ b/template_functions_test.go
@@ -1110,3 +1110,14 @@ func TestToUpper(t *testing.T) {
 		t.Errorf("expected %q to be %q", result, expected)
 	}
 }
+
+func TestRandElements(t *testing.T) {
+	result, err :=  randElements("foo", 5, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result[0] < 0 {
+		t.Errorf("A negative index was returned")
+	}
+}


### PR DESCRIPTION
This allows a user to hash the hostname to semi-randomize the elements chosen from a slice akin to https://docs.puppetlabs.com/references/latest/function.html#fqdnrand

It also allows truncation.

Example use case is in resolv.conf. I only want to select 2 of the services running bind and set 8.8.8.8 as the default nameserver.

```
{{range datacenters}}search {{.}}.node.consul service.{{.}}.consul {{end}}
{{ range service "bind" | fqdnRandService 2 }}
nameserver {{.Address}}
{{end}}
nameserver 8.8.8.8
```