### PR TITLE
Introduce TLS/SSL Mutual Authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,9 @@ _testmain.go
 .proc
 *.conf
 
+# IDE files
+*.iml
+*.idea
+
 bin/
 pkg/

--- a/cli.go
+++ b/cli.go
@@ -210,6 +210,13 @@ func (cli *CLI) parseFlags(args []string) (*Config, bool, bool, bool, error) {
 	}), "ssl-cert", "")
 
 	flags.Var((funcVar)(func(s string) error {
+		config.SSL.Key = s
+		config.set("ssl")
+		config.set("ssl.key")
+		return nil
+	}), "ssl-key", "")
+
+	flags.Var((funcVar)(func(s string) error {
 		config.SSL.CaCert = s
 		config.set("ssl")
 		config.set("ssl.ca_cert")
@@ -351,6 +358,8 @@ Options:
   -ssl                     Use SSL when connecting to Consul
   -ssl-verify              Verify certificates when connecting via SSL
   -ssl-cert                SSL client certificate to send to server
+  -ssl-key                 SSL/TLS private key for use in client authentication
+                           key exchange
   -ssl-ca-cert             Validate server certificate against this CA
                            certificate file list
   -token=<token>           Sets the Consul API token

--- a/cli_test.go
+++ b/cli_test.go
@@ -212,6 +212,27 @@ func TestParseFlags_SSLCert(t *testing.T) {
 	}
 }
 
+func TestParseFlags_SSLKey(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-ssl-key", "/path/to/client-key.pem",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "/path/to/client-key.pem"
+	if config.SSL.Key != expected {
+		t.Errorf("expected %v to be %v", config.SSL.Key, expected)
+	}
+	if !config.WasSet("ssl") {
+		t.Errorf("expected ssl to be set")
+	}
+	if !config.WasSet("ssl.key") {
+		t.Errorf("expected ssl.key to be set")
+	}
+}
+
 func TestParseFlags_SSLCaCert(t *testing.T) {
 	cli := NewCLI(ioutil.Discard, ioutil.Discard)
 	config, _, _, _, err := cli.parseFlags([]string{

--- a/config.go
+++ b/config.go
@@ -155,6 +155,10 @@ func (c *Config) Merge(config *Config) {
 			c.SSL.Cert = config.SSL.Cert
 			c.SSL.Enabled = true
 		}
+		if config.WasSet("ssl.key") {
+			c.SSL.Key = config.SSL.Key
+			c.SSL.Enabled = true
+		}
 		if config.WasSet("ssl.ca_cert") {
 			c.SSL.CaCert = config.SSL.CaCert
 			c.SSL.Enabled = true
@@ -465,6 +469,7 @@ type SSLConfig struct {
 	Enabled bool   `json:"enabled" mapstructure:"enabled"`
 	Verify  bool   `json:"verify" mapstructure:"verify"`
 	Cert    string `json:"cert,omitempty" mapstructure:"cert"`
+	Key     string `json:"key,omitempty" mapstructure:"key"`
 	CaCert  string `json:"ca_cert,omitempty" mapstructure:"ca_cert"`
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -427,6 +427,29 @@ func TestParseConfig_mapstructureError(t *testing.T) {
 	}
 }
 
+func TestParseConfig_ssh_key_should_enable_ssl(t *testing.T) {
+	config := testConfig(`
+		ssl {
+			key = "private-key.pem"
+			verify = true
+			cert = "1.pem"
+			ca_cert = "ca-1.pem"
+		}
+	`, t)
+
+	expected := &SSLConfig{
+		Enabled:	true,
+		Verify:		true,
+		Cert:		"1.pem",
+		Key:		"private-key.pem",
+		CaCert:		"ca-1.pem",
+	}
+
+	if !reflect.DeepEqual(config.SSL, expected) {
+		t.Errorf("expected \n\n%#v\n\n to be \n\n%#v\n\n", config.SSL, expected)
+	}
+}
+
 func TestParseConfig_extraKeys(t *testing.T) {
 	configFile := test.CreateTempfile([]byte(`
 		fake_key = "nope"

--- a/runner.go
+++ b/runner.go
@@ -840,7 +840,14 @@ func newConsulClient(config *Config) (*consulapi.Client, error) {
 
 		tlsConfig := &tls.Config{}
 
-		if config.SSL.Cert != "" {
+		// Client configured for TLS Mutual Authentication
+		if config.SSL.Cert != "" && config.SSL.Key != "" {
+			cert, err := tls.LoadX509KeyPair(config.SSL.Cert, config.SSL.Key)
+			if err != nil {
+				return nil, err
+			}
+			tlsConfig.Certificates = []tls.Certificate{cert}
+		} else if config.SSL.Cert != "" {
 			cert, err := tls.LoadX509KeyPair(config.SSL.Cert, config.SSL.Cert)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Setting the config option ssl.key or CLI flag
'-ssl-key=/my/private/key.pem' allows the HTTPS client to authenticate
itself towards a Consul server which has the option "verify_incoming": true


CC: @sorenmat