### PR TITLE
Add configuration option to set custom delimiter

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -281,6 +281,12 @@ func (cli *CLI) parseFlags(args []string) (*Config, bool, bool, bool, error) {
 		return nil
 	}), "log-level", "")
 
+	flags.Var((funcVar)(func(s string) error {
+		config.Delimiter = strings.SplitN(s, " ", 2)
+		config.set("delimiter")
+		return nil
+        }), "delimiter", "")
+
 	flags.BoolVar(&once, "once", false, "")
 	flags.BoolVar(&dry, "dry", false, "")
 	flags.BoolVar(&version, "v", false, "")
@@ -375,6 +381,9 @@ Options:
   -pid-file=<path>         Path on disk to write the PID of the process
   -log-level=<level>       Set the logging level - valid values are "debug",
                            "info", "warn" (default), and "err"
+
+  -delimiter=<delimiter>   Change the delimiter utilised by the template
+                           where the format of <delimiter> is <left> <right>
 
   -dry                     Dump generated templates to stdout
   -once                    Do not run the process as a daemon

--- a/config.go
+++ b/config.go
@@ -72,6 +72,9 @@ type Config struct {
 	// LogLevel is the level with which to log for this config.
 	LogLevel string `json:"log_level" mapstructure:"log_level"`
 
+	// Delimiter is the template action delimiter.
+	Delimiter []string `json:"delimiter" mapstructure:"delimiter"`
+
 	// setKeys is the list of config keys that were set by the user.
 	setKeys map[string]struct{}
 }
@@ -213,6 +216,10 @@ func (c *Config) Merge(config *Config) {
 
 	if config.WasSet("log_level") {
 		c.LogLevel = config.LogLevel
+	}
+
+	if config.WasSet("delimiter") {
+		c.Delimiter = config.Delimiter
 	}
 
 	if c.setKeys == nil {
@@ -409,6 +416,7 @@ func DefaultConfig() *Config {
 		MaxStale:        1 * time.Second,
 		Wait:            &watch.Wait{},
 		LogLevel:        logLevel,
+		Delimiter:       []string{"{{", "}}"},
 		setKeys:         make(map[string]struct{}),
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -375,6 +375,7 @@ func TestParseConfig_correctValues(t *testing.T) {
 		},
 		Retry:    10 * time.Second,
 		LogLevel: "warn",
+		Delimiter: []string{"{{", "}}"},
 		ConfigTemplates: []*ConfigTemplate{
 			&ConfigTemplate{
 				Source:      "nginx.conf.ctmpl",

--- a/runner.go
+++ b/runner.go
@@ -428,7 +428,7 @@ func (r *Runner) init() error {
 	// config templates is kept so templates can lookup their commands and output
 	// destinations.
 	for _, ctmpl := range r.config.ConfigTemplates {
-		tmpl, err := NewTemplate(ctmpl.Source)
+		tmpl, err := NewTemplate(ctmpl.Source, r.config)
 		if err != nil {
 			return err
 		}

--- a/template.go
+++ b/template.go
@@ -16,14 +16,17 @@ type Template struct {
 
 	// contents is string contents for this file when read from disk.
 	contents string
+
+	// config is the Config created by the Runner.
+	config *Config
 }
 
 // NewTemplate creates and parses a new Consul Template template at the given
 // path. If the template does not exist, an error is returned. During
 // initialization, the template is read and is parsed for dependencies. Any
 // errors that occur are returned.
-func NewTemplate(path string) (*Template, error) {
-	template := &Template{Path: path}
+func NewTemplate(path string, config *Config) (*Template, error) {
+	template := &Template{Path: path, config: config}
 	if err := template.init(); err != nil {
 		return nil, err
 	}
@@ -43,7 +46,7 @@ func (t *Template) Execute(brain *Brain) ([]dep.Dependency, []dep.Dependency, []
 	name := filepath.Base(t.Path)
 	funcs := funcMap(brain, usedMap, missingMap)
 
-	tmpl, err := template.New(name).Funcs(funcs).Parse(t.contents)
+	tmpl, err := template.New(name).Delims(t.config.Delimiter[0], t.config.Delimiter[1]).Funcs(funcs).Parse(t.contents)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("template: %s", err)
 	}

--- a/template_test.go
+++ b/template_test.go
@@ -13,7 +13,8 @@ import (
 )
 
 func TestNewTemplate_missingPath(t *testing.T) {
-	_, err := NewTemplate("/path/to/non-existent/file")
+	config := DefaultConfig()
+	_, err := NewTemplate("/path/to/non-existent/file", config)
 	if err == nil {
 		t.Fatal("expected error, but nothing was returned")
 	}
@@ -30,7 +31,8 @@ func TestNewTemplate_setsPathAndContents(t *testing.T) {
 	in := test.CreateTempfile(contents, t)
 	defer test.DeleteTempfile(in, t)
 
-	tmpl, err := NewTemplate(in.Name())
+	config := DefaultConfig()
+	tmpl, err := NewTemplate(in.Name(), config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +52,8 @@ func TestExecute_noDependencies(t *testing.T) {
 	in := test.CreateTempfile(contents, t)
 	defer test.DeleteTempfile(in, t)
 
-	tmpl, err := NewTemplate(in.Name())
+	config := DefaultConfig()
+	tmpl, err := NewTemplate(in.Name(), config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +83,8 @@ func TestExecute_missingDependencies(t *testing.T) {
 	in := test.CreateTempfile(contents, t)
 	defer test.DeleteTempfile(in, t)
 
-	tmpl, err := NewTemplate(in.Name())
+	config := DefaultConfig()
+	tmpl, err := NewTemplate(in.Name(), config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +129,8 @@ func TestExecte_badFuncs(t *testing.T) {
 	in := test.CreateTempfile([]byte(`{{ tickle_me_pink }}`), t)
 	defer test.DeleteTempfile(in, t)
 
-	tmpl, err := NewTemplate(in.Name())
+	config := DefaultConfig()
+	tmpl, err := NewTemplate(in.Name(), config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -162,7 +167,8 @@ func TestExecute_funcs(t *testing.T) {
   `), t)
 	defer test.DeleteTempfile(in, t)
 
-	tmpl, err := NewTemplate(in.Name())
+	config := DefaultConfig()
+	tmpl, err := NewTemplate(in.Name(), config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -190,7 +196,8 @@ func TestExecute_duplicateFuncs(t *testing.T) {
   `), t)
 	defer test.DeleteTempfile(in, t)
 
-	tmpl, err := NewTemplate(in.Name())
+	config := DefaultConfig()
+	tmpl, err := NewTemplate(in.Name(), config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -302,7 +309,8 @@ func TestExecute_renders(t *testing.T) {
 `), t)
 	defer test.DeleteTempfile(in, t)
 
-	tmpl, err := NewTemplate(in.Name())
+	config := DefaultConfig()
+	tmpl, err := NewTemplate(in.Name(), config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -587,7 +595,8 @@ func TestExecute_multipass(t *testing.T) {
 	`), t)
 	defer test.DeleteTempfile(in, t)
 
-	tmpl, err := NewTemplate(in.Name())
+	config := DefaultConfig()
+	tmpl, err := NewTemplate(in.Name(), config)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Various configuration files actually utilise the "{{ }}" delimiters and therefore it becomes more difficult to create the configuration automatically (e.g. RabbitMQ). This PR introduces an new flag that allows the user to select an custom delimiter.

Example Usage
```
./consul-template -delimiter "|| ||"
```

Example Template
```
Hello || env "NAME" ||
```