### PR TITLE
add timestamp special case 'unix'

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,13 +716,20 @@ Returns the current timestamp as a string (UTC). If no arguments are given, the 
 {{timestamp}} // e.g. 1970-01-01T00:00:00Z
 ```
 
-If the optional parameter is given, it is used to format the timestamp using the magic reference date **Mon Jan 2 15:04:05 -0700 MST 2006**:
+If the optional parameter is given, it is used to format the timestamp. The magic reference date **Mon Jan 2 15:04:05 -0700 MST 2006** can be used to format the date as required:
 
 ```liquid
 {{timestamp "2006-01-02"}} // e.g. 1970-01-01
 ```
 
 See Go's [time.Format()](http://golang.org/pkg/time/#Time.Format) for more information.
+
+As a special case, if the optional parameter is `"unix"`, the unix timestamp in seconds is returned as a string.
+
+```liquid
+{{timestamp "unix"}} // e.g. 0
+```
+
 
 ##### `toJSON`
 Takes the result from a `tree` or `ls` call and converts it into a JSON object.

--- a/template_functions.go
+++ b/template_functions.go
@@ -669,7 +669,11 @@ func timestamp(s ...string) (string, error) {
 	case 0:
 		return now().Format(time.RFC3339), nil
 	case 1:
-		return now().Format(s[0]), nil
+		if s[0] == "unix" {
+			return strconv.FormatInt(now().Unix(), 10), nil
+		} else {
+			return now().Format(s[0]), nil
+		}
 	default:
 		return "", fmt.Errorf("timestamp: wrong number of arguments, expected 0 or 1"+
 			", but got %d", len(s))

--- a/template_functions_test.go
+++ b/template_functions_test.go
@@ -1439,6 +1439,20 @@ func TestTimestamp_format(t *testing.T) {
 	}
 }
 
+func TestTimestamp_formatUnix(t *testing.T) {
+	now = func() time.Time { return time.Unix(0, 0).UTC() }
+
+	result, err := timestamp("unix")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "0"
+	if result != expected {
+		t.Errorf("expected %q to be %q", result, expected)
+	}
+}
+
 func TestTimestamp_tooManyArgs(t *testing.T) {
 	_, err := timestamp("a", "b")
 	if err == nil {


### PR DESCRIPTION
Ran into a case where a unix timestamp would be very useful but wouldn't be able to get that out of the timestamp formatting. Thought it might warrant a special case to `timestamp` as opposed to its own function.