### PR TITLE
Add a way to renew Vault tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ pid_file = "/path/to/pid"
 vault {
   address = "https://vault.service.consul:8200"
   token = "abcd1234" // May also be specified via the envvar VAULT_TOKEN
+  renew = true
   ssl {
     enabled = true
     verify = true

--- a/config.go
+++ b/config.go
@@ -97,6 +97,9 @@ func (c *Config) Merge(config *Config) {
 		if config.WasSet("vault.token") {
 			c.Vault.Token = config.Vault.Token
 		}
+		if config.WasSet("vault.renew") {
+			c.Vault.Renew = config.Vault.Renew
+		}
 		if config.WasSet("vault.ssl") {
 			if c.Vault.SSL == nil {
 				c.Vault.SSL = &SSLConfig{}
@@ -420,6 +423,7 @@ func DefaultConfig() *Config {
 
 	config := &Config{
 		Vault: &VaultConfig{
+			Renew: true,
 			SSL: &SSLConfig{
 				Enabled: true,
 				Verify:  true,
@@ -518,6 +522,7 @@ type ConfigTemplate struct {
 type VaultConfig struct {
 	Address string `json:"address,omitempty" mapstructure:"address"`
 	Token   string `json:"-" mapstructure:"token"`
+	Renew   bool   `json:"renew" mapstructure:"renew"`
 
 	// SSL indicates we should use a secure connection while talking to Vault.
 	SSL *SSLConfig `json:"ssl" mapstructure:"ssl"`

--- a/config_test.go
+++ b/config_test.go
@@ -74,17 +74,20 @@ func TestMerge_vault(t *testing.T) {
 		vault {
 			address = "1.1.1.1"
 			token = "1"
+			renew = true
 		}
 	`, t)
 	config.Merge(testConfig(`
 		vault {
 			address = "2.2.2.2"
+			renew = false
 		}
 	`, t))
 
 	expected := &VaultConfig{
 		Address: "2.2.2.2",
 		Token:   "1",
+		Renew:   false,
 		SSL: &SSLConfig{
 			Enabled: true,
 			Verify:  true,
@@ -126,8 +129,8 @@ func TestMerge_vaultSSL(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(config.Vault, expected) {
-		t.Errorf("expected \n\n%#v\n\n to be \n\n%#v\n\n", config.Vault, expected)
+	if !reflect.DeepEqual(config.Vault.SSL, expected.SSL) {
+		t.Errorf("expected \n\n%#v\n\n to be \n\n%#v\n\n", config.Vault.SSL, expected.SSL)
 	}
 }
 
@@ -300,6 +303,7 @@ func TestParseConfig_correctValues(t *testing.T) {
 		vault {
 			address = "vault.service.consul"
 			token = "efgh5678"
+			renew = true
 			ssl {
 				enabled = false
 			}
@@ -349,6 +353,7 @@ func TestParseConfig_correctValues(t *testing.T) {
 		Vault: &VaultConfig{
 			Address: "vault.service.consul",
 			Token:   "efgh5678",
+			Renew:   true,
 			SSL: &SSLConfig{
 				Enabled: false,
 				Verify:  true,

--- a/dependency/vault_secret.go
+++ b/dependency/vault_secret.go
@@ -95,7 +95,7 @@ func (d *VaultSecret) Fetch(clients *ClientSet, opts *QueryOptions) (interface{}
 	d.renewable = secret.Renewable
 	d.Unlock()
 
-	log.Printf("[DEBUG] (%s) Consul returned the secret", d.Display())
+	log.Printf("[DEBUG] (%s) vault returned the secret", d.Display())
 
 	ts := time.Now().Unix()
 	rm := &ResponseMetadata{

--- a/dependency/vault_token.go
+++ b/dependency/vault_token.go
@@ -1,0 +1,84 @@
+package dependency
+
+import (
+	"fmt"
+	"log"
+	"sync"
+	"time"
+)
+
+// VaultToken is the dependency to Vault for a secret
+type VaultToken struct {
+	sync.Mutex
+
+	leaseID       string
+	leaseDuration int
+}
+
+// Fetch queries the Vault API
+func (d *VaultToken) Fetch(clients *ClientSet, opts *QueryOptions) (interface{}, *ResponseMetadata, error) {
+	if opts == nil {
+		opts = &QueryOptions{}
+	}
+
+	log.Printf("[DEBUG] (%s) renewing vault token", d.Display())
+
+	// If this is not the first query and we have a lease duration, sleep until we
+	// try to renew.
+	if opts.WaitIndex != 0 && d.leaseDuration != 0 {
+		duration := time.Duration(d.leaseDuration/2) * time.Second
+		log.Printf("[DEBUG] (%s) sleeping for %q", d.Display(), duration)
+		time.Sleep(duration)
+	}
+
+	// Grab the vault client
+	vault, err := clients.Vault()
+	if err != nil {
+		return nil, nil, fmt.Errorf("vault_token: %s", err)
+	}
+
+	token, err := vault.Auth().Token().Renew(vault.Token(), 0)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error renewing vault token: %s", err)
+	}
+
+	// Create our cloned secret
+	secret := &Secret{
+		LeaseID:       token.LeaseID,
+		LeaseDuration: token.LeaseDuration,
+		Renewable:     token.Renewable,
+		Data:          token.Data,
+	}
+
+	leaseDuration := secret.LeaseDuration
+	if leaseDuration == 0 {
+		log.Printf("[WARN] (%s) lease duration is 0, setting to 5m", d.Display())
+		leaseDuration = 5 * 60
+	}
+
+	d.Lock()
+	d.leaseID = secret.LeaseID
+	d.leaseDuration = secret.LeaseDuration
+	d.Unlock()
+
+	log.Printf("[DEBUG] (%s) successfully renewed token", d.Display())
+
+	ts := time.Now().Unix()
+	rm := &ResponseMetadata{
+		LastContact: time.Duration(ts),
+		LastIndex:   uint64(ts),
+	}
+
+	return secret, rm, nil
+}
+
+// HashCode returns the hash code for this dependency.
+func (d *VaultToken) HashCode() string {
+	return "VaultToken"
+}
+
+// Display returns a string that should be displayed to the user in output (for
+// example).
+func (d *VaultToken) Display() string {
+	return "vault_token"
+}

--- a/dependency/vault_token_test.go
+++ b/dependency/vault_token_test.go
@@ -1,0 +1,41 @@
+package dependency
+
+import (
+	"testing"
+
+	"github.com/hashicorp/vault/api"
+)
+
+func TestVaultTokenFetch(t *testing.T) {
+	clients, server := testVaultServer(t)
+	defer server.Stop()
+
+	vault, err := clients.Vault()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a new token - the default token is a root token and is therefore
+	// not renewable
+	token, err := vault.Auth().Token().Create(&api.TokenCreateRequest{
+		Lease: "1h",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set the new token on the client so we can try to renew
+	newToken := token.Auth.ClientToken
+	vault.SetToken(newToken)
+
+	dep := new(VaultToken)
+	results, _, err := dep.Fetch(clients, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, ok := results.(*Secret)
+	if !ok {
+		t.Fatal("could not convert result to a *vault/api.Secret")
+	}
+}

--- a/runner.go
+++ b/runner.go
@@ -975,6 +975,7 @@ func newWatcher(config *Config, clients *dep.ClientSet, once bool) (*watch.Watch
 		RetryFunc: func(current time.Duration) time.Duration {
 			return config.Retry
 		},
+		RenewVault: config.Vault.Renew,
 	})
 	if err != nil {
 		return nil, err

--- a/template_functions.go
+++ b/template_functions.go
@@ -500,7 +500,7 @@ func parseBool(s string) (bool, error) {
 // parseFloat parses a string into a base 10 float
 func parseFloat(s string) (float64, error) {
 	if s == "" {
-		return 0.0
+		return 0.0, nil
 	}
 
 	result, err := strconv.ParseFloat(s, 10)
@@ -513,7 +513,7 @@ func parseFloat(s string) (float64, error) {
 // parseInt parses a string into a base 10 int
 func parseInt(s string) (int64, error) {
 	if s == "" {
-		return 0
+		return 0, nil
 	}
 
 	result, err := strconv.ParseInt(s, 10, 64)

--- a/watch/watcher.go
+++ b/watch/watcher.go
@@ -61,6 +61,10 @@ type WatcherConfig struct {
 	// RetryFunc is a RetryFunc that represents the way retrys and backoffs
 	// should occur.
 	RetryFunc RetryFunc
+
+	// RenewVault determines if the watcher should renew the Vault token as a
+	// background job.
+	RenewVault bool
 }
 
 // NewWatcher creates a new watcher using the given API client.
@@ -176,6 +180,13 @@ func (w *Watcher) init() error {
 
 	// Setup our map of dependencies to views
 	w.depViewMap = make(map[string]*View)
+
+	// Start a watcher for the Vault renew if that config was specified
+	if w.config.RenewVault {
+		if _, err := w.Add(new(dep.VaultToken)); err != nil {
+			return fmt.Errorf("watcher: %s", err)
+		}
+	}
 
 	return nil
 }

--- a/watch/watcher_test.go
+++ b/watch/watcher_test.go
@@ -79,6 +79,24 @@ func TestNewWatcher_values(t *testing.T) {
 	}
 }
 
+func TestNewWatcher_renewVault(t *testing.T) {
+	clients := dep.NewClientSet()
+
+	w, err := NewWatcher(&WatcherConfig{
+		Clients:    clients,
+		Once:       true,
+		RenewVault: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Stop()
+
+	if !w.Watching(new(dep.VaultToken)) {
+		t.Errorf("expected watcher to be renewing vault token")
+	}
+}
+
 func TestAdd_updatesMap(t *testing.T) {
 	w, err := NewWatcher(defaultWatcherConfig)
 	if err != nil {


### PR DESCRIPTION
This is a configuration option that defaults to true. Users can opt-out by setting the configuration option.