### PR TITLE
Adds a toMap function which converts a ServiceTags element into a map.

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,6 +749,19 @@ Takes the argument as a string and converts it to lowercase.
 
 See Go's [strings.ToLower()](http://golang.org/pkg/strings/#ToLower) for more information.
 
+##### 'toMap'
+Takes the argument as a ServiceTags and converts any tag which are of the style `key=value` into a `map`.
+
+Given the following tags in a service entry: ``path=/test lbset=group1``
+
+```liquid
+{{range service "www"}}
+   {{$x := .Tags | toMap}}
+   ProxyPass {{$x.path}} http://{{$x.lbset}}{{$x.path}}
+   ProxyPassReverse {{$x.path}} http://{{$x.lbset}}{{$x.path}}
+{{end}}
+```
+
 ##### `toTitle`
 Takes the argument as a string and converts it to titlecase.
 

--- a/template.go
+++ b/template.go
@@ -116,6 +116,7 @@ func funcMap(brain *Brain, used, missing map[string]dep.Dependency) template.Fun
 		"replaceAll":      replaceAll,
 		"timestamp":       timestamp,
 		"toLower":         toLower,
+		"toMap":           toMap,
 		"toJSON":          toJSON,
 		"toJSONPretty":    toJSONPretty,
 		"toTitle":         toTitle,

--- a/template_functions.go
+++ b/template_functions.go
@@ -810,3 +810,18 @@ func addDependency(m map[string]dep.Dependency, d dep.Dependency) {
 		m[d.HashCode()] = d
 	}
 }
+
+// toMap converts ServiceTags into a map. It loops through the tags
+// and any tag that has an equal sign in it is indexed in the map.
+func toMap(entries dep.ServiceTags) (map[string]string, error) {
+	m := make(map[string]string)
+	for i := 0; i < len(entries); i++ {
+		if strings.Contains(entries[i], "=") {
+			item := strings.Split(entries[i], "=")
+			m[item[0]] = item[1]
+		}
+	}
+	return m, nil
+}
+
+


### PR DESCRIPTION
This is needed to use the [Registrator](http://gliderlabs.com/registrator) / Consul-Template tools in order to dynamically configure Apache. Since Consul does not support Registrator's Attributes, and can only work with labels, a method of having key-values is necessary. By creating `key=value` labels, one can achieve this.