### PR TITLE
Add CLI option to ignore commands execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Usage
 | `consul`*         | The location of the Consul instance to query (may be an IP address or FQDN) with port.
 | `deduplicate`     | Enable de-duplication of template rendering. If many instances of consul-template render the same template this reduces the load on Consul. Please see the "De-Duplication Mode" section in caveats for more information.
 | `dry`             | Dump generated templates to the console. If specified, generated templates are not committed to disk and commands are not invoked. _(CLI-only)_
-| `ignore`          | Ignore commands. If specified, commands are not executed after templates rendering. _(CLI-only)_
+| `ignore-commands` | Ignore commands. If specified, commands are not executed after templates rendering. _(CLI-only)_
 | `log-level`       | The log level for output. This applies to the stdout/stderr logging as well as syslog logging (if enabled). Valid values are "debug", "info", "warn", and "err". The default value is "warn".
 | `max-stale`       | The maximum staleness of a query. If specified, Consul will distribute work among all servers instead of just the leader. The default value is 1s.
 | `once`            | Run Consul Template once and exit (as opposed to the default behavior of daemon). _(CLI-only)_

--- a/cli.go
+++ b/cli.go
@@ -60,7 +60,7 @@ func NewCLI(out, err io.Writer) *CLI {
 // status from the command.
 func (cli *CLI) Run(args []string) int {
 	// Parse the flags
-	config, once, ignore, dry, version, err := cli.parseFlags(args[1:])
+	config, once, ignoreCommands, dry, version, err := cli.parseFlags(args[1:])
 	if err != nil {
 		return cli.handleError(err, ExitCodeParseFlagsError)
 	}
@@ -113,7 +113,7 @@ func (cli *CLI) Run(args []string) int {
 	}
 
 	// Initial runner
-	runner, err := NewRunner(config, dry, once, ignore, &reapLock)
+	runner, err := NewRunner(config, dry, once, ignoreCommands, &reapLock)
 	if err != nil {
 		return cli.handleError(err, ExitCodeRunnerError)
 	}
@@ -150,7 +150,7 @@ func (cli *CLI) Run(args []string) int {
 					return cli.handleError(err, ExitCodeConfigError)
 				}
 
-				runner, err = NewRunner(config, dry, once, ignore, &reapLock)
+				runner, err = NewRunner(config, dry, once, ignoreCommands, &reapLock)
 				if err != nil {
 					return cli.handleError(err, ExitCodeRunnerError)
 				}
@@ -180,7 +180,7 @@ func (cli *CLI) stop() {
 // small, but it also makes writing tests for parsing command line arguments
 // much easier and cleaner.
 func (cli *CLI) parseFlags(args []string) (*Config, bool, bool, bool, bool, error) {
-	var dry, once, ignore, version bool
+	var dry, once, ignoreCommands, version bool
 	config := DefaultConfig()
 
 	// Parse the flags and options
@@ -331,7 +331,7 @@ func (cli *CLI) parseFlags(args []string) (*Config, bool, bool, bool, bool, erro
 	}), "reap", "")
 
 	flags.BoolVar(&once, "once", false, "")
-	flags.BoolVar(&ignore, "ignore", false, "")
+	flags.BoolVar(&ignoreCommands, "ignore-commands", false, "")
 	flags.BoolVar(&dry, "dry", false, "")
 	flags.BoolVar(&version, "v", false, "")
 	flags.BoolVar(&version, "version", false, "")
@@ -348,7 +348,7 @@ func (cli *CLI) parseFlags(args []string) (*Config, bool, bool, bool, bool, erro
 			args)
 	}
 
-	return config, once, ignore, dry, version, nil
+	return config, once, ignoreCommands, dry, version, nil
 }
 
 // handleError outputs the given error's Error() to the errStream and returns
@@ -433,7 +433,7 @@ Options:
 
   -dry                     Dump generated templates to stdout
   -once                    Do not run the process as a daemon
-  -ignore                  Do not execute commands after rendering
+  -ignore-commands         Do not execute commands after rendering
   -reap                    Control automatic reaping of child processes, useful
                            if running as PID 1 in a Docker container. By default,
                            if Consul Template detects that it is running as PID 1

--- a/cli_test.go
+++ b/cli_test.go
@@ -476,17 +476,17 @@ func TestParseFlags_once(t *testing.T) {
 	}
 }
 
-func TestParseFlags_ignore(t *testing.T) {
+func TestParseFlags_ignoreCommands(t *testing.T) {
 	cli := NewCLI(ioutil.Discard, ioutil.Discard)
-	_, _, ignore, _, _, err := cli.parseFlags([]string{
-		"-ignore",
+	_, _, ignoreCommands, _, _, err := cli.parseFlags([]string{
+		"-ignore-commands",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if ignore != true {
-		t.Errorf("expected ignore to be true")
+	if ignoreCommands != true {
+		t.Errorf("expected ignoreCommands to be true")
 	}
 }
 

--- a/runner_test.go
+++ b/runner_test.go
@@ -28,7 +28,7 @@ func TestNewRunner_initialize(t *testing.T) {
 	in3 := test.CreateTempfile(nil, t)
 	defer test.DeleteTempfile(in3, t)
 
-	dry, once, ignore := true, true, true
+	dry, once, ignoreCommands := true, true, true
 	config := DefaultConfig()
 	config.Merge(&Config{
 		ConfigTemplates: []*ConfigTemplate{
@@ -39,7 +39,7 @@ func TestNewRunner_initialize(t *testing.T) {
 		},
 	})
 
-	runner, err := NewRunner(config, dry, once, ignore, &sync.RWMutex{})
+	runner, err := NewRunner(config, dry, once, ignoreCommands, &sync.RWMutex{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,8 +52,8 @@ func TestNewRunner_initialize(t *testing.T) {
 		t.Errorf("expected %#v to be %#v", runner.once, once)
 	}
 
-	if runner.ignore != ignore {
-		t.Errorf("expected %#v to be %#v", runner.ignore, ignore)
+	if runner.ignoreCommands != ignoreCommands {
+		t.Errorf("expected %#v to be %#v", runner.ignoreCommands, ignoreCommands)
 	}
 
 	if runner.watcher == nil {
@@ -900,7 +900,7 @@ func TestRun_doesNotExecuteCommandMoreThanOnce(t *testing.T) {
 	}
 }
 
-func TestRun_doesNotExecuteCommandIfIgnore(t *testing.T) {
+func TestRun_doesNotExecuteCommandIfIgnoreCommands(t *testing.T) {
 	outFile := test.CreateTempfile(nil, t)
 	os.Remove(outFile.Name())
 	defer os.Remove(outFile.Name())


### PR DESCRIPTION
This patch adds a CLI option to ignore commands execution after templates rendering.

With my docker CT, I have two levels of configuration : 
- the first at init stage (container configuration) where consul-templates needs only to render templates and exit (once option enabled). No services are running at this stage.
- the second (services auto-reconfiguration) where services are running, consul-templates runs in daemon to render new configuration and execute commands to reload services if needed.

This patch allows me to have the same configuration files (with the commands) for the two configuration levels.