### PR TITLE
Fix node service list sort when multiple services have the same name.

### DIFF
--- a/dependency/catalog_node.go
+++ b/dependency/catalog_node.go
@@ -14,6 +14,7 @@ type NodeDetail struct {
 }
 
 type NodeService struct {
+	ID string
 	Service string
 	Tags    ServiceTags
 	Port    int
@@ -72,6 +73,7 @@ func (d *CatalogNode) Fetch(clients *ClientSet, opts *QueryOptions) (interface{}
 	services := make(NodeServiceList, 0, len(n.Services))
 	for _, v := range n.Services {
 		services = append(services, &NodeService{
+			ID:      v.ID,
 			Service: v.Service,
 			Tags:    ServiceTags(deepCopyAndSortTags(v.Tags)),
 			Port:    v.Port,
@@ -152,5 +154,5 @@ type NodeServiceList []*NodeService
 func (s NodeServiceList) Len() int      { return len(s) }
 func (s NodeServiceList) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s NodeServiceList) Less(i, j int) bool {
-	return s[i].Service <= s[j].Service
+	return s[i].ID <= s[j].ID
 }

--- a/dependency/catalog_node.go
+++ b/dependency/catalog_node.go
@@ -154,5 +154,8 @@ type NodeServiceList []*NodeService
 func (s NodeServiceList) Len() int      { return len(s) }
 func (s NodeServiceList) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s NodeServiceList) Less(i, j int) bool {
-	return s[i].ID <= s[j].ID
+	if s[i].Service == s[j].Service {
+		return s[i].ID <= s[j].ID
+	}
+	return s[i].Service <= s[j].Service
 }

--- a/dependency/catalog_node_test.go
+++ b/dependency/catalog_node_test.go
@@ -220,6 +220,12 @@ func TestParseCatalogNodeTwoArguments(t *testing.T) {
 func TestNodeServiceListSort(t *testing.T) {
 	services := make(NodeServiceList, 0, 2)
 	services = append(services, &NodeService{
+		ID:      "s-m",
+		Service: "z",
+		Tags:    make(ServiceTags, 0),
+		Port:    3000,
+	})
+	services = append(services, &NodeService{
 		ID:      "s-z",
 		Service: "s",
 		Tags:    make(ServiceTags, 0),
@@ -251,4 +257,11 @@ func TestNodeServiceListSort(t *testing.T) {
 		t.Errorf("expecting %q to be \"s\"", s.Service)
 	}
 
+	s = services[2]
+	if s.ID != "s-m" {
+		t.Errorf("expecting %q to be \"s-m\"", s.ID)
+	}
+	if s.Service != "z" {
+		t.Errorf("expecting %q to be \"z\"", s.Service)
+	}
 }

--- a/dependency/catalog_node_test.go
+++ b/dependency/catalog_node_test.go
@@ -41,6 +41,9 @@ func TestCatalogNodeFetch(t *testing.T) {
 	var s *NodeService
 
 	s = typed.Services[0]
+	if s.ID != "a" {
+		t.Errorf("expecting %q to be \"a\"", s.ID)
+	}
 	if s.Service != "a" {
 		t.Errorf("expecting %q to be \"a\"", s.Service)
 	}
@@ -58,6 +61,9 @@ func TestCatalogNodeFetch(t *testing.T) {
 	}
 
 	s = typed.Services[1]
+	if s.ID != "consul" {
+		t.Errorf("expecting %q to be \"consul\"", s.ID)
+	}
 	if s.Service != "consul" {
 		t.Errorf("expecting %q to be \"consul\"", s.Service)
 	}
@@ -69,6 +75,9 @@ func TestCatalogNodeFetch(t *testing.T) {
 	}
 
 	s = typed.Services[2]
+	if s.ID != "z" {
+		t.Errorf("expecting %q to be \"z\"", s.ID)
+	}
 	if s.Service != "z" {
 		t.Errorf("expecting %q to be \"z\"", s.Service)
 	}
@@ -137,6 +146,9 @@ func TestCatalogNodeFetch_nameArgument(t *testing.T) {
 	var s *NodeService
 
 	s = typed.Services[0]
+	if s.ID != "consul" {
+		t.Errorf("expecting %q to be \"consul\"", s.ID)
+	}
 	if s.Service != "consul" {
 		t.Errorf("expecting %q to be \"consul\"", s.Service)
 	}

--- a/dependency/catalog_node_test.go
+++ b/dependency/catalog_node_test.go
@@ -3,6 +3,7 @@ package dependency
 import (
 	"reflect"
 	"testing"
+	"sort"
 )
 
 func TestCatalogNodeFetch(t *testing.T) {
@@ -214,4 +215,40 @@ func TestParseCatalogNodeTwoArguments(t *testing.T) {
 	if !reflect.DeepEqual(nd, expected) {
 		t.Errorf("expected %+v to equal %+v", nd, expected)
 	}
+}
+
+func TestNodeServiceListSort(t *testing.T) {
+	services := make(NodeServiceList, 0, 2)
+	services = append(services, &NodeService{
+		ID:      "s-z",
+		Service: "s",
+		Tags:    make(ServiceTags, 0),
+		Port:    2000,
+	})
+	services = append(services, &NodeService{
+		ID:      "s-a",
+		Service: "s",
+		Tags:    make(ServiceTags, 0),
+		Port:    1000,
+	})
+	sort.Stable(services)
+
+	var s *NodeService
+
+	s = services[0]
+	if s.ID != "s-a" {
+		t.Errorf("expecting %q to be \"s-a\"", s.ID)
+	}
+	if s.Service != "s" {
+		t.Errorf("expecting %q to be \"s\"", s.Service)
+	}
+
+	s = services[1]
+	if s.ID != "s-z" {
+		t.Errorf("expecting %q to be \"s-z\"", s.ID)
+	}
+	if s.Service != "s" {
+		t.Errorf("expecting %q to be \"s\"", s.Service)
+	}
+
 }

--- a/dependency/catalog_node_test.go
+++ b/dependency/catalog_node_test.go
@@ -9,7 +9,7 @@ func TestCatalogNodeFetch(t *testing.T) {
 	clients, consul := testConsulServer(t)
 	defer consul.Stop()
 
-	// AddService does not let me specify a port.
+	// AddService does not let me specify an ID or a port.
 	consul.AddService("z", "passing", []string{"baz"})
 	consul.AddService("a", "critical", []string{"foo", "bar"})
 


### PR DESCRIPTION
Change how we sort `NodeService` items in a `NodeServiceList`. This should allow multiple services with the same name to have a consistent ordering based on the unique service `ID`.

Authored using the github web UI and I haven't had a change to build locally. Apologies in advance if this breaks things.