### PR TITLE
Remove assumptions about temp file locations

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -822,7 +822,14 @@ func atomicWrite(path string, contents []byte, perms os.FileMode, backup bool) e
 		}
 	}
 
-	f, err := ioutil.TempFile(parent, "")
+	workingdir := filepath.Join(parent, ".ctmpl")
+	if _, err := os.Stat(workingdir); os.IsNotExist(err) {
+		if err := os.Mkdir(workingdir, 0700); err != nil {
+			return err
+		}
+	}
+
+	f, err := ioutil.TempFile(workingdir, filepath.Base(path)+"-")
 	if err != nil {
 		return err
 	}

--- a/runner_test.go
+++ b/runner_test.go
@@ -444,12 +444,14 @@ func TestRun_multipleTemplatesRunsCommands(t *testing.T) {
 				Destination:    out1.Name(),
 				Command:        fmt.Sprintf("touch %s", touch1.Name()),
 				CommandTimeout: 1 * time.Second,
+				Perms:          defaultFilePerms,
 			},
 			&ConfigTemplate{
 				Source:         in2.Name(),
 				Destination:    out2.Name(),
 				Command:        fmt.Sprintf("touch %s", touch2.Name()),
 				CommandTimeout: 1 * time.Second,
+				Perms:          defaultFilePerms,
 			},
 		},
 	})
@@ -787,6 +789,7 @@ func TestRun_executesCommand(t *testing.T) {
 				Destination:    outTemplate.Name(),
 				Command:        fmt.Sprintf("echo 'foo' > %s", outFile.Name()),
 				CommandTimeout: 1 * time.Second,
+				Perms:          defaultFilePerms,
 			},
 		},
 	})
@@ -846,12 +849,14 @@ func TestRun_doesNotExecuteCommandMoreThanOnce(t *testing.T) {
 				Destination:    outTemplateA.Name(),
 				Command:        fmt.Sprintf("echo 'foo' >> %s", outFile.Name()),
 				CommandTimeout: 1 * time.Second,
+				Perms:          defaultFilePerms,
 			},
 			&ConfigTemplate{
 				Source:         inTemplate.Name(),
 				Destination:    outTemplateB.Name(),
 				Command:        fmt.Sprintf("echo 'foo' >> %s", outFile.Name()),
 				CommandTimeout: 1 * time.Second,
+				Perms:          defaultFilePerms,
 			},
 		},
 	})


### PR DESCRIPTION
Many configuration files live in a parent directory that is only writeable by root or another user.  Despite this, current code assumes the parent directory is writable by the consul-template process.

In addition, the assumption is made that the temporary file is created on the same filesystem.

We can still retain an atomic copy+delete using the existing `copyFile(...)` and deferred `os.Remove(...)`.

This patch allows for more granular security and more variation in the host filesystem.  In my case, this patch allows consul-template to run as a dedicated user, with explicit permission to writeable locations.