### PR TITLE
Correct README re: contains function

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,13 +483,13 @@ Takes the list of services returned by the [`service`](#service) or [`services`]
 {{end}}{{end}}
 ```
 
-##### `contains`
-Determines if a needle is within an iterable element.
+##### `.Tags.Contains`
+Determines if a needle is within an service's tags.
 
 ```liquid
-{{ if .Tags | contains "production" }}
+{{ range service "consul" }}{{ if .Tags.Contains "production" }}
 # ...
-{{ end }}
+{{ end }}{{ end }}
 ```
 
 ##### `env`


### PR DESCRIPTION
Presently, there is no "contains" function - rather, there is a ServiceTags.Contains function.

This PR corrects the docs, albeit in a manner that makes the heading inconsistent the wording of the surrounding text (the other functions are all 'global' and have single-word, lower-case names).

See #375.