### PR TITLE
Add node function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,33 @@ maxconns 12
 
 If you omit the datacenter attribute on `ls`, the local Consul datacenter will be queried.
 
+##### `node`
+Query Consul for a single node in the catalog.
+
+```liquid
+{{node "node1"}}
+```
+
+When called without any arguments then the node for the current agent is returned.
+
+```liquid
+{{node}}
+```
+
+You can specify an optional parameter to the `nodes` call to specify the datacenter:
+
+```liquid
+{{node "node1" "@east-aws"}}
+```
+
+If the node specified is not found then `nil` is returned. If the node is found then you are provided with information about the node and a list of services that it provides.
+
+```liquid
+{{with node}}{{.Node.Node}} ({{.Node.Address}}){{range .Services}}
+  {{.Service}} {{.Port}} ({{.Tags | join ","}}){{end}}
+{{end}}
+```
+
 ##### `nodes`
 Query Consul for all nodes in the catalog. Nodes are queried using the following syntax:
 

--- a/dependency/catalog_node.go
+++ b/dependency/catalog_node.go
@@ -1,0 +1,157 @@
+package dependency
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"regexp"
+	"sort"
+)
+
+type CatalogNode struct {
+	Node     *Node
+	Services CatalogNodeServiceList
+}
+
+type CatalogNodeService struct {
+	Service string
+	Tags    ServiceTags
+	Port    int
+}
+
+type CatalogNodeServiceList []*CatalogNodeService
+
+func (s CatalogNodeServiceList) Len() int {
+	return len(s)
+}
+
+func (s CatalogNodeServiceList) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s CatalogNodeServiceList) Less(i, j int) bool {
+	return s[i].Service <= s[j].Service
+}
+
+type CatalogSingleNode struct {
+	rawKey     string
+	dataCenter string
+}
+
+// Fetch queries the Consul API defined by the given client and returns a
+// of CatalogNode object
+func (d *CatalogSingleNode) Fetch(clients *ClientSet, opts *QueryOptions) (interface{}, *ResponseMetadata, error) {
+	if opts == nil {
+		opts = &QueryOptions{}
+	}
+
+	consulOpts := opts.consulQueryOptions()
+	if d.dataCenter != "" {
+		consulOpts.Datacenter = d.dataCenter
+	}
+
+	log.Printf("[DEBUG] (%s) querying Consul with %+v", d.Display(), consulOpts)
+
+	consul, err := clients.Consul()
+	if err != nil {
+		return nil, nil, fmt.Errorf("catalog node: error getting client: %s", err)
+	}
+
+	nodeName := d.rawKey
+	if nodeName == "" {
+		nodeName, err = consul.Agent().NodeName()
+		if err != nil {
+			return nil, nil, fmt.Errorf("catalog node: error getting the node name of the current agent: %s", err)
+		}
+	}
+
+	catalog := consul.Catalog()
+	n, qm, err := catalog.Node(nodeName, consulOpts)
+	if err != nil {
+		return nil, nil, fmt.Errorf("catalog node: error fetching: %s", err)
+	}
+
+	var node *CatalogNode
+	if n != nil {
+		services := make(CatalogNodeServiceList, len(n.Services))
+		i := 0
+		for _, v := range n.Services {
+			services[i] = &CatalogNodeService{
+				Service: v.Service,
+				Tags:    ServiceTags(deepCopyAndSortTags(v.Tags)),
+				Port:    v.Port,
+			}
+			i++
+		}
+		sort.Stable(services)
+		node = &CatalogNode{
+			Node: &Node{
+				Node:    n.Node.Node,
+				Address: n.Node.Address,
+			},
+			Services: services,
+		}
+	}
+
+	rm := &ResponseMetadata{
+		LastIndex:   qm.LastIndex,
+		LastContact: qm.LastContact,
+	}
+
+	return node, rm, nil
+}
+
+func (d *CatalogSingleNode) HashCode() string {
+	if d.dataCenter != "" {
+		return fmt.Sprintf("CatalogNode|%s@%s", d.rawKey, d.dataCenter)
+	}
+	return fmt.Sprintf("CatalogNode|%s", d.rawKey)
+}
+
+func (d *CatalogSingleNode) Display() string {
+	if d.dataCenter != "" {
+		return fmt.Sprintf("node(%s@%s)", d.rawKey, d.dataCenter)
+	}
+	return fmt.Sprintf(`"node(%s)"`, d.rawKey)
+}
+
+// ParseCatalogSingleNode parses a name name and optional datacenter value.
+// If the name is empty or not provided then the current agent is used.
+func ParseCatalogSingleNode(s ...string) (*CatalogSingleNode, error) {
+	switch len(s) {
+	case 0:
+		return &CatalogSingleNode{}, nil
+	case 1:
+		return &CatalogSingleNode{rawKey: s[0]}, nil
+	case 2:
+		dc := s[1]
+
+		re := regexp.MustCompile(`\A` +
+			`(@(?P<datacenter>[[:word:]\.\-]+))?` +
+			`\z`)
+		names := re.SubexpNames()
+		match := re.FindAllStringSubmatch(dc, -1)
+
+		if len(match) == 0 {
+			return nil, errors.New("invalid node dependency format")
+		}
+
+		r := match[0]
+
+		m := map[string]string{}
+		for i, n := range r {
+			if names[i] != "" {
+				m[names[i]] = n
+			}
+		}
+
+		nd := &CatalogSingleNode{
+			rawKey:     s[0],
+			dataCenter: m["datacenter"],
+		}
+
+		return nd, nil
+	default:
+		return nil, fmt.Errorf("expected 0, 1, or 2 arguments, got %d", len(s))
+	}
+}

--- a/dependency/catalog_node_test.go
+++ b/dependency/catalog_node_test.go
@@ -1,0 +1,208 @@
+package dependency
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCatalogSingleNodeFetchForUnknownNode(t *testing.T) {
+	clients, consul := testConsulServer(t)
+	defer consul.Stop()
+
+	dep := &CatalogSingleNode{rawKey: "unknownNode"}
+	result, _, err := dep.Fetch(clients, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	typed, ok := result.(*CatalogNode)
+	if !ok {
+		t.Fatal("could not convert result to *CatalogNode")
+	}
+
+	if typed != nil {
+		t.Fatal("Expecting to get nil for an unknown node")
+	}
+
+}
+
+func TestCatalogSingleNodeFetch(t *testing.T) {
+	clients, consul := testConsulServer(t)
+	defer consul.Stop()
+
+	// AddService does not let me specify a port.
+	consul.AddService("z", "passing", []string{"baz"})
+	consul.AddService("a", "critical", []string{"foo", "bar"})
+
+	dep := &CatalogSingleNode{}
+	result, _, err := dep.Fetch(clients, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	typed, ok := result.(*CatalogNode)
+	if !ok {
+		t.Fatal("could not convert result to *CatalogNode")
+	}
+
+	if typed == nil {
+		t.Fatal("Not expecting to get nil for a known node")
+	}
+
+	if typed.Node.Node != consul.Config.NodeName {
+		t.Errorf("expected %q to be %q", typed.Node.Node, consul.Config.NodeName)
+	}
+	if typed.Node.Address != "127.0.0.1" {
+		t.Errorf("expected %q to be %q", typed.Node.Address, "127.0.0.1")
+	}
+	if len(typed.Services) != 3 {
+		t.Fatalf("expected 3 services got %d", len(typed.Services))
+	}
+
+	var s *CatalogNodeService
+
+	s = typed.Services[0]
+	if s.Service != "a" {
+		t.Errorf("expecting %q to be \"a\"", s.Service)
+	}
+	if s.Port != 0 {
+		t.Errorf("expecting %d to be 0", s.Port)
+	}
+	if len(s.Tags) != 2 {
+		t.Fatalf("expecting %d to be 2", len(s.Tags))
+	}
+	if s.Tags[0] != "bar" {
+		t.Errorf("expecting %q to be \"bar\"", s.Tags[0])
+	}
+	if s.Tags[1] != "foo" {
+		t.Errorf("expecting %q to be \"foo\"", s.Tags[1])
+	}
+
+	s = typed.Services[1]
+	if s.Service != "consul" {
+		t.Errorf("expecting %q to be \"consul\"", s.Service)
+	}
+	if s.Port != consul.Config.Ports.Server {
+		t.Errorf("expecting %d to be %d", s.Port, consul.Config.Ports.Server)
+	}
+	if len(s.Tags) != 0 {
+		t.Fatalf("expecting %d to be 0", len(s.Tags))
+	}
+
+	s = typed.Services[2]
+	if s.Service != "z" {
+		t.Errorf("expecting %q to be \"z\"", s.Service)
+	}
+	if s.Port != 0 {
+		t.Errorf("expecting %d to be 0", s.Port)
+	}
+	if len(s.Tags) != 1 {
+		t.Fatalf("expecting %d to be 1", len(s.Tags))
+	}
+	if s.Tags[0] != "baz" {
+		t.Errorf("expecting %q to be \"baz\"", s.Tags[0])
+	}
+
+}
+
+func TestCatalogSingleNodeFetchWithNameArgument(t *testing.T) {
+	clients, consul := testConsulServer(t)
+	defer consul.Stop()
+
+	dep := &CatalogSingleNode{
+		rawKey: consul.Config.NodeName,
+	}
+	result, _, err := dep.Fetch(clients, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	typed, ok := result.(*CatalogNode)
+	if !ok {
+		t.Fatal("could not convert result to *CatalogNode")
+	}
+
+	if typed == nil {
+		t.Fatal("Not expecting to get nil for a known node")
+	}
+
+	if typed.Node.Node != consul.Config.NodeName {
+		t.Errorf("expected %q to be %q", typed.Node.Node, consul.Config.NodeName)
+	}
+	if typed.Node.Address != "127.0.0.1" {
+		t.Errorf("expected %q to be %q", typed.Node.Address, "127.0.0.1")
+	}
+	if len(typed.Services) != 1 {
+		t.Fatalf("expected 1 services got %d", len(typed.Services))
+	}
+
+	var s *CatalogNodeService
+
+	s = typed.Services[0]
+	if s.Service != "consul" {
+		t.Errorf("expecting %q to be \"consul\"", s.Service)
+	}
+	if s.Port != consul.Config.Ports.Server {
+		t.Errorf("expecting %d to be %d", s.Port, consul.Config.Ports.Server)
+	}
+	if len(s.Tags) != 0 {
+		t.Fatalf("expecting %d to be 0", len(s.Tags))
+	}
+
+}
+
+func TestCatalogSingleNodeHashCode_isUnique(t *testing.T) {
+	dep1 := &CatalogSingleNode{rawKey: ""}
+	dep2 := &CatalogSingleNode{rawKey: "node"}
+	dep3 := &CatalogSingleNode{rawKey: "", dataCenter: "@nyc1"}
+	if dep1.HashCode() == dep2.HashCode() {
+		t.Errorf("expected HashCode to be unique")
+	}
+	if dep1.HashCode() == dep3.HashCode() {
+		t.Errorf("expected HashCode to be unique")
+	}
+	if dep2.HashCode() == dep3.HashCode() {
+		t.Errorf("expected HashCode to be unique")
+	}
+}
+
+func TestParseCatalogSingleNodeNoArguments(t *testing.T) {
+	nd, err := ParseCatalogSingleNode()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := &CatalogSingleNode{}
+	if !reflect.DeepEqual(nd, expected) {
+		t.Errorf("expected %+v to equal %+v", nd, expected)
+	}
+}
+
+func TestParseCatalogSingleNodeOneArgument(t *testing.T) {
+	nd, err := ParseCatalogSingleNode("node")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := &CatalogSingleNode{
+		rawKey: "node",
+	}
+	if !reflect.DeepEqual(nd, expected) {
+		t.Errorf("expected %+v to equal %+v", nd, expected)
+	}
+}
+
+func TestParseCatalogSingleNodeTwoArguments(t *testing.T) {
+	nd, err := ParseCatalogSingleNode("node", "@nyc1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := &CatalogSingleNode{
+		rawKey:     "node",
+		dataCenter: "nyc1",
+	}
+	if !reflect.DeepEqual(nd, expected) {
+		t.Errorf("expected %+v to equal %+v", nd, expected)
+	}
+}

--- a/template.go
+++ b/template.go
@@ -89,6 +89,7 @@ func funcMap(brain *Brain, used, missing map[string]dep.Dependency) template.Fun
 		"file":        fileFunc(brain, used, missing),
 		"key":         keyFunc(brain, used, missing),
 		"ls":          lsFunc(brain, used, missing),
+		"node":        nodeFunc(brain, used, missing),
 		"nodes":       nodesFunc(brain, used, missing),
 		"service":     serviceFunc(brain, used, missing),
 		"services":    servicesFunc(brain, used, missing),

--- a/template_functions.go
+++ b/template_functions.go
@@ -129,6 +129,27 @@ func lsFunc(brain *Brain,
 	}
 }
 
+func nodeFunc(brain *Brain,
+	used, missing map[string]dep.Dependency) func(...string) (*dep.CatalogNode, error) {
+	return func(s ...string) (*dep.CatalogNode, error) {
+
+		d, err := dep.ParseCatalogSingleNode(s...)
+		if err != nil {
+			return nil, err
+		}
+
+		addDependency(used, d)
+
+		if value, ok := brain.Recall(d); ok {
+			return value.(*dep.CatalogNode), nil
+		}
+
+		addDependency(missing, d)
+
+		return nil, nil
+	}
+}
+
 // nodesFunc returns or accumulates catalog node dependencies.
 func nodesFunc(brain *Brain,
 	used, missing map[string]dep.Dependency) func(...string) ([]*dep.Node, error) {

--- a/template_functions_test.go
+++ b/template_functions_test.go
@@ -355,6 +355,73 @@ func TestNodesFunc_noArgs(t *testing.T) {
 	}
 }
 
+func TestNodeFunc_hasData(t *testing.T) {
+	d, err := dep.ParseCatalogSingleNode("@existing")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data := &dep.CatalogNode{
+		Node:     &dep.Node{Node: "a"},
+		Services: make(dep.CatalogNodeServiceList, 0),
+	}
+
+	brain := NewBrain()
+	brain.Remember(d, data)
+
+	used := make(map[string]dep.Dependency)
+	missing := make(map[string]dep.Dependency)
+
+	f := nodeFunc(brain, used, missing)
+	result, err := f("@existing")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := data
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("expected %q to be %q", result, expected)
+	}
+
+	if len(missing) != 0 {
+		t.Errorf("expected missing to have 0 elements, but had %d", len(missing))
+	}
+
+	if _, ok := used[d.HashCode()]; !ok {
+		t.Errorf("expected dep to be used")
+	}
+}
+
+func TestNodeFunc_missingData(t *testing.T) {
+	d, err := dep.ParseCatalogSingleNode("@non-existing")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	brain := NewBrain()
+
+	used := make(map[string]dep.Dependency)
+	missing := make(map[string]dep.Dependency)
+
+	f := nodeFunc(brain, used, missing)
+	result, err := f("@non-existing")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result != nil {
+		t.Errorf("expected %q to be nil", result)
+	}
+
+	if _, ok := used[d.HashCode()]; !ok {
+		t.Errorf("expected dep to be used")
+	}
+
+	if _, ok := missing[d.HashCode()]; !ok {
+		t.Errorf("expected dep to be missing")
+	}
+}
+
 func TestNodesFunc_hasData(t *testing.T) {
 	d, err := dep.ParseCatalogNodes("@existing")
 	if err != nil {

--- a/template_test.go
+++ b/template_test.go
@@ -223,6 +223,9 @@ func TestExecute_renders(t *testing.T) {
 		key: {{ key "config/redis/maxconns" }}
 		ls:{{ range ls "config/redis" }}
 			{{.Key}}={{.Value}}{{ end }}
+		node:{{ with node }}
+			{{.Node.Node}}{{ range .Services}}
+				{{.Service}}{{ end }}{{ end }}
 		nodes:{{ range nodes }}
 			{{.Node}}{{ end }}
 		service:{{ range service "webapp" }}
@@ -310,6 +313,19 @@ func TestExecute_renders(t *testing.T) {
 		&dep.KeyPair{Key: "admin/port", Value: "1134"},
 		&dep.KeyPair{Key: "maxconns", Value: "5"},
 		&dep.KeyPair{Key: "minconns", Value: "2"},
+	})
+
+	d, err = dep.ParseCatalogSingleNode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	brain.Remember(d, &dep.CatalogNode{
+		Node: &dep.Node{Node: "node1"},
+		Services: dep.CatalogNodeServiceList{
+			&dep.CatalogNodeService{
+				Service: "service1",
+			},
+		},
 	})
 
 	d, err = dep.ParseCatalogNodes("")
@@ -408,6 +424,9 @@ func TestExecute_renders(t *testing.T) {
 		ls:
 			maxconns=5
 			minconns=2
+		node:
+			node1
+				service1
 		nodes:
 			node1
 			node2


### PR DESCRIPTION
Query Consul for a single node in the catalog. Essentially this exposes the `/v1/catalog/node/<node>` API to templates.