### PR TITLE
Support for minimum of entries required.

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -272,9 +272,18 @@ func (r *Runner) Run() error {
 		// Attempt to render the template, returning any missing dependencies and
 		// the rendered contents. If there are any missing dependencies, the
 		// contents cannot be rendered or trusted!
-		used, missing, contents, err := tmpl.Execute(r.brain)
+		used, missing, contents, control, err := tmpl.Execute(r.brain)
 		if err != nil {
 			return err
+		}
+		if control != nil {
+			switch control.controlType {
+			case ControlTypeSkip:
+				log.Printf("[ERR] skipping template generation: %s", control.reason)
+				continue
+			default:
+				return fmt.Errorf("Invalid control type: %v", control.controlType)
+			}
 		}
 
 		// Add the dependency to the list of dependencies for this runner.


### PR DESCRIPTION
This feature introduces `minimum` function. It allows user to specify minimum number of nodes required for a valid configuration. If number of nodes returned is less than specified value, the template won't be updated and an error message will be generated. This can be used as an extra sanity check for critical services.

Example usage:
```nginx
upstream frontend { {{range service "web@sfo1" | minimum 3}} 
        server {{.Address}}:{{.Port}};{{end}}
}

server {
        listen 80 default_server;

        location / { 
                proxy_pass http://frontend;
        }
}
```
