### PR TITLE
Add template-specific wait timers

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,10 @@ template {
   // This is the maximum amount of time to wait for the optional command to
   // return. Default is 30s.
   command_timeout = "60s"
+  perms           = 0600
+  backup          = true
+  wait            = "2s:6s"
+}
 
   // This is the permission to render the file. If this option is left
   // unspecified, Consul Template will attempt to match the permissions of the

--- a/cli_test.go
+++ b/cli_test.go
@@ -288,6 +288,7 @@ func TestParseFlags_configTemplates(t *testing.T) {
 		Command:        "some command",
 		CommandTimeout: defaultCommandTimeout,
 		Perms:          defaultFilePerms,
+		Wait:           &watch.Wait{},
 	}
 	if !reflect.DeepEqual(config.ConfigTemplates[0], expected) {
 		t.Errorf("expected %q to be %q", config.ConfigTemplates[0], expected)

--- a/config.go
+++ b/config.go
@@ -149,6 +149,7 @@ func (c *Config) Copy() *Config {
 			CommandTimeout: t.CommandTimeout,
 			Perms:          t.Perms,
 			Backup:         t.Backup,
+			Wait:           t.Wait,
 		}
 	}
 
@@ -299,6 +300,7 @@ func (c *Config) Merge(config *Config) {
 				CommandTimeout: template.CommandTimeout,
 				Perms:          template.Perms,
 				Backup:         template.Backup,
+				Wait:           template.Wait,
 			})
 		}
 	}
@@ -425,6 +427,10 @@ func ParseConfig(path string) (*Config, error) {
 		// Ensure we have a default command timeout
 		if t.CommandTimeout == 0 {
 			t.CommandTimeout = defaultCommandTimeout
+		}
+
+		if t.Wait == nil {
+			t.Wait = &watch.Wait{}
 		}
 	}
 
@@ -636,6 +642,7 @@ type ConfigTemplate struct {
 	CommandTimeout time.Duration `json:"command_timeout,omitempty" mapstructure:"command_timeout"`
 	Perms          os.FileMode   `json:"perms,string" mapstructure:"perms"`
 	Backup         bool          `json:"backup" mapstructure:"backup"`
+	Wait           *watch.Wait   `json:"wait" mapstructure:"wait"`
 }
 
 // VaultConfig is the configuration for connecting to a vault server.
@@ -674,6 +681,7 @@ func ParseConfigTemplate(s string) (*ConfigTemplate, error) {
 		Command:        command,
 		CommandTimeout: defaultCommandTimeout,
 		Perms:          defaultFilePerms,
+		Wait:           &watch.Wait{},
 	}, nil
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -252,6 +252,7 @@ func TestMerge_configTemplates(t *testing.T) {
 			command_timeout = "2h"
 			perms = 0755
 			backup = true
+			wait = "6s"
 		}
 	`, t))
 
@@ -263,6 +264,7 @@ func TestMerge_configTemplates(t *testing.T) {
 			CommandTimeout: 60 * time.Second,
 			Perms:          0600,
 			Backup:         false,
+			Wait:           &watch.Wait{},
 		},
 		&ConfigTemplate{
 			Source:         "2",
@@ -271,6 +273,10 @@ func TestMerge_configTemplates(t *testing.T) {
 			CommandTimeout: 2 * time.Hour,
 			Perms:          0755,
 			Backup:         true,
+			Wait: &watch.Wait{
+				Min: 6 * time.Second,
+				Max: 24 * time.Second,
+			},
 		},
 	}
 
@@ -381,6 +387,7 @@ func TestParseConfig_correctValues(t *testing.T) {
 			command = "service redis restart"
 			command_timeout = "60s"
 			perms = 0755
+			wait = "3s:7s"
 		}
 
 		deduplicate {
@@ -441,6 +448,7 @@ func TestParseConfig_correctValues(t *testing.T) {
 				Destination:    "/etc/nginx/nginx.conf",
 				CommandTimeout: defaultCommandTimeout,
 				Perms:          0644,
+				Wait:           &watch.Wait{},
 			},
 			&ConfigTemplate{
 				Source:         "redis.conf.ctmpl",
@@ -448,6 +456,10 @@ func TestParseConfig_correctValues(t *testing.T) {
 				Command:        "service redis restart",
 				CommandTimeout: 60 * time.Second,
 				Perms:          0755,
+				Wait: &watch.Wait{
+					Min: 3 * time.Second,
+					Max: 7 * time.Second,
+				},
 			},
 		},
 		Deduplicate: &DeduplicateConfig{
@@ -762,6 +774,7 @@ func TestParseConfigurationTemplate_windowsDrives(t *testing.T) {
 		Command:        "some command",
 		CommandTimeout: defaultCommandTimeout,
 		Perms:          0644,
+		Wait:           &watch.Wait{},
 	}
 
 	if !reflect.DeepEqual(ct, expected) {

--- a/runner.go
+++ b/runner.go
@@ -134,10 +134,21 @@ func (r *Runner) Start() {
 
 	for {
 		// Enable quiescence for all templates if we have specified wait intervals.
-		if r.config.Wait.Min != 0 && r.config.Wait.Max != 0 {
-			for _, t := range r.templates {
+		for _, t := range r.templates {
+			for _, ctemplate := range r.configTemplatesFor(t) {
+				if ctemplate.Wait.Min != 0 && ctemplate.Wait.Max != 0 {
+					if _, ok := r.quiescenceMap[t.Path]; !ok {
+						log.Printf("[DEBUG] (runner) enabling template-specific quiescence for %q", t.Path)
+						r.quiescenceMap[t.Path] = newQuiescence(
+							r.quiescenceCh, ctemplate.Wait.Min, ctemplate.Wait.Max, t)
+					}
+					break
+				}
+			}
+
+			if r.config.Wait.Min != 0 && r.config.Wait.Max != 0 {
 				if _, ok := r.quiescenceMap[t.Path]; !ok {
-					log.Printf("[DEBUG] (runner) enabling quiescence for %q", t.Path)
+					log.Printf("[DEBUG] (runner) enabling global quiescence for %q", t.Path)
 					r.quiescenceMap[t.Path] = newQuiescence(
 						r.quiescenceCh, r.config.Wait.Min, r.config.Wait.Max, t)
 				}

--- a/runner_test.go
+++ b/runner_test.go
@@ -14,6 +14,7 @@ import (
 
 	dep "github.com/hashicorp/consul-template/dependency"
 	"github.com/hashicorp/consul-template/test"
+	"github.com/hashicorp/consul-template/watch"
 	"github.com/hashicorp/consul/testutil"
 	"github.com/hashicorp/go-gatedio"
 )
@@ -989,6 +990,7 @@ func TestRunner_onceAlreadyRenderedDoesNotHangOrRunCommands(t *testing.T) {
 				Source:      in.Name(),
 				Destination: out.Name(),
 				Command:     fmt.Sprintf("echo 'foo' >> %s", outFile.Name()),
+				Wait:        &watch.Wait{},
 			},
 		},
 	})
@@ -1159,7 +1161,7 @@ func TestRunner_dedup(t *testing.T) {
 	config := DefaultConfig()
 	config.Merge(&Config{
 		ConfigTemplates: []*ConfigTemplate{
-			&ConfigTemplate{Source: in.Name(), Destination: out1.Name()},
+			&ConfigTemplate{Source: in.Name(), Destination: out1.Name(), Wait: &watch.Wait{}},
 		},
 	})
 	config.Deduplicate.Enabled = true
@@ -1171,7 +1173,7 @@ func TestRunner_dedup(t *testing.T) {
 	config2 := DefaultConfig()
 	config2.Merge(&Config{
 		ConfigTemplates: []*ConfigTemplate{
-			&ConfigTemplate{Source: in.Name(), Destination: out2.Name()},
+			&ConfigTemplate{Source: in.Name(), Destination: out2.Name(), Wait: &watch.Wait{}},
 		},
 	})
 	config2.Deduplicate.Enabled = true


### PR DESCRIPTION
Previously you could only configure the global `wait` parameter. Now you can set a `wait` parameter for each template. The template-specific wait takes precedence over the global wait.

This will make it simpler to run consul-template and render configurations where you want to limit the rate of reloads for some services. I guess you could do that with the global wait parameter, but then you'd need to run multiple consul-template processes.

There is one edge-case which this PR ignores. There could be multiple `wait`s for the same source template. This PR just takes the first one, and uses that. I'm not sure what the use-case for multiple identical source templates are, or what the expected result would be to specify different waits, or no waits.

What do you think?