### PR TITLE
Do not remove the Windows file if it does not exist.

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -786,18 +786,6 @@ func atomicWrite(path string, contents []byte) error {
 		return err
 	}
 
-	// Remove the file if we are running on Windows. There is a bug in Go on
-	// Windows such that Go uses MoveFile which raises an exception if the file
-	// already exists.
-	//
-	// See: http://grokbase.com/t/gg/golang-nuts/13aab5f210/go-nuts-atomic-replacement-of-files-on-windows
-	// for more information.
-	if runtime.GOOS == "windows" {
-		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-			return err
-		}
-	}
-
 	if err := os.Rename(f.Name(), path); err != nil {
 		return err
 	}


### PR DESCRIPTION
According to this commit in Go:

  https://github.com/golang/go/commit/92c57363e0b4d193c4324e2af6902fe56b7524a0

this has been fixed in Go and is no longer needed.

This fixes GH-378