### PR TITLE
Add support for listing secrets

### DIFF
--- a/dependency/vault_secret.go
+++ b/dependency/vault_secret.go
@@ -118,7 +118,7 @@ func (d *VaultSecret) HashCode() string {
 // Display returns a string that should be displayed to the user in output (for
 // example).
 func (d *VaultSecret) Display() string {
-	return fmt.Sprintf(`"vault(%s)"`, d.Path)
+	return fmt.Sprintf(`"secret(%s)"`, d.Path)
 }
 
 // ParseVaultSecret creates a new datacenter dependency.

--- a/dependency/vault_secret_test.go
+++ b/dependency/vault_secret_test.go
@@ -31,15 +31,3 @@ func TestVaultSecretHashCode_isUnique(t *testing.T) {
 		t.Errorf("expected HashCode to be unique")
 	}
 }
-
-func TestParseVaultSecret_emptyString(t *testing.T) {
-	secret, err := ParseVaultSecret("secret/foo/bar")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expected := "secret/foo/bar"
-	if secret.Path != expected {
-		t.Errorf("expected %q to be %q", secret.Path, expected)
-	}
-}

--- a/dependency/vault_secrets.go
+++ b/dependency/vault_secrets.go
@@ -1,0 +1,109 @@
+package dependency
+
+import (
+	"fmt"
+	"log"
+	"sort"
+	"time"
+)
+
+// VaultSecrets is the dependency to list secrets in Vault.
+type VaultSecrets struct {
+	Path string
+}
+
+// Fetch queries the Vault API
+func (d *VaultSecrets) Fetch(clients *ClientSet, opts *QueryOptions) (interface{}, *ResponseMetadata, error) {
+	if opts == nil {
+		opts = &QueryOptions{}
+	}
+
+	log.Printf("[DEBUG] (%s) querying vault with %+v", d.Display(), opts)
+
+	// If this is not the first query and we have a lease duration, sleep until we
+	// try to renew.
+	if opts.WaitIndex != 0 {
+		log.Printf("[DEBUG] (%s) pretending to long-poll", d.Display())
+		time.Sleep(sleepTime)
+	}
+
+	// Grab the vault client
+	vault, err := clients.Vault()
+	if err != nil {
+		return nil, nil, fmt.Errorf("vault secrets: %s", err)
+	}
+
+	// Get the list as a secret
+	vaultSecret, err := vault.Logical().List(d.Path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error listing secrets from vault: %s", err)
+	}
+
+	// The secret could be nil (maybe it does not exist yet). This is not an error
+	// to Vault, but it is an error to Consul Template, so return an error
+	// instead.
+	if vaultSecret == nil {
+		return nil, nil, fmt.Errorf("no secrets exist at path %q", d.Display())
+	}
+
+	// If the data is nil, return an empty list of strings.
+	if vaultSecret.Data == nil {
+		return respWithMetadata(make([]string, 0))
+	}
+
+	// If there are no keys at that path, return the empty list.
+	keys, ok := vaultSecret.Data["keys"]
+	if !ok {
+		return respWithMetadata(make([]string, 0))
+	}
+
+	// Convert the interface into a list of interfaces.
+	list, ok := keys.([]interface{})
+	if !ok {
+		return nil, nil, fmt.Errorf("vault returned an unexpected payload for %q", d.Display())
+	}
+
+	// Pull each item out of the list and safely cast to a string.
+	result := make([]string, len(list))
+	for i, v := range list {
+		typed, ok := v.(string)
+		if !ok {
+			return nil, nil, fmt.Errorf("vault returned a non-string when listing secrets for %q", d.Display())
+		}
+		result[i] = typed
+	}
+	sort.Strings(result)
+
+	log.Printf("[DEBUG] (%s) vault listed %d secrets(s)", d.Display(), len(result))
+
+	return respWithMetadata(result)
+}
+
+// CanShare returns if this dependency is shareable.
+func (d *VaultSecrets) CanShare() bool {
+	return false
+}
+
+// HashCode returns the hash code for this dependency.
+func (d *VaultSecrets) HashCode() string {
+	return fmt.Sprintf("VaultSecrets|%s", d.Path)
+}
+
+// Display returns a string that should be displayed to the user in output (for
+// example).
+func (d *VaultSecrets) Display() string {
+	return fmt.Sprintf(`"secrets(%s)"`, d.Path)
+}
+
+// ParseVaultSecrets creates a new datacenter dependency.
+func ParseVaultSecrets(s string) (*VaultSecrets, error) {
+	// Ensure a trailing slash, always.
+	if len(s) == 0 {
+		s = "/"
+	}
+	if s[len(s)-1] != '/' {
+		s = fmt.Sprintf("%s/", s)
+	}
+
+	return &VaultSecrets{Path: s}, nil
+}

--- a/dependency/vault_secrets_test.go
+++ b/dependency/vault_secrets_test.go
@@ -1,0 +1,93 @@
+package dependency
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestVaultSecretsFetch_empty(t *testing.T) {
+	clients, vault := testVaultServer(t)
+	defer vault.Stop()
+
+	dep := &VaultSecrets{Path: "secret"}
+	results, _, err := dep.Fetch(clients, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	typed, ok := results.([]string)
+	if !ok {
+		t.Fatal("could not convert result to []string")
+	}
+
+	expected := []string{}
+	if !reflect.DeepEqual(typed, expected) {
+		t.Errorf("expected %#v to be %#v", typed, expected)
+	}
+}
+
+func TestVaultSecretsFetch(t *testing.T) {
+	clients, vault := testVaultServer(t)
+	defer vault.Stop()
+
+	vault.CreateSecret("foo", map[string]interface{}{"a": "b"})
+	vault.CreateSecret("bar", map[string]interface{}{"c": "d"})
+
+	dep := &VaultSecrets{Path: "secret"}
+	results, _, err := dep.Fetch(clients, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	typed, ok := results.([]string)
+	if !ok {
+		t.Fatal("could not convert result to []string")
+	}
+
+	expected := []string{"bar", "foo"}
+	if !reflect.DeepEqual(typed, expected) {
+		t.Errorf("expected %#v to be %#v", typed, expected)
+	}
+}
+
+func TestVaultSecretsHashCode_isUnique(t *testing.T) {
+	dep1 := &VaultSecrets{Path: "secret"}
+	dep2 := &VaultSecrets{Path: "postgresql"}
+	if dep1.HashCode() == dep2.HashCode() {
+		t.Errorf("expected HashCode to be unique")
+	}
+}
+
+func TestParseVaultSecrets_trailingSlash(t *testing.T) {
+	d, err := ParseVaultSecrets("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Path != "/" {
+		t.Errorf("expected %q to be %q", d.Path, "/")
+	}
+
+	d, err = ParseVaultSecrets("/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Path != "/" {
+		t.Errorf("expected %q to be %q", d.Path, "/")
+	}
+
+	d, err = ParseVaultSecrets("secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Path != "secret/" {
+		t.Errorf("expected %q to be %q", d.Path, "/")
+	}
+
+	d, err = ParseVaultSecrets("secret/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Path != "secret/" {
+		t.Errorf("expected %q to be %q", d.Path, "/")
+	}
+}

--- a/template.go
+++ b/template.go
@@ -101,6 +101,8 @@ func funcMap(brain *Brain, used, missing map[string]dep.Dependency) template.Fun
 		"ls":             lsFunc(brain, used, missing),
 		"node":           nodeFunc(brain, used, missing),
 		"nodes":          nodesFunc(brain, used, missing),
+		"secret":         secretFunc(brain, used, missing),
+		"secrets":        secretsFunc(brain, used, missing),
 		"service":        serviceFunc(brain, used, missing),
 		"services":       servicesFunc(brain, used, missing),
 		"tree":           treeFunc(brain, used, missing),

--- a/template_test.go
+++ b/template_test.go
@@ -251,6 +251,9 @@ func TestExecute_renders(t *testing.T) {
 				{{.Service}}{{ end }}{{ end }}
 		nodes:{{ range nodes }}
 			{{.Node}}{{ end }}
+		secret: {{ with secret "secret/foo/bar" }}{{.Data.zip}}{{ end }}
+		secrets:{{ range secrets "secret/" }}
+			{{.}}{{ end }}
 		service:{{ range service "webapp" }}
 			{{.Address}}{{ end }}
 		service (any):{{ range service "webapp" "any" }}
@@ -443,6 +446,12 @@ func TestExecute_renders(t *testing.T) {
 		},
 	})
 
+	d, err = dep.ParseVaultSecrets("secret/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	brain.Remember(d, []string{"bar", "foo"})
+
 	d, err = dep.ParseVaultSecret("secret/foo/bar")
 	if err != nil {
 		t.Fatal(err)
@@ -492,6 +501,10 @@ func TestExecute_renders(t *testing.T) {
 		nodes:
 			node1
 			node2
+		secret: zap
+		secrets:
+			bar
+			foo
 		service:
 			1.2.3.4
 			5.6.7.8
@@ -598,7 +611,7 @@ minconns: "2"
 `)
 
 	if !bytes.Equal(result, expected) {
-		t.Errorf("expected %s to be %s", result, expected)
+		t.Errorf("expected \n\n%q\n\n to be \n\n%q\n\n", result, expected)
 	}
 }
 


### PR DESCRIPTION
This adds a new template function "secrets" which may be used to list secrets in Vault, provided the endpoint supports it. This commit also renames the "vault" template function to "secret" for consistency with other projects and deprecates the use of the "vault" template function.

Fixes GH-270