### PR TITLE
Protects the view's data and last index from races.

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -176,9 +176,9 @@ func (r *Runner) Start() {
 
 	OUTER:
 		select {
-		case data := <-r.watcher.DataCh:
+		case view := <-r.watcher.DataCh:
 			// Receive this update
-			r.Receive(data.Dependency, data.GetData())
+			r.Receive(view.Dependency, view.Data())
 
 			// Drain all dependency data. Given a large number of dependencies, it is
 			// feasible that we have data for more than one of them. Instead of
@@ -191,8 +191,8 @@ func (r *Runner) Start() {
 			// more information about this optimization and the entire backstory.
 			for {
 				select {
-				case data := <-r.watcher.DataCh:
-					r.Receive(data.Dependency, data.GetData())
+				case view := <-r.watcher.DataCh:
+					r.Receive(view.Dependency, view.Data())
 				default:
 					break OUTER
 				}

--- a/runner.go
+++ b/runner.go
@@ -178,7 +178,7 @@ func (r *Runner) Start() {
 		select {
 		case data := <-r.watcher.DataCh:
 			// Receive this update
-			r.Receive(data.Dependency, data.Data)
+			r.Receive(data.Dependency, data.GetData())
 
 			// Drain all dependency data. Given a large number of dependencies, it is
 			// feasible that we have data for more than one of them. Instead of
@@ -192,7 +192,7 @@ func (r *Runner) Start() {
 			for {
 				select {
 				case data := <-r.watcher.DataCh:
-					r.Receive(data.Dependency, data.Data)
+					r.Receive(data.Dependency, data.GetData())
 				default:
 					break OUTER
 				}

--- a/watch/view.go
+++ b/watch/view.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"reflect"
+	"sync"
 	"time"
 
 	dep "github.com/hashicorp/consul-template/dependency"
@@ -26,9 +27,10 @@ type View struct {
 	config *WatcherConfig
 
 	// Data is the most-recently-received data from Consul for this View
-	Data         interface{}
-	ReceivedData bool
-	LastIndex    uint64
+	dataLock     sync.RWMutex
+	data         interface{}
+	receivedData bool
+	lastIndex    uint64
 
 	// stopCh is used to stop polling on this View
 	stopCh chan struct{}
@@ -50,6 +52,22 @@ func NewView(config *WatcherConfig, d dep.Dependency) (*View, error) {
 		config:     config,
 		stopCh:     make(chan struct{}),
 	}, nil
+}
+
+// GetData returns the most-recently-received data from Consul for this View.
+func (v *View) GetData() interface{} {
+	v.dataLock.RLock()
+	defer v.dataLock.RUnlock()
+	return v.data
+}
+
+// GetDataAndLastIndex returns the most-recently-received data from Consul for
+// this view, along with the last index. This is atomic so you will get the
+// index that goes with the data you are fetching.
+func (v *View) GetDataAndLastIndex() (interface{}, uint64) {
+	v.dataLock.RLock()
+	defer v.dataLock.RUnlock()
+	return v.data, v.lastIndex
 }
 
 // poll queries the Consul instance for data using the fetch function, but also
@@ -129,7 +147,7 @@ func (v *View) fetch(doneCh chan<- struct{}, errCh chan<- error) {
 		opts := &dep.QueryOptions{
 			AllowStale: allowStale,
 			WaitTime:   defaultWaitTime,
-			WaitIndex:  v.LastIndex,
+			WaitIndex:  v.lastIndex,
 		}
 		data, rm, err := v.Dependency.Fetch(v.config.Clients, opts)
 		if err != nil {
@@ -160,26 +178,29 @@ func (v *View) fetch(doneCh chan<- struct{}, errCh chan<- error) {
 			allowStale = true
 		}
 
-		if rm.LastIndex == v.LastIndex {
+		if rm.LastIndex == v.lastIndex {
 			log.Printf("[DEBUG] (view) %s no new data (index was the same)", v.display())
 			continue
 		}
 
-		if rm.LastIndex < v.LastIndex {
+		v.dataLock.Lock()
+		if rm.LastIndex < v.lastIndex {
 			log.Printf("[DEBUG] (view) %s had a lower index, resetting", v.display())
-			v.LastIndex = 0
+			v.lastIndex = 0
+			v.dataLock.Unlock()
 			continue
 		}
+		v.lastIndex = rm.LastIndex
 
-		v.LastIndex = rm.LastIndex
-
-		if v.ReceivedData && reflect.DeepEqual(data, v.Data) {
+		if v.receivedData && reflect.DeepEqual(data, v.data) {
 			log.Printf("[DEBUG] (view) %s no new data (contents were the same)", v.display())
+			v.dataLock.Unlock()
 			continue
 		}
+		v.data = data
+		v.receivedData = true
+		v.dataLock.Unlock()
 
-		v.Data = data
-		v.ReceivedData = true
 		close(doneCh)
 		return
 	}

--- a/watch/view.go
+++ b/watch/view.go
@@ -54,17 +54,17 @@ func NewView(config *WatcherConfig, d dep.Dependency) (*View, error) {
 	}, nil
 }
 
-// GetData returns the most-recently-received data from Consul for this View.
-func (v *View) GetData() interface{} {
+// Data returns the most-recently-received data from Consul for this View.
+func (v *View) Data() interface{} {
 	v.dataLock.RLock()
 	defer v.dataLock.RUnlock()
 	return v.data
 }
 
-// GetDataAndLastIndex returns the most-recently-received data from Consul for
+// DataAndLastIndex returns the most-recently-received data from Consul for
 // this view, along with the last index. This is atomic so you will get the
 // index that goes with the data you are fetching.
-func (v *View) GetDataAndLastIndex() (interface{}, uint64) {
+func (v *View) DataAndLastIndex() (interface{}, uint64) {
 	v.dataLock.RLock()
 	defer v.dataLock.RUnlock()
 	return v.data, v.lastIndex

--- a/watch/view_test.go
+++ b/watch/view_test.go
@@ -201,8 +201,8 @@ func TestFetch_maxStale(t *testing.T) {
 	select {
 	case <-doneCh:
 		expected := "this is some fresh data"
-		if !reflect.DeepEqual(view.Data, expected) {
-			t.Errorf("expected %q to be %q", view.Data, expected)
+		if !reflect.DeepEqual(view.GetData(), expected) {
+			t.Errorf("expected %q to be %q", view.GetData(), expected)
 		}
 	case err := <-errCh:
 		t.Errorf("error while fetching: %s", err)
@@ -223,8 +223,8 @@ func TestFetch_savesView(t *testing.T) {
 	select {
 	case <-doneCh:
 		expected := "this is some data"
-		if !reflect.DeepEqual(view.Data, expected) {
-			t.Errorf("expected %q to be %q", view.Data, expected)
+		if !reflect.DeepEqual(view.GetData(), expected) {
+			t.Errorf("expected %q to be %q", view.GetData(), expected)
 		}
 	case err := <-errCh:
 		t.Errorf("error while fetching: %s", err)

--- a/watch/view_test.go
+++ b/watch/view_test.go
@@ -201,8 +201,8 @@ func TestFetch_maxStale(t *testing.T) {
 	select {
 	case <-doneCh:
 		expected := "this is some fresh data"
-		if !reflect.DeepEqual(view.GetData(), expected) {
-			t.Errorf("expected %q to be %q", view.GetData(), expected)
+		if !reflect.DeepEqual(view.Data(), expected) {
+			t.Errorf("expected %q to be %q", view.Data(), expected)
 		}
 	case err := <-errCh:
 		t.Errorf("error while fetching: %s", err)
@@ -223,8 +223,8 @@ func TestFetch_savesView(t *testing.T) {
 	select {
 	case <-doneCh:
 		expected := "this is some data"
-		if !reflect.DeepEqual(view.GetData(), expected) {
-			t.Errorf("expected %q to be %q", view.GetData(), expected)
+		if !reflect.DeepEqual(view.Data(), expected) {
+			t.Errorf("expected %q to be %q", view.Data(), expected)
 		}
 	case err := <-errCh:
 		t.Errorf("error while fetching: %s", err)


### PR DESCRIPTION
This is the consul-template side of https://github.com/hashicorp/consul-replicate/issues/29. The old `View` interface was dangerous in that it allowed the outside to fetch its `Data` when the fetching goroutine could be updating it (probably an atomic op to update a pointer, but still sketchy), and most importantly, another fetch could come along and update the `LastIndex` while you are processing an older chunk of data.

This hides all the data-related members and exposes them through accessors that do RW locking, and adds an atomic fetch of data and the last index that goes along with that data.