### PR TITLE
Print a nice error a node is a root and leaf

### DIFF
--- a/template_functions_test.go
+++ b/template_functions_test.go
@@ -1232,6 +1232,22 @@ func TestExplode(t *testing.T) {
 	}
 }
 
+func TestExplode_notMap(t *testing.T) {
+	list := []*dep.KeyPair{
+		&dep.KeyPair{Key: "a/b", Value: "foo"},
+		&dep.KeyPair{Key: "a/b/c", Value: "bar"},
+	}
+
+	_, err := explode(list)
+	if err == nil {
+		t.Errorf("expected error")
+	}
+
+	if !strings.Contains(err.Error(), "not a map") {
+		t.Errorf("bad error")
+	}
+}
+
 func TestIn_string(t *testing.T) {
 	list := []string{"a", "b", "c"}
 


### PR DESCRIPTION
It is perfectly valid to have a key that is both a "key" and a "folder" in Consul's KV store. However, in the "explode" function, it is not possible to represent this, so we return an error.

Fixes GH-596