### PR TITLE
Allow long-running dependencies to stop on reload

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -47,6 +47,7 @@ type CLI struct {
 	stopped bool
 }
 
+// NewCLI creates a new CLI object with the given stdout and stderr streams.
 func NewCLI(out, err io.Writer) *CLI {
 	return &CLI{
 		outStream: out,
@@ -65,7 +66,7 @@ func (cli *CLI) Run(args []string) int {
 	}
 
 	// Save original config (defaults + parsed flags) for handling reloads
-	base_config := config
+	baseConfig := config.Copy()
 
 	// Setup the config and logging
 	config, err = cli.setup(config)
@@ -85,7 +86,7 @@ func (cli *CLI) Run(args []string) int {
 		return ExitCodeOK
 	}
 
-	// If they configured a child process reaper, start that now
+	// If they configured a child process reaper, start that now.
 	var reapLock sync.RWMutex
 	if config.Reap || (!config.WasSet("reap") && os.Getpid() == 1) {
 		if !reap.IsSupported() {
@@ -144,7 +145,7 @@ func (cli *CLI) Run(args []string) int {
 				runner.Stop()
 
 				// Load the new configuration from disk
-				config, err = cli.setup(base_config)
+				config, err = cli.setup(baseConfig)
 				if err != nil {
 					return cli.handleError(err, ExitCodeConfigError)
 				}

--- a/config.go
+++ b/config.go
@@ -87,6 +87,97 @@ type Config struct {
 	setKeys map[string]struct{}
 }
 
+// Copy returns a deep copy of the current configuration. This is useful because
+// the nested data structures may be shared.
+func (c *Config) Copy() *Config {
+	config := new(Config)
+	config.Path = c.Path
+	config.Consul = c.Consul
+	config.Token = c.Token
+
+	if c.Auth != nil {
+		config.Auth = &AuthConfig{
+			Enabled:  c.Auth.Enabled,
+			Username: c.Auth.Username,
+			Password: c.Auth.Password,
+		}
+	}
+
+	if c.Vault != nil {
+		config.Vault = &VaultConfig{
+			Address: c.Vault.Address,
+			Token:   c.Vault.Token,
+			Renew:   c.Vault.Renew,
+		}
+
+		if c.Vault.SSL != nil {
+			config.Vault.SSL = &SSLConfig{
+				Enabled: c.Vault.SSL.Enabled,
+				Verify:  c.Vault.SSL.Verify,
+				Cert:    c.Vault.SSL.Cert,
+				Key:     c.Vault.SSL.Key,
+				CaCert:  c.Vault.SSL.CaCert,
+			}
+		}
+	}
+
+	if c.SSL != nil {
+		config.SSL = &SSLConfig{
+			Enabled: c.SSL.Enabled,
+			Verify:  c.SSL.Verify,
+			Cert:    c.SSL.Cert,
+			Key:     c.SSL.Key,
+			CaCert:  c.SSL.CaCert,
+		}
+	}
+
+	if c.Syslog != nil {
+		config.Syslog = &SyslogConfig{
+			Enabled:  c.Syslog.Enabled,
+			Facility: c.Syslog.Facility,
+		}
+	}
+
+	config.MaxStale = c.MaxStale
+
+	config.ConfigTemplates = make([]*ConfigTemplate, len(c.ConfigTemplates))
+	for i, t := range c.ConfigTemplates {
+		config.ConfigTemplates[i] = &ConfigTemplate{
+			Source:         t.Source,
+			Destination:    t.Destination,
+			Command:        t.Command,
+			CommandTimeout: t.CommandTimeout,
+			Perms:          t.Perms,
+			Backup:         t.Backup,
+		}
+	}
+
+	config.Retry = c.Retry
+
+	if c.Wait != nil {
+		config.Wait = &watch.Wait{
+			Min: c.Wait.Min,
+			Max: c.Wait.Max,
+		}
+	}
+
+	config.PidFile = c.PidFile
+	config.LogLevel = c.LogLevel
+
+	if c.Deduplicate != nil {
+		config.Deduplicate = &DeduplicateConfig{
+			Enabled: c.Deduplicate.Enabled,
+			Prefix:  c.Deduplicate.Prefix,
+			TTL:     c.Deduplicate.TTL,
+		}
+	}
+
+	config.Reap = c.Reap
+	config.setKeys = c.setKeys
+
+	return config
+}
+
 // Merge merges the values in config into this config object. Values in the
 // config object overwrite the values in c.
 func (c *Config) Merge(config *Config) {

--- a/dependency/catalog_node.go
+++ b/dependency/catalog_node.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"regexp"
 	"sort"
+
+	"github.com/hashicorp/consul/api"
 )
 
 func init() {
@@ -14,11 +16,13 @@ func init() {
 	gob.Register([]*NodeService{})
 }
 
+// NodeDetail is a wrapper around the node and its services.
 type NodeDetail struct {
 	Node     *Node
 	Services NodeServiceList
 }
 
+// NodeService is a service on a single node.
 type NodeService struct {
 	ID      string
 	Service string
@@ -26,13 +30,16 @@ type NodeService struct {
 	Port    int
 }
 
+// CatalogNode represents a single node from the Consul catalog.
 type CatalogNode struct {
 	rawKey     string
 	dataCenter string
+	stopped    bool
+	stopCh     chan struct{}
 }
 
 // Fetch queries the Consul API defined by the given client and returns a
-// of NodeDetail object
+// of NodeDetail object.
 func (d *CatalogNode) Fetch(clients *ClientSet, opts *QueryOptions) (interface{}, *ResponseMetadata, error) {
 	if opts == nil {
 		opts = &QueryOptions{}
@@ -42,8 +49,6 @@ func (d *CatalogNode) Fetch(clients *ClientSet, opts *QueryOptions) (interface{}
 	if d.dataCenter != "" {
 		consulOpts.Datacenter = d.dataCenter
 	}
-
-	log.Printf("[DEBUG] (%s) querying Consul with %+v", d.Display(), consulOpts)
 
 	consul, err := clients.Consul()
 	if err != nil {
@@ -59,8 +64,21 @@ func (d *CatalogNode) Fetch(clients *ClientSet, opts *QueryOptions) (interface{}
 		}
 	}
 
-	catalog := consul.Catalog()
-	n, qm, err := catalog.Node(nodeName, consulOpts)
+	var n *api.CatalogNode
+	var qm *api.QueryMeta
+	dataCh := make(chan struct{})
+	go func() {
+		log.Printf("[DEBUG] (%s) querying consul with %+v", d.Display(), consulOpts)
+		n, qm, err = consul.Catalog().Node(nodeName, consulOpts)
+		close(dataCh)
+	}()
+
+	select {
+	case <-d.stopCh:
+		return nil, nil, ErrStopped
+	case <-dataCh:
+	}
+
 	if err != nil {
 		return nil, nil, fmt.Errorf("catalog node: error fetching: %s", err)
 	}
@@ -98,11 +116,12 @@ func (d *CatalogNode) Fetch(clients *ClientSet, opts *QueryOptions) (interface{}
 	return node, rm, nil
 }
 
-// CanShare returns if this dependency is shareable.
+// CanShare returns a boolean if this dependency is shareable.
 func (d *CatalogNode) CanShare() bool {
 	return true
 }
 
+// HashCode returns a unique identifier.
 func (d *CatalogNode) HashCode() string {
 	if d.dataCenter != "" {
 		return fmt.Sprintf("NodeDetail|%s@%s", d.rawKey, d.dataCenter)
@@ -110,6 +129,7 @@ func (d *CatalogNode) HashCode() string {
 	return fmt.Sprintf("NodeDetail|%s", d.rawKey)
 }
 
+// Display prints the human-friendly output.
 func (d *CatalogNode) Display() string {
 	if d.dataCenter != "" {
 		return fmt.Sprintf("node(%s@%s)", d.rawKey, d.dataCenter)
@@ -117,14 +137,27 @@ func (d *CatalogNode) Display() string {
 	return fmt.Sprintf(`"node(%s)"`, d.rawKey)
 }
 
+// Stop halts the dependency's fetch function.
+func (d *CatalogNode) Stop() {
+	if !d.stopped {
+		close(d.stopCh)
+		d.stopped = true
+	}
+}
+
 // ParseCatalogNode parses a name name and optional datacenter value.
 // If the name is empty or not provided then the current agent is used.
 func ParseCatalogNode(s ...string) (*CatalogNode, error) {
 	switch len(s) {
 	case 0:
-		return &CatalogNode{}, nil
+		cn := &CatalogNode{stopCh: make(chan struct{})}
+		return cn, nil
 	case 1:
-		return &CatalogNode{rawKey: s[0]}, nil
+		cn := &CatalogNode{
+			rawKey: s[0],
+			stopCh: make(chan struct{}),
+		}
+		return cn, nil
 	case 2:
 		dc := s[1]
 
@@ -150,6 +183,7 @@ func ParseCatalogNode(s ...string) (*CatalogNode, error) {
 		nd := &CatalogNode{
 			rawKey:     s[0],
 			dataCenter: m["datacenter"],
+			stopCh:     make(chan struct{}),
 		}
 
 		return nd, nil
@@ -160,6 +194,7 @@ func ParseCatalogNode(s ...string) (*CatalogNode, error) {
 
 // Sorting
 
+// NodeServiceList is a sortable list of node service names.
 type NodeServiceList []*NodeService
 
 func (s NodeServiceList) Len() int      { return len(s) }

--- a/dependency/catalog_nodes.go
+++ b/dependency/catalog_nodes.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"regexp"
 	"sort"
+
+	"github.com/hashicorp/consul/api"
 )
 
 func init() {
@@ -19,9 +21,12 @@ type Node struct {
 	Address string
 }
 
+// CatalogNodes is the representation of all registered nodes in Consul.
 type CatalogNodes struct {
 	rawKey     string
 	DataCenter string
+	stopped    bool
+	stopCh     chan struct{}
 }
 
 // Fetch queries the Consul API defined by the given client and returns a slice
@@ -36,15 +41,26 @@ func (d *CatalogNodes) Fetch(clients *ClientSet, opts *QueryOptions) (interface{
 		consulOpts.Datacenter = d.DataCenter
 	}
 
-	log.Printf("[DEBUG] (%s) querying Consul with %+v", d.Display(), consulOpts)
-
 	consul, err := clients.Consul()
 	if err != nil {
 		return nil, nil, fmt.Errorf("catalog nodes: error getting client: %s", err)
 	}
 
-	catalog := consul.Catalog()
-	n, qm, err := catalog.Nodes(consulOpts)
+	var n []*api.Node
+	var qm *api.QueryMeta
+	dataCh := make(chan struct{})
+	go func() {
+		log.Printf("[DEBUG] (%s) querying Consul with %+v", d.Display(), consulOpts)
+		n, qm, err = consul.Catalog().Nodes(consulOpts)
+		close(dataCh)
+	}()
+
+	select {
+	case <-d.stopCh:
+		return nil, nil, ErrStopped
+	case <-dataCh:
+	}
+
 	if err != nil {
 		return nil, nil, fmt.Errorf("catalog nodes: error fetching: %s", err)
 	}
@@ -68,15 +84,17 @@ func (d *CatalogNodes) Fetch(clients *ClientSet, opts *QueryOptions) (interface{
 	return nodes, rm, nil
 }
 
-// CanShare returns if this dependency is shareable.
+// CanShare returns a boolean if this dependency is shareable.
 func (d *CatalogNodes) CanShare() bool {
 	return true
 }
 
+// HashCode returns a unique identifier.
 func (d *CatalogNodes) HashCode() string {
 	return fmt.Sprintf("CatalogNodes|%s", d.rawKey)
 }
 
+// Display prints the human-friendly output.
 func (d *CatalogNodes) Display() string {
 	if d.rawKey == "" {
 		return fmt.Sprintf(`"nodes"`)
@@ -85,11 +103,23 @@ func (d *CatalogNodes) Display() string {
 	return fmt.Sprintf(`"nodes(%s)"`, d.rawKey)
 }
 
+// Stop halts the dependency's fetch function.
+func (d *CatalogNodes) Stop() {
+	if !d.stopped {
+		close(d.stopCh)
+		d.stopped = true
+	}
+}
+
 // ParseCatalogNodes parses a string of the format @dc.
 func ParseCatalogNodes(s ...string) (*CatalogNodes, error) {
 	switch len(s) {
 	case 0:
-		return &CatalogNodes{rawKey: ""}, nil
+		cn := &CatalogNodes{
+			rawKey: "",
+			stopCh: make(chan struct{}),
+		}
+		return cn, nil
 	case 1:
 		dc := s[0]
 
@@ -112,17 +142,19 @@ func ParseCatalogNodes(s ...string) (*CatalogNodes, error) {
 			}
 		}
 
-		nd := &CatalogNodes{
+		cn := &CatalogNodes{
 			rawKey:     dc,
 			DataCenter: m["datacenter"],
+			stopCh:     make(chan struct{}),
 		}
 
-		return nd, nil
+		return cn, nil
 	default:
 		return nil, fmt.Errorf("expected 0 or 1 arguments, got %d", len(s))
 	}
 }
 
+// NodeList is a sortable list of node objects by name and then IP address.
 type NodeList []*Node
 
 func (s NodeList) Len() int      { return len(s) }

--- a/dependency/catalog_services.go
+++ b/dependency/catalog_services.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"regexp"
 	"sort"
+
+	"github.com/hashicorp/consul/api"
 )
 
 func init() {
@@ -26,6 +28,8 @@ type CatalogServices struct {
 	Name       string
 	Tags       []string
 	DataCenter string
+	stopped    bool
+	stopCh     chan struct{}
 }
 
 // Fetch queries the Consul API defined by the given client and returns a slice
@@ -40,15 +44,26 @@ func (d *CatalogServices) Fetch(clients *ClientSet, opts *QueryOptions) (interfa
 		consulOpts.Datacenter = d.DataCenter
 	}
 
-	log.Printf("[DEBUG] (%s) querying Consul with %+v", d.Display(), consulOpts)
-
 	consul, err := clients.Consul()
 	if err != nil {
 		return nil, nil, fmt.Errorf("catalog services: error getting client: %s", err)
 	}
 
-	catalog := consul.Catalog()
-	entries, qm, err := catalog.Services(consulOpts)
+	var entries map[string][]string
+	var qm *api.QueryMeta
+	dataCh := make(chan struct{})
+	go func() {
+		log.Printf("[DEBUG] (%s) querying Consul with %+v", d.Display(), consulOpts)
+		entries, qm, err = consul.Catalog().Services(consulOpts)
+		close(dataCh)
+	}()
+
+	select {
+	case <-d.stopCh:
+		return nil, nil, ErrStopped
+	case <-dataCh:
+	}
+
 	if err != nil {
 		return nil, nil, fmt.Errorf("catalog services: error fetching: %s", err)
 	}
@@ -74,18 +89,17 @@ func (d *CatalogServices) Fetch(clients *ClientSet, opts *QueryOptions) (interfa
 	return catalogServices, rm, nil
 }
 
-// CanShare returns if this dependency is shareable.
+// CanShare returns a boolean if this dependency is shareable.
 func (d *CatalogServices) CanShare() bool {
 	return true
 }
 
-// HashCode returns the hash code for this dependency.
+// HashCode returns a unique identifier.
 func (d *CatalogServices) HashCode() string {
 	return fmt.Sprintf("CatalogServices|%s", d.rawKey)
 }
 
-// Display returns a string that should be displayed to the user in output (for
-// example).
+// Display prints the human-friendly output.
 func (d *CatalogServices) Display() string {
 	if d.rawKey == "" {
 		return fmt.Sprintf(`"services"`)
@@ -94,11 +108,23 @@ func (d *CatalogServices) Display() string {
 	return fmt.Sprintf(`"services(%s)"`, d.rawKey)
 }
 
+// Stop halts the dependency's fetch function.
+func (d *CatalogServices) Stop() {
+	if !d.stopped {
+		close(d.stopCh)
+		d.stopped = true
+	}
+}
+
 // ParseCatalogServices parses a string of the format @dc.
 func ParseCatalogServices(s ...string) (*CatalogServices, error) {
 	switch len(s) {
 	case 0:
-		return &CatalogServices{rawKey: ""}, nil
+		cs := &CatalogServices{
+			rawKey: "",
+			stopCh: make(chan struct{}),
+		}
+		return cs, nil
 	case 1:
 		dc := s[0]
 
@@ -124,6 +150,7 @@ func ParseCatalogServices(s ...string) (*CatalogServices, error) {
 		nd := &CatalogServices{
 			rawKey:     dc,
 			DataCenter: m["datacenter"],
+			stopCh:     make(chan struct{}),
 		}
 
 		return nd, nil

--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -1,11 +1,17 @@
 package dependency
 
 import (
+	"errors"
 	"sort"
 	"time"
 
 	consulapi "github.com/hashicorp/consul/api"
 )
+
+// ErrStopped is a special error that is returned when a dependency is
+// prematurely stopped, usually due to a configuration reload or a process
+// interrupt.
+var ErrStopped = errors.New("dependency stopped")
 
 // Dependency is an interface for a dependency that Consul Template is capable
 // of watching.
@@ -14,6 +20,7 @@ type Dependency interface {
 	CanShare() bool
 	HashCode() string
 	Display() string
+	Stop()
 }
 
 // ServiceTags is a slice of tags assigned to a Service

--- a/dependency/file.go
+++ b/dependency/file.go
@@ -10,19 +10,35 @@ import (
 	"time"
 )
 
+// File represents a local file dependency.
 type File struct {
 	mutex    sync.RWMutex
 	rawKey   string
 	lastStat os.FileInfo
+	stopped  bool
+	stopCh   chan struct{}
 }
 
+// Fetch retrieves this dependency and returns the result or any errors that
+// occur in the process.
 func (d *File) Fetch(clients *ClientSet, opts *QueryOptions) (interface{}, *ResponseMetadata, error) {
-	var err error = nil
+	var err error
+	var newStat os.FileInfo
 	var data []byte
 
-	log.Printf("[DEBUG] (%s) querying file", d.Display())
+	dataCh := make(chan struct{})
+	go func() {
+		log.Printf("[DEBUG] (%s) querying file", d.Display())
+		newStat, err = d.watch()
+		close(dataCh)
+	}()
 
-	newStat, err := d.watch()
+	select {
+	case <-d.stopCh:
+		return nil, nil, ErrStopped
+	case <-dataCh:
+	}
+
 	if err != nil {
 		return "", nil, fmt.Errorf("file: error watching: %s", err)
 	}
@@ -37,16 +53,27 @@ func (d *File) Fetch(clients *ClientSet, opts *QueryOptions) (interface{}, *Resp
 	return nil, nil, fmt.Errorf("file: error reading: %s", err)
 }
 
+// CanShare returns a boolean if this dependency is shareable.
 func (d *File) CanShare() bool {
 	return false
 }
 
+// HashCode returns a unique identifier.
 func (d *File) HashCode() string {
 	return fmt.Sprintf("StoreKeyPrefix|%s", d.rawKey)
 }
 
+// Display prints the human-friendly output.
 func (d *File) Display() string {
 	return fmt.Sprintf(`"file(%s)"`, d.rawKey)
+}
+
+// Stop halts the dependency's fetch function.
+func (d *File) Stop() {
+	if !d.stopped {
+		close(d.stopCh)
+		d.stopped = true
+	}
 }
 
 // watch watchers the file for changes
@@ -77,12 +104,12 @@ func (d *File) watch() (os.FileInfo, error) {
 
 		if changed {
 			return stat, nil
-		} else {
-			time.Sleep(3 * time.Second)
 		}
+		time.Sleep(3 * time.Second)
 	}
 }
 
+// ParseFile creates a file dependency from the given path.
 func ParseFile(s string) (*File, error) {
 	if len(s) == 0 {
 		return nil, errors.New("cannot specify empty file dependency")
@@ -90,6 +117,7 @@ func ParseFile(s string) (*File, error) {
 
 	kd := &File{
 		rawKey: s,
+		stopCh: make(chan struct{}),
 	}
 
 	return kd, nil

--- a/dependency/test.go
+++ b/dependency/test.go
@@ -28,6 +28,8 @@ func (d *Test) HashCode() string {
 
 func (d *Test) Display() string { return "fakedep" }
 
+func (d *Test) Stop() {}
+
 // TestStale is a special dependency that can be used to test what happens when
 // stale data is permitted.
 type TestStale struct {
@@ -63,6 +65,8 @@ func (d *TestStale) HashCode() string {
 
 func (d *TestStale) Display() string { return "fakedep" }
 
+func (d *TestStale) Stop() {}
+
 // TestFetchError is a special dependency that returns an error while fetching.
 type TestFetchError struct {
 	Name string
@@ -82,6 +86,8 @@ func (d *TestFetchError) HashCode() string {
 }
 
 func (d *TestFetchError) Display() string { return "fakedep" }
+
+func (d *TestFetchError) Stop() {}
 
 // TestRetry is a special dependency that errors on the first fetch and
 // succeeds on subsequent fetches.
@@ -116,3 +122,5 @@ func (d *TestRetry) HashCode() string {
 }
 
 func (d *TestRetry) Display() string { return "fakedep" }
+
+func (d *TestRetry) Stop() {}

--- a/dependency/vault_secret.go
+++ b/dependency/vault_secret.go
@@ -31,9 +31,12 @@ type VaultSecret struct {
 
 // Fetch queries the Vault API
 func (d *VaultSecret) Fetch(clients *ClientSet, opts *QueryOptions) (interface{}, *ResponseMetadata, error) {
+	d.Lock()
 	if d.stopped {
+		defer d.Unlock()
 		return nil, nil, ErrStopped
 	}
+	d.Unlock()
 
 	if opts == nil {
 		opts = &QueryOptions{}
@@ -135,6 +138,9 @@ func (d *VaultSecret) Display() string {
 
 // Stop halts the given dependency's fetch.
 func (d *VaultSecret) Stop() {
+	d.Lock()
+	defer d.Unlock()
+
 	if !d.stopped {
 		close(d.stopCh)
 		d.stopped = true

--- a/dependency/vault_secret_test.go
+++ b/dependency/vault_secret_test.go
@@ -1,6 +1,9 @@
 package dependency
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestVaultSecretFetch(t *testing.T) {
 	clients, vault := testVaultServer(t)
@@ -8,7 +11,11 @@ func TestVaultSecretFetch(t *testing.T) {
 
 	vault.CreateSecret("foo/bar", map[string]interface{}{"zip": "zap"})
 
-	dep := &VaultSecret{Path: "secret/foo/bar"}
+	dep, err := ParseVaultSecret("secret/foo/bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	results, _, err := dep.Fetch(clients, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -24,9 +31,55 @@ func TestVaultSecretFetch(t *testing.T) {
 	}
 }
 
+func TestVaultSecretFetch_stopped(t *testing.T) {
+	clients, vault := testVaultServer(t)
+	defer vault.Stop()
+
+	vault.CreateSecret("foo/bar", map[string]interface{}{"zip": "zap"})
+
+	dep, err := ParseVaultSecret("secret/foo/bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Attach a secret to make it appear like we already requested once.
+	dep.secret = &Secret{
+		LeaseDuration: 5,
+		Renewable:     true,
+	}
+
+	errCh := make(chan error)
+	go func() {
+		results, _, err := dep.Fetch(clients, &QueryOptions{WaitIndex: 100})
+		if results != nil {
+			t.Fatalf("should not get results: %#v", results)
+		}
+		errCh <- err
+	}()
+
+	dep.Stop()
+
+	select {
+	case err := <-errCh:
+		if err != ErrStopped {
+			t.Errorf("expected %q to be %q", err, ErrStopped)
+		}
+	case <-time.After(50 * time.Millisecond):
+		t.Errorf("did not return in 50ms")
+	}
+}
+
 func TestVaultSecretHashCode_isUnique(t *testing.T) {
-	dep1 := &VaultSecret{Path: "secret/foo/foo"}
-	dep2 := &VaultSecret{Path: "secret/foo/bar"}
+	dep1, err := ParseVaultSecret("secret/foo/bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dep2, err := ParseVaultSecret("secret/foo/foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if dep1.HashCode() == dep2.HashCode() {
 		t.Errorf("expected HashCode to be unique")
 	}

--- a/dependency/vault_secrets.go
+++ b/dependency/vault_secrets.go
@@ -10,10 +10,17 @@ import (
 // VaultSecrets is the dependency to list secrets in Vault.
 type VaultSecrets struct {
 	Path string
+
+	stopped bool
+	stopCh  chan struct{}
 }
 
 // Fetch queries the Vault API
 func (d *VaultSecrets) Fetch(clients *ClientSet, opts *QueryOptions) (interface{}, *ResponseMetadata, error) {
+	if d.stopped {
+		return nil, nil, ErrStopped
+	}
+
 	if opts == nil {
 		opts = &QueryOptions{}
 	}
@@ -24,7 +31,11 @@ func (d *VaultSecrets) Fetch(clients *ClientSet, opts *QueryOptions) (interface{
 	// try to renew.
 	if opts.WaitIndex != 0 {
 		log.Printf("[DEBUG] (%s) pretending to long-poll", d.Display())
-		time.Sleep(sleepTime)
+		select {
+		case <-d.stopCh:
+			return nil, nil, ErrStopped
+		case <-time.After(sleepTime):
+		}
 	}
 
 	// Grab the vault client
@@ -95,6 +106,14 @@ func (d *VaultSecrets) Display() string {
 	return fmt.Sprintf(`"secrets(%s)"`, d.Path)
 }
 
+// Stop halts the dependency's fetch function.
+func (d *VaultSecrets) Stop() {
+	if !d.stopped {
+		close(d.stopCh)
+		d.stopped = true
+	}
+}
+
 // ParseVaultSecrets creates a new datacenter dependency.
 func ParseVaultSecrets(s string) (*VaultSecrets, error) {
 	// Ensure a trailing slash, always.
@@ -105,5 +124,9 @@ func ParseVaultSecrets(s string) (*VaultSecrets, error) {
 		s = fmt.Sprintf("%s/", s)
 	}
 
-	return &VaultSecrets{Path: s}, nil
+	vs := &VaultSecrets{
+		Path:   s,
+		stopCh: make(chan struct{}),
+	}
+	return vs, nil
 }

--- a/dependency/vault_token.go
+++ b/dependency/vault_token.go
@@ -20,9 +20,12 @@ type VaultToken struct {
 
 // Fetch queries the Vault API
 func (d *VaultToken) Fetch(clients *ClientSet, opts *QueryOptions) (interface{}, *ResponseMetadata, error) {
+	d.Lock()
 	if d.stopped {
+		defer d.Unlock()
 		return nil, nil, ErrStopped
 	}
+	d.Unlock()
 
 	if opts == nil {
 		opts = &QueryOptions{}
@@ -95,6 +98,9 @@ func (d *VaultToken) Display() string {
 
 // Stop halts the dependency's fetch function.
 func (d *VaultToken) Stop() {
+	d.Lock()
+	defer d.Unlock()
+
 	if !d.stopped {
 		close(d.stopCh)
 		d.stopped = true

--- a/dependency/vault_token_test.go
+++ b/dependency/vault_token_test.go
@@ -2,6 +2,7 @@ package dependency
 
 import (
 	"testing"
+	"time"
 
 	"github.com/hashicorp/vault/api"
 )
@@ -20,7 +21,11 @@ func TestVaultTokenFetch(t *testing.T) {
 	}
 	clients.vault.SetToken(secret.Auth.ClientToken)
 
-	dep := new(VaultToken)
+	dep, err := ParseVaultToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	results, _, err := dep.Fetch(clients, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -29,5 +34,48 @@ func TestVaultTokenFetch(t *testing.T) {
 	_, ok := results.(*Secret)
 	if !ok {
 		t.Fatal("could not convert result to a *vault/api.Secret")
+	}
+}
+
+func TestVaultTokenFetch_stoped(t *testing.T) {
+	clients, server := testVaultServer(t)
+	defer server.Stop()
+
+	// Create a new token - the default token is a root token and is therefore
+	// not renewable
+	secret, err := clients.vault.Auth().Token().Create(&api.TokenCreateRequest{
+		Lease: "1h",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	clients.vault.SetToken(secret.Auth.ClientToken)
+
+	dep, err := ParseVaultToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Attach a lease to make it appear like we already requested once.
+	dep.leaseDuration = 5
+
+	errCh := make(chan error)
+	go func() {
+		results, _, err := dep.Fetch(clients, &QueryOptions{WaitIndex: 100})
+		if results != nil {
+			t.Fatalf("should not get results: %#v", results)
+		}
+		errCh <- err
+	}()
+
+	dep.Stop()
+
+	select {
+	case err := <-errCh:
+		if err != ErrStopped {
+			t.Errorf("expected %q to be %q", err, ErrStopped)
+		}
+	case <-time.After(50 * time.Millisecond):
+		t.Errorf("did not return in 50ms")
 	}
 }

--- a/template_test.go
+++ b/template_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"os"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -118,22 +117,6 @@ func TestExecute_missingDependencies(t *testing.T) {
 
 	if num := len(missing); num != 1 {
 		t.Fatalf("expected 1 missing, got: %d", num)
-	}
-
-	expected, err := dep.ParseStoreKey("foo")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(missing[0], expected) {
-		t.Errorf("expected %v to be %v", missing[0], expected)
-	}
-
-	if num := len(used); num != 1 {
-		t.Fatalf("expected 1 used, got %d", num)
-	}
-
-	if !reflect.DeepEqual(used[0], expected) {
-		t.Errorf("expected %v to be %v", used[0], expected)
 	}
 
 	expectedResult := []byte("")

--- a/watch/watcher.go
+++ b/watch/watcher.go
@@ -199,7 +199,11 @@ func (w *Watcher) init() error {
 
 	// Start a watcher for the Vault renew if that config was specified
 	if w.config.RenewVault {
-		if _, err := w.Add(new(dep.VaultToken)); err != nil {
+		vt, err := dep.ParseVaultToken()
+		if err != nil {
+			return fmt.Errorf("watcher: %s", err)
+		}
+		if _, err := w.Add(vt); err != nil {
 			return fmt.Errorf("watcher: %s", err)
 		}
 	}

--- a/watch/watcher_test.go
+++ b/watch/watcher_test.go
@@ -92,7 +92,7 @@ func TestNewWatcher_renewVault(t *testing.T) {
 	}
 	defer w.Stop()
 
-	if !w.Watching(new(dep.VaultToken)) {
+	if !w.Watching(&dep.VaultToken{}) {
 		t.Errorf("expected watcher to be renewing vault token")
 	}
 }


### PR DESCRIPTION
Previously, when the watcher stopped a view, there was no way for the underlying dependency to stop fetching. This was especially true if the dependency performed a sleep operation since not all endpoints support blocking queries.

- Fixes GH-534
- Closes GH-537