### PR TITLE
Don't error if file doesn't exist initially on Windows

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -793,7 +793,7 @@ func atomicWrite(path string, contents []byte) error {
 	// See: http://grokbase.com/t/gg/golang-nuts/13aab5f210/go-nuts-atomic-replacement-of-files-on-windows
 	// for more information.
 	if runtime.GOOS == "windows" {
-		if err := os.Remove(path); err != nil {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 			return err
 		}
 	}

--- a/runner_test.go
+++ b/runner_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -621,6 +622,26 @@ func TestAtomicWrite_retainsPermissions(t *testing.T) {
 	expected := os.FileMode(0644)
 	if stat.Mode() != expected {
 		t.Errorf("expected %q to be %q", stat.Mode(), expected)
+	}
+}
+
+func TestAtomicWrite_nonExistent(t *testing.T) {
+	// Create a temp dir
+	outDir, err := ioutil.TempDir(os.TempDir(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(outDir)
+
+	// Try atomicWrite to a file that doesn't exist yet
+	file := filepath.Join(outDir, "nope")
+	if err := atomicWrite(file, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// File was created
+	if _, err := os.Stat(file); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
This should fix #315, but I don't have a Windows environment set up to test at the moment. @highlyunavailable if you want to give this a quick test that would be great, otherwise I'll see if I can get something going on Monday.