### PR TITLE
Add key_or_default

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,16 @@ The example above is querying Consul for the `service/redis/maxconns` in the eas
 
 The beauty of Consul is that the key-value structure is entirely up to you!
 
+##### `key_or_default`
+Query Consul for the value at the given key. If no key exists at the given path, the default value will be used instead. The existing constraints and usage for keys apply:
+
+```liquid
+{{key_or_default "service/redis/maxconns@east-aws" "5"}}
+```
+
+Please note that Consul Template uses a multi-phase evaluation. During the first phase of evaluation, Consul Template will have no data from Consul and thus will _always_ fall back to the default value. Subsequent reads from Consul will pull in the real value from Consul (if the key exists) on the next template pass. This is important because it means that Consul Template will never "block" the rendering of a template due to a missing key from a `key_or_default`. Even if the key exists, if Consul has not yet returned data for the key, the
+default value will be used instead.
+
 ##### `ls`
 Query Consul for all top-level key-value pairs at the given prefix. If any of the values cannot be converted to a string-like value, an error will occur:
 

--- a/dependency/store_key_test.go
+++ b/dependency/store_key_test.go
@@ -24,10 +24,49 @@ func TestStoreKeyFetch(t *testing.T) {
 	}
 }
 
+func TestStoreKeySetDefault(t *testing.T) {
+	dep, err := ParseStoreKey("conns")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dep.SetDefault("3")
+
+	if dep.defaultValue != "3" {
+		t.Errorf("expected %q to be %q", dep.defaultValue, "3")
+	}
+}
+
+func TestStoreKeyDisplay_includesDefault(t *testing.T) {
+	dep, err := ParseStoreKey("conns")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dep.SetDefault("3")
+	expected := `"key_or_default(conns, "3")"`
+	if dep.Display() != expected {
+		t.Errorf("expected %q to be %q", dep.Display(), expected)
+	}
+}
+
 func TestStoreKeyHashCode_isUnique(t *testing.T) {
-	dep1 := &StoreKey{rawKey: "config/redis/maxconns"}
-	dep2 := &StoreKey{rawKey: "config/redis/minconns"}
+	dep1, err := ParseStoreKey("config/redis/maxconns")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dep2, err := ParseStoreKey("config/redis/minconns")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dep3, err := ParseStoreKey("config/redis/minconns")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dep3.SetDefault("3")
+
 	if dep1.HashCode() == dep2.HashCode() {
+		t.Errorf("expected HashCode to be unique")
+	}
+	if dep2.HashCode() == dep3.HashCode() {
 		t.Errorf("expected HashCode to be unique")
 	}
 }

--- a/template.go
+++ b/template.go
@@ -85,16 +85,17 @@ func (t *Template) init() error {
 func funcMap(brain *Brain, used, missing map[string]dep.Dependency) template.FuncMap {
 	return template.FuncMap{
 		// API functions
-		"datacenters": datacentersFunc(brain, used, missing),
-		"file":        fileFunc(brain, used, missing),
-		"key":         keyFunc(brain, used, missing),
-		"ls":          lsFunc(brain, used, missing),
-		"node":        nodeFunc(brain, used, missing),
-		"nodes":       nodesFunc(brain, used, missing),
-		"service":     serviceFunc(brain, used, missing),
-		"services":    servicesFunc(brain, used, missing),
-		"tree":        treeFunc(brain, used, missing),
-		"vault":       vaultFunc(brain, used, missing),
+		"datacenters":    datacentersFunc(brain, used, missing),
+		"file":           fileFunc(brain, used, missing),
+		"key":            keyFunc(brain, used, missing),
+		"key_or_default": keyWithDefaultFunc(brain, used, missing),
+		"ls":             lsFunc(brain, used, missing),
+		"node":           nodeFunc(brain, used, missing),
+		"nodes":          nodesFunc(brain, used, missing),
+		"service":        serviceFunc(brain, used, missing),
+		"services":       servicesFunc(brain, used, missing),
+		"tree":           treeFunc(brain, used, missing),
+		"vault":          vaultFunc(brain, used, missing),
 
 		// Helper functions
 		"byKey":           byKey,

--- a/template_functions.go
+++ b/template_functions.go
@@ -101,6 +101,37 @@ func keyFunc(brain *Brain,
 	}
 }
 
+// keyWithDefaultFunc returns or accumulates key dependencies that have a
+// default value.
+func keyWithDefaultFunc(brain *Brain,
+	used, missing map[string]dep.Dependency) func(string, string) (string, error) {
+	return func(s, def string) (string, error) {
+		if len(s) == 0 {
+			return def, nil
+		}
+
+		d, err := dep.ParseStoreKey(s)
+		if err != nil {
+			return "", err
+		}
+		d.SetDefault(def)
+
+		addDependency(used, d)
+
+		if value, ok := brain.Recall(d); ok {
+			if value == nil {
+				return def, nil
+			} else {
+				return value.(string), nil
+			}
+		}
+
+		addDependency(missing, d)
+
+		return def, nil
+	}
+}
+
 // lsFunc returns or accumulates keyPrefix dependencies.
 func lsFunc(brain *Brain,
 	used, missing map[string]dep.Dependency) func(string) ([]*dep.KeyPair, error) {

--- a/template_functions_test.go
+++ b/template_functions_test.go
@@ -246,6 +246,85 @@ func TestKeyFunc_missingData(t *testing.T) {
 	}
 }
 
+func TestKeyWithDefaultFunc_emptyString(t *testing.T) {
+	brain := NewBrain()
+	used := make(map[string]dep.Dependency)
+	missing := make(map[string]dep.Dependency)
+
+	f := keyWithDefaultFunc(brain, used, missing)
+	result, err := f("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result != "" {
+		t.Errorf("expected %q to be %q", result, "")
+	}
+}
+
+func TestKeyWithDefaultFunc_hasData(t *testing.T) {
+	d, err := dep.ParseStoreKey("existing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d.SetDefault("default")
+
+	brain := NewBrain()
+	brain.Remember(d, "contents")
+
+	used := make(map[string]dep.Dependency)
+	missing := make(map[string]dep.Dependency)
+
+	f := keyWithDefaultFunc(brain, used, missing)
+	result, err := f("existing", "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result != "contents" {
+		t.Errorf("expected %q to be %q", result, "contents")
+	}
+
+	if len(missing) != 0 {
+		t.Errorf("expected missing to have 0 elements, but had %d", len(missing))
+	}
+
+	if _, ok := used[d.HashCode()]; !ok {
+		t.Errorf("expected dep to be used")
+	}
+}
+
+func TestKeyWithDefaultFunc_missingData(t *testing.T) {
+	d, err := dep.ParseStoreKey("non-existing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d.SetDefault("default")
+
+	brain := NewBrain()
+
+	used := make(map[string]dep.Dependency)
+	missing := make(map[string]dep.Dependency)
+
+	f := keyWithDefaultFunc(brain, used, missing)
+	result, err := f("non-existing", "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result != "default" {
+		t.Errorf("expected %q to be %q", result, "")
+	}
+
+	if _, ok := used[d.HashCode()]; !ok {
+		t.Errorf("expected dep to be used")
+	}
+
+	if _, ok := missing[d.HashCode()]; !ok {
+		t.Errorf("expected dep to be missing")
+	}
+}
+
 func TestLsFunc_emptyString(t *testing.T) {
 	brain := NewBrain()
 	used := make(map[string]dep.Dependency)

--- a/template_test.go
+++ b/template_test.go
@@ -221,6 +221,8 @@ func TestExecute_renders(t *testing.T) {
 			{{.}}{{ end }}
 		file: {{ file "/path/to/file" }}
 		key: {{ key "config/redis/maxconns" }}
+		key_or_default (exists): {{ key_or_default "config/redis/minconns" "100" }}
+		key_or_default (missing): {{ key_or_default "config/redis/maxconns" "200" }}
 		ls:{{ range ls "config/redis" }}
 			{{.Key}}={{.Value}}{{ end }}
 		node:{{ with node }}
@@ -326,6 +328,19 @@ func TestExecute_renders(t *testing.T) {
 		t.Fatal(err)
 	}
 	brain.Remember(d, "5")
+
+	d, err = dep.ParseStoreKey("config/redis/minconns")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d.(*dep.StoreKey).SetDefault("100")
+	brain.Remember(d, "150")
+
+	d, err = dep.ParseStoreKey("config/redis/maxconns")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d.(*dep.StoreKey).SetDefault("200")
 
 	d, err = dep.ParseStoreKeyPrefix("config/redis")
 	if err != nil {
@@ -444,6 +459,8 @@ func TestExecute_renders(t *testing.T) {
 			dc2
 		file: some content
 		key: 5
+		key_or_default (exists): 150
+		key_or_default (missing): 200
 		ls:
 			maxconns=5
 			minconns=2


### PR DESCRIPTION
This new function builds on the existing `key` function, but provides an easy
way for users to specify a default value. This replaces the common pattern of:

    {{if key "service/app/max_conns"}}
      max_conns={{key "service/app/max_conns"}}
    {{else}}
      max_conns=500
    {{end}}

or

    {{ or (key "service/app/max_conns") "5" }}

with

    {{ key_or_default "service/app/max_conns" "5" }}

Fixes GH-368