### PR TITLE
Adds support for de-duplication of template rendering between multiple instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ branches:
 
 before_script:
   - mkdir -p ~/bin/
-  - wget -O consul.zip -q https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip
+  - wget -O consul.zip -q https://releases.hashicorp.com/consul/0.6.0/consul_0.6.0_linux_amd64.zip
   - unzip consul.zip
   - mv consul ~/bin/
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Usage
 | `auth`            | The basic authentication username (and optional password), separated by a colon. There is no default value.
 | `consul`*         | The location of the Consul instance to query (may be an IP address or FQDN) with port.
 | `max-stale`       | The maximum staleness of a query. If specified, Consul will distribute work among all servers instead of just the leader. The default value is 1s.
+| `deduplicate`*    | Enable de-duplication of template rendering. If many instances of consul-template render the same template this reduces the load on Consul.
 | `ssl`             | Use HTTPS while talking to Consul. Requires the Consul server to be configured to serve secure connections. The default value is false.
 | `ssl-verify`      | Verify certificates when connecting via SSL. This requires the use of `-ssl`. The default value is true.
 | `ssl-cert`        | Path to an SSL client certificate to use to authenticate to the consul server. Useful if the consul server "verify_incoming" option is set.
@@ -149,6 +150,11 @@ template {
   command = "optional command to run when the template is updated"
   perms = 0600
   backup = true
+}
+
+deduplicate {
+  enabled = true
+  prefix = "consul-template/dedup/"
 }
 
 template {
@@ -926,6 +932,19 @@ func main() {
 
 Caveats
 -------
+### De-Duplication Mode
+
+Consul Template works by parsing templates to determine what data is needed and then watching Consul
+for any changes to that data. This allows Consul Template to efficiently re-render templates when a
+change occurs. However, if there are many instances of Consul Template rendering a common template
+there is a linear duplicaiton of work as each instance is querying the same data.
+
+To make this pattern more efficient Consul Template supports work de-duplication across instances.
+This can be enabled with the `-dedup` flag or via the `deduplicate` configuration block. Once enabled,
+Consul Template uses [leader election](https://consul.io/docs/guides/leader-election.html) on a per
+template basis to have only a single node perform the queries. Results are shared among other instances
+rending the same template by passing compressed data through the Consul K/V store.
+
 ### Termination on Error
 By default Consul Template is highly fault-tolerant. If Consul is unreachable or a template changes, Consul Template will happily continue running. The only exception to this rule is if the optional `command` exits non-zero. In this case, Consul Template will also exit non-zero. The reason for this decision is so the user can easily configure something like Upstart or God to manage Consul Template as a service.
 
@@ -1212,7 +1231,7 @@ $ consul-template -log-level debug ...
 FAQ
 ---
 **Q: How is this different than confd?**<br>
-A: The answer is simple: Service Discovery as a first class citizen. You are also encouraged to read [this Pull Request](https://github.com/kelseyhightower/confd/pull/102) on the project for more background information. We think confd is a great project, but Consul Template fills a missing gap.
+A: The answer is simple: Service Discovery as a first class citizen. You are also encouraged to read [this Pull Request](https://github.com/kelseyhightower/confd/pull/102) on the project for more background information. We think confd is a great project, but Consul Template fills a missing gap. Additionally, Consul Template has first class integration with [Vault](https://vaultproject.io), making it easy to incorporate secret material like database credentials or API tokens into configuraiton files.
 
 **Q: How is this different than Puppet/Chef/Ansible/Salt?**<br>
 A: Configuration management tools are designed to be used in unison with Consul Template. Instead of rendering a stale configuration file, use your configuration management software to render a dynamic template that will be populated by [Consul][].

--- a/brain.go
+++ b/brain.go
@@ -53,6 +53,16 @@ func (b *Brain) Recall(d dep.Dependency) (interface{}, bool) {
 	return b.data[d.HashCode()], true
 }
 
+// ForceSet is used to force set the value of a depdency
+// for a given hash code
+func (b *Brain) ForceSet(hashCode string, data interface{}) {
+	b.Lock()
+	defer b.Unlock()
+
+	b.data[hashCode] = data
+	b.receivedData[hashCode] = struct{}{}
+}
+
 // Forget accepts a dependency and removes all associated data with this
 // dependency. It also resets the "receivedData" internal map.
 func (b *Brain) Forget(d dep.Dependency) {

--- a/brain.go
+++ b/brain.go
@@ -53,7 +53,7 @@ func (b *Brain) Recall(d dep.Dependency) (interface{}, bool) {
 	return b.data[d.HashCode()], true
 }
 
-// ForceSet is used to force set the value of a depdency
+// ForceSet is used to force set the value of a dependency
 // for a given hash code
 func (b *Brain) ForceSet(hashCode string, data interface{}) {
 	b.Lock()

--- a/brain_test.go
+++ b/brain_test.go
@@ -38,6 +38,25 @@ func TestRecall(t *testing.T) {
 	}
 }
 
+func TestForceSet(t *testing.T) {
+	b := NewBrain()
+
+	d := &dep.CatalogNodes{}
+	nodes := []*dep.Node{&dep.Node{Node: "node", Address: "address"}}
+
+	b.ForceSet(d.HashCode(), nodes)
+	data, ok := b.Recall(d)
+
+	if !ok {
+		t.Fatal("expected data from brain")
+	}
+
+	result := data.([]*dep.Node)
+	if !reflect.DeepEqual(result, nodes) {
+		t.Errorf("expected %#v to be %#v", result, nodes)
+	}
+}
+
 func TestForget(t *testing.T) {
 	b := NewBrain()
 

--- a/cli.go
+++ b/cli.go
@@ -356,6 +356,9 @@ Options:
   -max-stale=<duration>    Set the maximum staleness and allow stale queries to
                            Consul which will distribute work among all servers
                            instead of just the leader
+  -dedup                   Enable de-duplication mode. Reduces load on Consul when
+                           many instances of Consul Template are rendering a common
+                           template.
   -ssl                     Use SSL when connecting to Consul
   -ssl-verify              Verify certificates when connecting via SSL
   -ssl-cert                SSL client certificate to send to server

--- a/cli.go
+++ b/cli.go
@@ -246,6 +246,12 @@ func (cli *CLI) parseFlags(args []string) (*Config, bool, bool, bool, error) {
 		return nil
 	}), "syslog-facility", "")
 
+	flags.Var((funcBoolVar)(func(b bool) error {
+		config.Deduplicate.Enabled = b
+		config.set("deduplicate.enabled")
+		return nil
+	}), "dedup", "")
+
 	flags.Var((funcVar)(func(s string) error {
 		w, err := watch.ParseWait(s)
 		if err != nil {

--- a/cli.go
+++ b/cli.go
@@ -236,6 +236,7 @@ func (cli *CLI) parseFlags(args []string) (*Config, bool, bool, bool, error) {
 
 	flags.Var((funcBoolVar)(func(b bool) error {
 		config.Syslog.Enabled = b
+		config.set("syslog")
 		config.set("syslog.enabled")
 		return nil
 	}), "syslog", "")
@@ -248,6 +249,7 @@ func (cli *CLI) parseFlags(args []string) (*Config, bool, bool, bool, error) {
 
 	flags.Var((funcBoolVar)(func(b bool) error {
 		config.Deduplicate.Enabled = b
+		config.set("deduplicate")
 		config.set("deduplicate.enabled")
 		return nil
 	}), "dedup", "")

--- a/cli_test.go
+++ b/cli_test.go
@@ -272,6 +272,24 @@ func TestParseFlags_configTemplates(t *testing.T) {
 	}
 }
 
+func TestParseFlags_dedup(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-dedup",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := true
+	if config.Deduplicate.Enabled != expected {
+		t.Errorf("expected %v to be %v", config.Deduplicate.Enabled, expected)
+	}
+	if !config.WasSet("deduplicate.enabled") {
+		t.Errorf("expected deduplicate.enabled to be set")
+	}
+}
+
 func TestParseFlags_syslog(t *testing.T) {
 	cli := NewCLI(ioutil.Discard, ioutil.Discard)
 	config, _, _, _, err := cli.parseFlags([]string{

--- a/cli_test.go
+++ b/cli_test.go
@@ -285,6 +285,9 @@ func TestParseFlags_dedup(t *testing.T) {
 	if config.Deduplicate.Enabled != expected {
 		t.Errorf("expected %v to be %v", config.Deduplicate.Enabled, expected)
 	}
+	if !config.WasSet("deduplicate") {
+		t.Errorf("expected deduplicate to be set")
+	}
 	if !config.WasSet("deduplicate.enabled") {
 		t.Errorf("expected deduplicate.enabled to be set")
 	}
@@ -302,6 +305,9 @@ func TestParseFlags_syslog(t *testing.T) {
 	expected := true
 	if config.Syslog.Enabled != expected {
 		t.Errorf("expected %v to be %v", config.Syslog.Enabled, expected)
+	}
+	if !config.WasSet("syslog") {
+		t.Errorf("expected syslog to be set")
 	}
 	if !config.WasSet("syslog.enabled") {
 		t.Errorf("expected syslog.enabled to be set")

--- a/config.go
+++ b/config.go
@@ -87,14 +87,14 @@ type Config struct {
 // to reduce the cost of many instances of CT running the same template.
 type DeduplicateConfig struct {
 	// Controls if deduplication mode is enabled
-	Enabled bool
+	Enabled bool `json:"enabled" mapstructure:"enabled"`
 
 	// Controls the KV prefix used. Defaults to defaultDedupPrefix
-	Prefix string
+	Prefix string `json:"prefix" mapstructure:"prefix"`
 
 	// TTL is the Session TTL used for lock acquisition, defaults
 	// to 15 seconds.
-	TTL time.Duration
+	TTL time.Duration `json:"ttl" mapstructure:"ttl"`
 }
 
 // Merge merges the values in config into this config object. Values in the

--- a/config_test.go
+++ b/config_test.go
@@ -85,6 +85,7 @@ func TestMerge_deduplicate(t *testing.T) {
 	expected := &DeduplicateConfig{
 		Prefix:  "abc/",
 		Enabled: true,
+		TTL:     15 * time.Second,
 	}
 
 	if !reflect.DeepEqual(config.Deduplicate, expected) {

--- a/config_test.go
+++ b/config_test.go
@@ -68,6 +68,30 @@ func TestMerge_topLevel(t *testing.T) {
 	}
 }
 
+func TestMerge_deduplicate(t *testing.T) {
+	config := testConfig(`
+		deduplicate {
+			prefix = "foobar/"
+			enabled = true
+		}
+	`, t)
+	config.Merge(testConfig(`
+		deduplicate {
+			prefix = "abc/"
+			enabled = true
+		}
+	`, t))
+
+	expected := &DeduplicateConfig{
+		Prefix:  "abc/",
+		Enabled: true,
+	}
+
+	if !reflect.DeepEqual(config.Deduplicate, expected) {
+		t.Errorf("expected \n\n%#v\n\n to be \n\n%#v\n\n", config.Deduplicate, expected)
+	}
+}
+
 func TestMerge_vault(t *testing.T) {
 	config := testConfig(`
 		vault {
@@ -329,6 +353,11 @@ func TestParseConfig_correctValues(t *testing.T) {
 			command = "service redis restart"
 			perms = 0755
 		}
+
+		deduplicate {
+			prefix = "my-prefix/"
+			enabled = true
+		}
   `), t)
 	defer test.DeleteTempfile(configFile, t)
 
@@ -387,6 +416,11 @@ func TestParseConfig_correctValues(t *testing.T) {
 				Command:     "service redis restart",
 				Perms:       0755,
 			},
+		},
+		Deduplicate: &DeduplicateConfig{
+			Prefix:  "my-prefix/",
+			Enabled: true,
+			TTL:     15 * time.Second,
 		},
 		setKeys: config.setKeys,
 	}

--- a/dedup.go
+++ b/dedup.go
@@ -1,0 +1,409 @@
+package main
+
+import (
+	"bytes"
+	"compress/lzw"
+	"encoding/gob"
+	"log"
+	"path"
+	"sync"
+	"time"
+
+	dep "github.com/hashicorp/consul-template/dependency"
+	consulapi "github.com/hashicorp/consul/api"
+)
+
+const (
+	// sessionCreateRetry is the amount of time we wait
+	// to recreate a session when lost.
+	sessionCreateRetry = 15 * time.Second
+
+	// lockRetry is the interval on which we try to re-acquire locks
+	lockRetry = 10 * time.Second
+
+	// listRetry is the interval on which we retry listing a data path
+	listRetry = 10 * time.Second
+
+	// templateDataFlag is added as a flag to the shared data values
+	// so that we can use it as a sanity check
+	templateDataFlag = 0x22b9a127a2c03520
+)
+
+// templateData is GOB encoded share the depdency values
+type templateData struct {
+	Data map[string]interface{}
+}
+
+// DedupManager is used to de-duplicate which instance of Consul-Template
+// is handling each template. For each template, a lock path is determined
+// using the MD5 of the template. This path is used to elect a "leader"
+// instance.
+//
+// The leader instance operations like usual, but any time a template is
+// rendered, any of the data required for rendering is stored in the
+// Consul KV store under the lock path.
+//
+// The follower instances depend on the leader to do the primary watching
+// and rendering, and instead only watch the aggregated data in the KV.
+// Followers wait for updates and re-render the template.
+//
+// If a template depends on 50 views, and is running on 50 machines, that
+// would normally require 2500 blocking queries. Using deduplication, one
+// instance has 50 view queries, plus 50 additional queries on the lock
+// path for a total of 100.
+//
+type DedupManager struct {
+	// config is the consul-template configuration
+	config *Config
+
+	// clients is used to access the underlying clinets
+	clients *dep.ClientSet
+
+	// Brain is where we inject udpates
+	brain *Brain
+
+	// templates is the set of templates we are trying to dedup
+	templates []*Template
+
+	// leader tracks if we are currently the leader
+	leader     map[*Template]<-chan struct{}
+	leaderLock sync.RWMutex
+
+	// leaderCh is used to indicate a change in leadership
+	leaderCh chan struct{}
+
+	// updateCh is used to indicate an update watched data
+	updateCh chan struct{}
+
+	// wg is used to wait for a clean shutdown
+	wg sync.WaitGroup
+
+	stop     bool
+	stopCh   chan struct{}
+	stopLock sync.Mutex
+}
+
+// NewDedupManager creates a new Dedup manager
+func NewDedupManager(config *Config, clients *dep.ClientSet, brain *Brain, templates []*Template) (*DedupManager, error) {
+	d := &DedupManager{
+		config:    config,
+		clients:   clients,
+		brain:     brain,
+		templates: templates,
+		leader:    make(map[*Template]<-chan struct{}),
+		leaderCh:  make(chan struct{}, 1),
+		updateCh:  make(chan struct{}, 1),
+		stopCh:    make(chan struct{}),
+	}
+	return d, nil
+}
+
+// Start is used to start the de-duplication manager
+func (d *DedupManager) Start() error {
+	log.Printf("[INFO] (dedup) starting de-duplication manager")
+
+	client, err := d.clients.Consul()
+	if err != nil {
+		return err
+	}
+	go d.createSession(client)
+
+	// Start to watch each template
+	for _, t := range d.templates {
+		go d.watchTemplate(client, t)
+	}
+	return nil
+}
+
+// Stop is used to stop the de-duplication manager
+func (d *DedupManager) Stop() error {
+	d.stopLock.Lock()
+	defer d.stopLock.Unlock()
+	if d.stop {
+		return nil
+	}
+
+	log.Printf("[INFO] (dedup) stopping de-duplication manager")
+	d.stop = true
+	close(d.stopCh)
+	d.wg.Wait()
+	return nil
+}
+
+// createSession is used to create and maintain a session to Consul
+func (d *DedupManager) createSession(client *consulapi.Client) {
+START:
+	log.Printf("[INFO] (dedup) attempting to create session")
+	session := client.Session()
+	sessionCh := make(chan struct{})
+	se := &consulapi.SessionEntry{
+		Name:     "Consul-Template de-duplication",
+		Behavior: "delete",
+		TTL:      "15s",
+	}
+	id, _, err := session.Create(se, nil)
+	if err != nil {
+		log.Printf("[ERR] (dedup) failed to create session: %v", err)
+		goto WAIT
+	}
+	log.Printf("[INFO] (dedup) created session %s", id)
+
+	// Attempt to lock each template
+	for _, t := range d.templates {
+		d.wg.Add(1)
+		go d.attemptLock(client, id, sessionCh, t)
+	}
+
+	// Renew our session periodically
+	if err := session.RenewPeriodic("15s", id, nil, d.stopCh); err != nil {
+		log.Printf("[ERR] (dedup) failed to renew session: %v", err)
+	}
+	close(sessionCh)
+
+WAIT:
+	select {
+	case <-time.After(sessionCreateRetry):
+		goto START
+	case <-d.stopCh:
+		return
+	}
+}
+
+// IsLeader checks if we are currently the leader instance
+func (d *DedupManager) IsLeader(tmpl *Template) bool {
+	d.leaderLock.RLock()
+	defer d.leaderLock.RUnlock()
+
+	lockCh, ok := d.leader[tmpl]
+	if !ok {
+		return false
+	}
+	select {
+	case <-lockCh:
+		return false
+	default:
+		return true
+	}
+}
+
+// UpdateDeps is used to update the values of the dependencies for a template
+func (d *DedupManager) UpdateDeps(t *Template, deps []dep.Dependency) {
+	// Calculate the path to write updates to
+	dataPath := path.Join(d.config.Deduplicate.Prefix, t.hexMD5, "data")
+
+	// Package up the dependency data
+	td := templateData{
+		Data: make(map[string]interface{}),
+	}
+	for _, dp := range deps {
+		// Do not persist any vault related depdendencies
+		_, isVaultSecret := dp.(*dep.VaultSecret)
+		_, isVaultToken := dp.(*dep.VaultToken)
+		if isVaultSecret || isVaultToken {
+			continue
+		}
+
+		// Pull the current value from the brain
+		val, ok := d.brain.Recall(dp)
+		if ok {
+			td.Data[dp.HashCode()] = val
+		}
+	}
+
+	// Encode via GOB and LZW compress
+	var buf bytes.Buffer
+	compress := lzw.NewWriter(&buf, lzw.LSB, 8)
+	enc := gob.NewEncoder(compress)
+	if err := enc.Encode(&td); err != nil {
+		log.Printf("[ERR] (dedup) failed to encode data for '%s': %v",
+			dataPath, err)
+		return
+	}
+	compress.Close()
+
+	// Write the KV update
+	kvPair := consulapi.KVPair{
+		Key:   dataPath,
+		Value: buf.Bytes(),
+		Flags: templateDataFlag,
+	}
+	client, err := d.clients.Consul()
+	if err != nil {
+		log.Printf("[ERR] (dedup) failed to get consul client: %v", err)
+		return
+	}
+	if _, err := client.KV().Put(&kvPair, nil); err != nil {
+		log.Printf("[ERR] (dedup) failed to write '%s': %v",
+			dataPath, err)
+	}
+	log.Printf("[INFO] (dedup) updated de-duplicate data '%s'", dataPath)
+}
+
+// LeaderCh returns a channel to watch for leadership changes
+func (d *DedupManager) LeaderCh() <-chan struct{} {
+	return d.leaderCh
+}
+
+// UpdateCh returns a channel to watch for depedency updates
+func (d *DedupManager) UpdateCh() <-chan struct{} {
+	return d.updateCh
+}
+
+// setLeader sets if we are currently the leader instance
+func (d *DedupManager) setLeader(tmpl *Template, lockCh <-chan struct{}) {
+	// Update the lock state
+	d.leaderLock.Lock()
+	if lockCh != nil {
+		d.leader[tmpl] = lockCh
+	} else {
+		delete(d.leader, tmpl)
+	}
+	d.leaderLock.Unlock()
+
+	// Do an async push on the leaderCh
+	select {
+	case d.leaderCh <- struct{}{}:
+	default:
+	}
+}
+
+func (d *DedupManager) watchTemplate(client *consulapi.Client, t *Template) {
+	log.Printf("[INFO] (dedup) starting watch for template hash %s", t.hexMD5)
+	path := path.Join(d.config.Deduplicate.Prefix, t.hexMD5, "data")
+	opts := &consulapi.QueryOptions{WaitTime: 60 * time.Second}
+START:
+	// Stop listening if we're stopped
+	select {
+	case <-d.stopCh:
+		return
+	default:
+	}
+
+	// If we are current the leader, wait for leadership lost
+	d.leaderLock.RLock()
+	lockCh, ok := d.leader[t]
+	d.leaderLock.RUnlock()
+	if ok {
+		select {
+		case <-lockCh:
+			goto START
+		case <-d.stopCh:
+			return
+		}
+	}
+
+	// Block for updates on the data key
+	log.Printf("[INFO] (dedup) listing data for template hash %s", t.hexMD5)
+	pair, meta, err := client.KV().Get(path, opts)
+	if err != nil {
+		log.Printf("[ERR] (dedup) failed to get '%s': %v", path, err)
+		select {
+		case <-time.After(listRetry):
+			goto START
+		case <-d.stopCh:
+			return
+		}
+	}
+	opts.WaitIndex = meta.LastIndex
+
+	// Stop listening if we're stopped
+	select {
+	case <-d.stopCh:
+		return
+	default:
+	}
+
+	// If we are current the leader, wait for leadership lost
+	d.leaderLock.RLock()
+	lockCh, ok = d.leader[t]
+	d.leaderLock.RUnlock()
+	if ok {
+		select {
+		case <-lockCh:
+			goto START
+		case <-d.stopCh:
+			return
+		}
+	}
+
+	// Parse the data file
+	if pair != nil && pair.Flags == templateDataFlag {
+		d.parseData(pair.Key, pair.Value)
+	}
+	goto START
+}
+
+// parseData is used to update brain from a KV data pair
+func (d *DedupManager) parseData(path string, raw []byte) {
+	// Setup the decompression and decoders
+	r := bytes.NewReader(raw)
+	decompress := lzw.NewReader(r, lzw.LSB, 8)
+	defer decompress.Close()
+	dec := gob.NewDecoder(decompress)
+
+	// Decode the data
+	var td templateData
+	if err := dec.Decode(&td); err != nil {
+		log.Printf("[ERR] (dedup) failed to decode '%s': %v",
+			path, err)
+		return
+	}
+	log.Printf("[INFO] (dedup) loading %d dependencies from '%s'",
+		len(td.Data), path)
+
+	// Update the data in the brain
+	for hashCode, value := range td.Data {
+		d.brain.ForceSet(hashCode, value)
+	}
+
+	// Trigger the updateCh
+	select {
+	case d.updateCh <- struct{}{}:
+	default:
+	}
+}
+
+func (d *DedupManager) attemptLock(client *consulapi.Client, session string, sessionCh chan struct{}, t *Template) {
+	defer d.wg.Done()
+START:
+	log.Printf("[INFO] (dedup) attempting lock for template hash %s", t.hexMD5)
+	basePath := path.Join(d.config.Deduplicate.Prefix, t.hexMD5)
+	lopts := &consulapi.LockOptions{
+		Key:     path.Join(basePath, "lock"),
+		Session: session,
+	}
+	lock, err := client.LockOpts(lopts)
+	if err != nil {
+		log.Printf("[ERR] (dedup) failed to create lock '%s': %v",
+			lopts.Key, err)
+		return
+	}
+
+	var retryCh <-chan time.Time
+	leaderCh, err := lock.Lock(sessionCh)
+	if err != nil {
+		log.Printf("[ERR] (dedup) failed to acquire lock '%s': %v",
+			lopts.Key, err)
+		retryCh = time.After(lockRetry)
+	} else {
+		log.Printf("[INFO] (dedup) acquired lock '%s'", lopts.Key)
+		d.setLeader(t, leaderCh)
+	}
+
+	select {
+	case <-retryCh:
+		retryCh = nil
+		goto START
+	case <-leaderCh:
+		log.Printf("[WARN] (dedup) lost lock ownership '%s'", lopts.Key)
+		d.setLeader(t, nil)
+		goto START
+	case <-sessionCh:
+		log.Printf("[INFO] (dedup) releasing lock '%s'", lopts.Key)
+		d.setLeader(t, nil)
+		lock.Unlock()
+	case <-d.stopCh:
+		log.Printf("[INFO] (dedup) releasing lock '%s'", lopts.Key)
+		lock.Unlock()
+	}
+}

--- a/dedup.go
+++ b/dedup.go
@@ -139,10 +139,11 @@ START:
 	log.Printf("[INFO] (dedup) attempting to create session")
 	session := client.Session()
 	sessionCh := make(chan struct{})
+	ttl := fmt.Sprintf("%ds", d.config.Deduplicate.TTL/time.Second)
 	se := &consulapi.SessionEntry{
 		Name:     "Consul-Template de-duplication",
 		Behavior: "delete",
-		TTL:      "15s",
+		TTL:      ttl,
 	}
 	id, _, err := session.Create(se, nil)
 	if err != nil {

--- a/dedup.go
+++ b/dedup.go
@@ -408,8 +408,10 @@ START:
 	log.Printf("[INFO] (dedup) attempting lock for template hash %s", t.hexMD5)
 	basePath := path.Join(d.config.Deduplicate.Prefix, t.hexMD5)
 	lopts := &consulapi.LockOptions{
-		Key:     path.Join(basePath, "lock"),
-		Session: session,
+		Key:              path.Join(basePath, "lock"),
+		Session:          session,
+		MonitorRetries:   3,
+		MonitorRetryTime: 3 * time.Second,
 	}
 	lock, err := client.LockOpts(lopts)
 	if err != nil {

--- a/dedup.go
+++ b/dedup.go
@@ -200,10 +200,8 @@ func (d *DedupManager) UpdateDeps(t *Template, deps []dep.Dependency) error {
 		Data: make(map[string]interface{}),
 	}
 	for _, dp := range deps {
-		// Do not persist any vault related depdendencies
-		_, isVaultSecret := dp.(*dep.VaultSecret)
-		_, isVaultToken := dp.(*dep.VaultToken)
-		if isVaultSecret || isVaultToken {
+		// Skip any dependencies that can't be shared
+		if !dep.CanShare(dp) {
 			continue
 		}
 

--- a/dedup_test.go
+++ b/dedup_test.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul-template/dependency"
+	"github.com/hashicorp/consul-template/test"
+	"github.com/hashicorp/consul/testutil"
+)
+
+func testDedupManager(t *testing.T, templ []*Template) (*testutil.TestServer, *DedupManager) {
+	consul := testutil.NewTestServerConfig(t, func(c *testutil.TestServerConfig) {
+		c.Stdout = ioutil.Discard
+		c.Stderr = ioutil.Discard
+	})
+
+	// Setup the configuration
+	config := DefaultConfig()
+	config.Consul = consul.HTTPAddr
+
+	// Create the clientset
+	clients, err := newClientSet(config)
+	if err != nil {
+		t.Fatalf("runner: %s", err)
+	}
+
+	// Setup a brain
+	brain := NewBrain()
+
+	// Create the dedup manager
+	dedup, err := NewDedupManager(config, clients, brain, templ)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	return consul, dedup
+}
+
+func testDedupFollower(t *testing.T, leader *DedupManager) *DedupManager {
+	// Setup the configuration
+	config := DefaultConfig()
+	config.Consul = leader.config.Consul
+
+	// Create the clientset
+	clients, err := newClientSet(config)
+	if err != nil {
+		t.Fatalf("runner: %s", err)
+	}
+
+	// Setup a brain
+	brain := NewBrain()
+
+	// Create the dedup manager
+	dedup, err := NewDedupManager(config, clients, brain, leader.templates)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	return dedup
+}
+
+func TestDedup_StartStop(t *testing.T) {
+	consul, dedup := testDedupManager(t, nil)
+	defer consul.Stop()
+
+	// Start and stop
+	if err := dedup.Start(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if err := dedup.Stop(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestDedup_IsLeader(t *testing.T) {
+	// Create a template
+	in := test.CreateTempfile([]byte(`
+    {{ range service "consul" }}{{.Node}}{{ end }}
+  `), t)
+	defer test.DeleteTempfile(in, t)
+	tmpl, err := NewTemplate(in.Name())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	consul, dedup := testDedupManager(t, []*Template{tmpl})
+	defer consul.Stop()
+
+	// Start dedup
+	if err := dedup.Start(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer dedup.Stop()
+
+	// Wait until we are leader
+	select {
+	case <-dedup.UpdateCh():
+	case <-time.After(time.Second):
+		t.Fatalf("timeout")
+	}
+
+	// Check that we are the leader
+	if !dedup.IsLeader(tmpl) {
+		t.Fatalf("should be leader")
+	}
+}
+
+func TestDedup_UpdateDeps(t *testing.T) {
+	// Create a template
+	in := test.CreateTempfile([]byte(`
+    {{ range service "consul" }}{{.Node}}{{ end }}
+  `), t)
+	defer test.DeleteTempfile(in, t)
+	tmpl, err := NewTemplate(in.Name())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	consul, dedup := testDedupManager(t, []*Template{tmpl})
+	defer consul.Stop()
+
+	// Start dedup
+	if err := dedup.Start(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer dedup.Stop()
+
+	// Wait until we are leader
+	select {
+	case <-dedup.UpdateCh():
+	case <-time.After(time.Second):
+		t.Fatalf("timeout")
+	}
+
+	// Create the dependency
+	dep, err := dependency.ParseHealthServices("consul")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Inject data into the brain
+	dedup.brain.Remember(dep, 123)
+
+	// Update the dependencies
+	err = dedup.UpdateDeps(tmpl, []dependency.Dependency{dep})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestDedup_FollowerUpdate(t *testing.T) {
+	// Create a template
+	in := test.CreateTempfile([]byte(`
+    {{ range service "consul" }}{{.Node}}{{ end }}
+  `), t)
+	defer test.DeleteTempfile(in, t)
+	tmpl, err := NewTemplate(in.Name())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	consul, dedup1 := testDedupManager(t, []*Template{tmpl})
+	defer consul.Stop()
+
+	dedup2 := testDedupFollower(t, dedup1)
+
+	// Start dedups
+	if err := dedup1.Start(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer dedup1.Stop()
+	if err := dedup2.Start(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer dedup2.Stop()
+
+	// Wait until we have a leader
+	var leader, follow *DedupManager
+	select {
+	case <-dedup1.UpdateCh():
+		if dedup1.IsLeader(tmpl) {
+			leader = dedup1
+			follow = dedup2
+		}
+	case <-dedup2.UpdateCh():
+		if dedup2.IsLeader(tmpl) {
+			leader = dedup2
+			follow = dedup1
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timeout")
+	}
+
+	// Create the dependency
+	dep, err := dependency.ParseHealthServices("consul")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Inject data into the brain
+	leader.brain.Remember(dep, 123)
+
+	// Update the dependencies
+	err = leader.UpdateDeps(tmpl, []dependency.Dependency{dep})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Follower should get an update
+	select {
+	case <-follow.UpdateCh():
+	case <-time.After(time.Second):
+		t.Fatalf("timeout")
+	}
+
+	// Recall from the brain
+	data, ok := follow.brain.Recall(dep)
+	if !ok {
+		t.Fatalf("missing data")
+	}
+	if data != 123 {
+		t.Fatalf("bad: %v", data)
+	}
+}

--- a/dependency/catalog_node.go
+++ b/dependency/catalog_node.go
@@ -1,12 +1,18 @@
 package dependency
 
 import (
+	"encoding/gob"
 	"errors"
 	"fmt"
 	"log"
 	"regexp"
 	"sort"
 )
+
+func init() {
+	gob.Register([]*NodeDetail{})
+	gob.Register([]*NodeService{})
+}
 
 type NodeDetail struct {
 	Node     *Node

--- a/dependency/catalog_nodes.go
+++ b/dependency/catalog_nodes.go
@@ -1,12 +1,17 @@
 package dependency
 
 import (
+	"encoding/gob"
 	"errors"
 	"fmt"
 	"log"
 	"regexp"
 	"sort"
 )
+
+func init() {
+	gob.Register([]*Node{})
+}
 
 // Node is a node entry in Consul
 type Node struct {

--- a/dependency/catalog_services.go
+++ b/dependency/catalog_services.go
@@ -1,12 +1,17 @@
 package dependency
 
 import (
+	"encoding/gob"
 	"errors"
 	"fmt"
 	"log"
 	"regexp"
 	"sort"
 )
+
+func init() {
+	gob.Register([]*CatalogService{})
+}
 
 // CatalogService is a catalog entry in Consul.
 type CatalogService struct {

--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -15,6 +15,21 @@ type Dependency interface {
 	Display() string
 }
 
+// CanShare is used to check if the dependency can be shared for deduplication.
+// This is used to avoid sharing Vault or local file values between instances.
+func CanShare(dep Dependency) bool {
+	switch dep.(type) {
+	case *File:
+		return false
+	case *VaultSecret:
+		return false
+	case *VaultToken:
+		return false
+	default:
+		return true
+	}
+}
+
 // ServiceTags is a slice of tags assigned to a Service
 type ServiceTags []string
 

--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -15,6 +15,26 @@ import (
 	"github.com/hashicorp/vault/vault"
 )
 
+func TestCanShare(t *testing.T) {
+	vs := &VaultSecret{}
+	vt := &VaultToken{}
+	file := &File{}
+	service := &HealthServices{}
+
+	if CanShare(vs) {
+		t.Fatalf("should not share vault")
+	}
+	if CanShare(vt) {
+		t.Fatalf("should not share vault")
+	}
+	if CanShare(file) {
+		t.Fatalf("should not share file")
+	}
+	if !CanShare(service) {
+		t.Fatalf("should share service")
+	}
+}
+
 func TestDeepCopyAndSortTags(t *testing.T) {
 	tags := []string{"hello", "world", "these", "are", "tags"}
 	expected := []string{"are", "hello", "tags", "these", "world"}

--- a/dependency/health_service.go
+++ b/dependency/health_service.go
@@ -1,6 +1,7 @@
 package dependency
 
 import (
+	"encoding/gob"
 	"errors"
 	"fmt"
 	"log"
@@ -11,6 +12,10 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-multierror"
 )
+
+func init() {
+	gob.Register([]*HealthService{})
+}
 
 // Ripped from https://github.com/hashicorp/consul/blob/master/consul/structs/structs.go#L31
 const (

--- a/dependency/store_key_prefix.go
+++ b/dependency/store_key_prefix.go
@@ -1,12 +1,17 @@
 package dependency
 
 import (
+	"encoding/gob"
 	"errors"
 	"fmt"
 	"log"
 	"regexp"
 	"strings"
 )
+
+func init() {
+	gob.Register([]*KeyPair{})
+}
 
 // KeyPair is a simple Key-Value pair
 type KeyPair struct {

--- a/runner.go
+++ b/runner.go
@@ -355,7 +355,9 @@ func (r *Runner) Run() error {
 
 		// Trigger an update of the de-duplicaiton manager
 		if r.dedup != nil && isLeader {
-			r.dedup.UpdateDeps(tmpl, used)
+			if err := r.dedup.UpdateDeps(tmpl, used); err != nil {
+				log.Printf("[ERR] (runner) failed to update dependency data for de-duplication: %v", err)
+			}
 		}
 
 		// If quiescence is activated, start/update the timers and loop back around.

--- a/runner.go
+++ b/runner.go
@@ -334,12 +334,9 @@ func (r *Runner) Run() error {
 		if len(unwatched) > 0 {
 			log.Printf("[INFO] (runner) was not watching %d dependencies", len(unwatched))
 			for _, d := range unwatched {
-				_, isVaultSecret := d.(*dep.VaultSecret)
-				_, isVaultToken := d.(*dep.VaultToken)
-
-				// If we are deduplicating, we must still handle Vault dependencies,
-				// since those will be ignored to avoid leaking secrets.
-				if isLeader || isVaultSecret || isVaultToken {
+				// If we are deduplicating, we must still handle non-sharable
+				// dependencies, since those will be ignored.
+				if isLeader || !dep.CanShare(d) {
 					r.watcher.Add(d)
 				}
 			}

--- a/runner.go
+++ b/runner.go
@@ -81,6 +81,9 @@ type Runner struct {
 	// fires.
 	quiescenceMap map[string]*quiescence
 	quiescenceCh  chan *Template
+
+	// dedup is the deduplication manager if enabled
+	dedup *DedupManager
 }
 
 // NewRunner accepts a slice of ConfigTemplates and returns a pointer to the new
@@ -111,6 +114,17 @@ func (r *Runner) Start() {
 	if err := r.storePid(); err != nil {
 		r.ErrCh <- err
 		return
+	}
+
+	// Attempt to acquire the locks for the de-duplication manager
+	var updateCh, leaderCh <-chan struct{}
+	if r.dedup != nil {
+		if err := r.dedup.Start(); err != nil {
+			r.ErrCh <- err
+			return
+		}
+		leaderCh = r.dedup.LeaderCh()
+		updateCh = r.dedup.UpdateCh()
 	}
 
 	// Fire an initial run to parse all the templates and setup the first-pass
@@ -173,6 +187,18 @@ func (r *Runner) Start() {
 					break OUTER
 				}
 			}
+
+		case <-leaderCh:
+			// On change of leadership we may need need to either stop updating
+			// a particular template or start updating the template
+			log.Printf("[INFO] (runner) watcher triggered by leadership change")
+			break OUTER
+
+		case <-updateCh:
+			// On update of a template data we may need to render a template
+			log.Printf("[INFO] (runner) watcher triggered by de-duplication data update")
+			break OUTER
+
 		case err := <-r.watcher.ErrCh:
 			// Intentionally do not send the error back up to the runner. Eventually,
 			// once Consul API implements errwrap and multierror, we can check the
@@ -211,6 +237,9 @@ func (r *Runner) Start() {
 // Stop halts the execution of this runner and its subprocesses.
 func (r *Runner) Stop() {
 	log.Printf("[INFO] (runner) stopping")
+	if r.dedup != nil {
+		r.dedup.Stop()
+	}
 	r.watcher.Stop()
 	if err := r.deletePid(); err != nil {
 		log.Printf("[WARN] (runner) could not remove pid at %q: %s",
@@ -259,6 +288,12 @@ func (r *Runner) Run() error {
 	for _, tmpl := range r.templates {
 		log.Printf("[DEBUG] (runner) checking template %s", tmpl.Path)
 
+		// Check if we are currently the leader instance
+		isLeader := true
+		if r.dedup != nil {
+			isLeader = r.dedup.IsLeader(tmpl)
+		}
+
 		// If we are in once mode and this template was already rendered, move
 		// onto the next one. We do not want to re-render the template if we are
 		// in once mode, and we certainly do not want to re-run any commands.
@@ -279,6 +314,12 @@ func (r *Runner) Run() error {
 
 		// Add the dependency to the list of dependencies for this runner.
 		for _, d := range used {
+			// If we've taken over leadership for a template, we may have data
+			// that is cached, but not have the watcher. We must treat this as
+			// missing so that we create the watcher and re-run the template.
+			if isLeader && !r.watcher.Watching(d) {
+				missing = append(missing, d)
+			}
 			if _, ok := depsMap[d.HashCode()]; !ok {
 				depsMap[d.HashCode()] = d
 			}
@@ -297,8 +338,15 @@ func (r *Runner) Run() error {
 		// next one.
 		if len(unwatched) > 0 {
 			log.Printf("[INFO] (runner) was not watching %d dependencies", len(unwatched))
-			for _, dep := range unwatched {
-				r.watcher.Add(dep)
+			for _, d := range unwatched {
+				_, isVaultSecret := d.(*dep.VaultSecret)
+				_, isVaultToken := d.(*dep.VaultToken)
+
+				// If we are deduplicating, we must still handle Vault dependencies,
+				// since those will be ignored to avoid leaking secrets.
+				if isLeader || isVaultSecret || isVaultToken {
+					r.watcher.Add(d)
+				}
 			}
 			continue
 		}
@@ -308,6 +356,11 @@ func (r *Runner) Run() error {
 		if len(missing) > 0 {
 			log.Printf("[INFO] (runner) missing data for %d dependencies", len(missing))
 			continue
+		}
+
+		// Trigger an update of the de-duplicaiton manager
+		if r.dedup != nil && isLeader {
+			r.dedup.UpdateDeps(tmpl, used)
 		}
 
 		// If quiescence is activated, start/update the timers and loop back around.
@@ -464,6 +517,18 @@ func (r *Runner) init() error {
 
 	r.quiescenceMap = make(map[string]*quiescence)
 	r.quiescenceCh = make(chan *Template)
+
+	// Setup the dedup manager if needed. This is
+	if r.config.Deduplicate.Enabled {
+		if r.once {
+			log.Printf("[INFO] (runner) disabling de-duplication in once mode")
+		} else {
+			r.dedup, err = NewDedupManager(r.config, clients, r.brain, r.templates)
+			if err != nil {
+				return err
+			}
+		}
+	}
 
 	return nil
 }

--- a/runner_test.go
+++ b/runner_test.go
@@ -219,6 +219,7 @@ func TestRun_dry(t *testing.T) {
 		&dep.HealthService{Node: "consul2"},
 	}
 	runner.dependencies[d.HashCode()] = d
+	runner.watcher.ForceWatching(d, true)
 	runner.Receive(d, data)
 
 	buff := gatedio.NewByteBuffer()
@@ -464,6 +465,7 @@ func TestRun_multipleTemplatesRunsCommands(t *testing.T) {
 		&dep.HealthService{Node: "consul2"},
 	}
 	runner.dependencies[d.HashCode()] = d
+	runner.watcher.ForceWatching(d, true)
 	runner.Receive(d, data)
 
 	if err := runner.Run(); err != nil {
@@ -803,6 +805,7 @@ func TestRun_executesCommand(t *testing.T) {
 		},
 	}
 	runner.dependencies[d.HashCode()] = d
+	runner.watcher.ForceWatching(d, true)
 	runner.Receive(d, data)
 
 	if err := runner.Run(); err != nil {
@@ -865,6 +868,7 @@ func TestRun_doesNotExecuteCommandMoreThanOnce(t *testing.T) {
 		},
 	}
 	runner.dependencies[d.HashCode()] = d
+	runner.watcher.ForceWatching(d, true)
 	runner.Receive(d, data)
 
 	if err := runner.Run(); err != nil {
@@ -994,6 +998,7 @@ func TestRunner_onceAlreadyRenderedDoesNotHangOrRunCommands(t *testing.T) {
 	}
 	data := "redis"
 	runner.dependencies[d.HashCode()] = d
+	runner.watcher.ForceWatching(d, true)
 	runner.Receive(d, data)
 
 	go runner.Start()

--- a/runner_test.go
+++ b/runner_test.go
@@ -1121,3 +1121,92 @@ func TestExecute_timeout(t *testing.T) {
 		t.Errorf("expected %q to include %q", err.Error(), expected)
 	}
 }
+
+func TestRunner_dedup(t *testing.T) {
+	// Create a template
+	in := test.CreateTempfile([]byte(`
+    {{ range service "consul" }}{{.Node}}{{ end }}
+  `), t)
+	defer test.DeleteTempfile(in, t)
+
+	out1 := test.CreateTempfile(nil, t)
+	defer test.DeleteTempfile(out1, t)
+
+	out2 := test.CreateTempfile(nil, t)
+	defer test.DeleteTempfile(out2, t)
+
+	// Start consul
+	consul := testutil.NewTestServerConfig(t, func(c *testutil.TestServerConfig) {
+		c.Stdout = ioutil.Discard
+		c.Stderr = ioutil.Discard
+	})
+	defer consul.Stop()
+
+	// Setup the runner config
+	config := DefaultConfig()
+	config.Merge(&Config{
+		ConfigTemplates: []*ConfigTemplate{
+			&ConfigTemplate{Source: in.Name(), Destination: out1.Name()},
+		},
+	})
+	config.Deduplicate.Enabled = true
+	config.Consul = consul.HTTPAddr
+	config.set("consul")
+	config.set("deduplicate")
+	config.set("deduplicate.enabled")
+
+	config2 := DefaultConfig()
+	config2.Merge(&Config{
+		ConfigTemplates: []*ConfigTemplate{
+			&ConfigTemplate{Source: in.Name(), Destination: out2.Name()},
+		},
+	})
+	config2.Deduplicate.Enabled = true
+	config2.Consul = consul.HTTPAddr
+	config2.set("consul")
+	config2.set("deduplicate")
+	config2.set("deduplicate.enabled")
+
+	// Create the runners
+	r1, err := NewRunner(config, false, false)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	go r1.Start()
+	defer r1.Stop()
+
+	r2, err := NewRunner(config2, false, false)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	go r2.Start()
+	defer r2.Stop()
+
+	// Wait until the output file exists
+	testutil.WaitForResult(func() (bool, error) {
+		_, err := os.Stat(out1.Name())
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+
+	// Wait until the output file exists
+	testutil.WaitForResult(func() (bool, error) {
+		_, err := os.Stat(out2.Name())
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+
+	// Should only be a single total watcher
+	total := r1.watcher.Size() + r2.watcher.Size()
+	if total != 1 {
+		t.Fatalf("too many watchers: %d", total)
+	}
+}

--- a/template.go
+++ b/template.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"crypto/md5"
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -16,6 +18,9 @@ type Template struct {
 
 	// contents is string contents for this file when read from disk.
 	contents string
+
+	// hexMD5 stores the hex version of the MD5
+	hexMD5 string
 }
 
 // NewTemplate creates and parses a new Consul Template template at the given
@@ -77,6 +82,10 @@ func (t *Template) init() error {
 		return err
 	}
 	t.contents = string(contents)
+
+	// Compute the MD5, encode as hex
+	hash := md5.Sum(contents)
+	t.hexMD5 = hex.EncodeToString(hash[:])
 
 	return nil
 }

--- a/template_test.go
+++ b/template_test.go
@@ -44,6 +44,27 @@ func TestNewTemplate_setsPathAndContents(t *testing.T) {
 	}
 }
 
+func TestNewTemplate_setsPathAndMD5(t *testing.T) {
+	contents := []byte("some content")
+
+	in := test.CreateTempfile(contents, t)
+	defer test.DeleteTempfile(in, t)
+
+	tmpl, err := NewTemplate(in.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if tmpl.Path != in.Name() {
+		t.Errorf("expected %q to be %q", tmpl.Path, in.Name())
+	}
+
+	expect := "9893532233caff98cd083a116b013c0b"
+	if tmpl.hexMD5 != expect {
+		t.Errorf("expected %q to be %q", tmpl.hexMD5, expect)
+	}
+}
+
 func TestExecute_noDependencies(t *testing.T) {
 	contents := []byte("This is a template with just text")
 

--- a/watch/watcher.go
+++ b/watch/watcher.go
@@ -118,6 +118,19 @@ func (w *Watcher) Watching(d dep.Dependency) bool {
 	return ok
 }
 
+// ForceWatching is used to force setting the internal state of watching
+// a depedency. This is only used for unit testing purposes.
+func (w *Watcher) ForceWatching(d dep.Dependency, enabled bool) {
+	w.Lock()
+	defer w.Unlock()
+
+	if enabled {
+		w.depViewMap[d.HashCode()] = nil
+	} else {
+		delete(w.depViewMap, d.HashCode())
+	}
+}
+
 // Remove removes the given dependency from the list and stops the
 // associated View. If a View for the given dependency does not exist, this
 // function will return false. If the View does exist, this function will return

--- a/watch/watcher.go
+++ b/watch/watcher.go
@@ -168,6 +168,9 @@ func (w *Watcher) Stop() {
 	log.Printf("[INFO] (watcher) stopping all views")
 
 	for _, view := range w.depViewMap {
+		if view == nil {
+			continue
+		}
 		log.Printf("[DEBUG] (watcher) stopping %s", view.Dependency.Display())
 		view.stop()
 	}


### PR DESCRIPTION
This adds a new de-duplication mode which is used to have a single instance of consul-template run the watchers, and the other instances receive the data in a single KV key. This works by:

* Generating a KV prefix based on the hash of the template `prefix = consul-template/dedup/MD5/`
* Locking a key for the template (`prefix/lock`)
* If leader, run views normally, and on render write the dependencies as (`prefix/data`)
* If follower, watch template data (`prefix/data`), re-render on data updates
* Vault data is excluded from this, as it should not be shared

In this system, instead of running 50 queries per template on 50 nodes (2500 queries), we instead run 50 queries on one node, and 100 KV watches on the others, for a total of 150. This results in a dramatic reduction of read pressure on Consul.

TODO:
- [x] Unit tests for DeduplicationManager
- [x] Unit tests for Runner changes

