### PR TITLE
Use mapstructure decoder for os.FileMode

### DIFF
--- a/config.go
+++ b/config.go
@@ -405,6 +405,7 @@ func ParseConfig(path string) (*Config, error) {
 	metadata := new(mapstructure.Metadata)
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			StringToFileMode(),
 			watch.StringToWaitDurationHookFunc(),
 			mapstructure.StringToSliceHookFunc(","),
 			mapstructure.StringToTimeDurationHookFunc(),
@@ -650,7 +651,7 @@ type ConfigTemplate struct {
 	Destination    string        `json:"destination" mapstructure:"destination"`
 	Command        string        `json:"command,omitempty" mapstructure:"command"`
 	CommandTimeout time.Duration `json:"command_timeout,omitempty" mapstructure:"command_timeout"`
-	Perms          os.FileMode   `json:"perms,string" mapstructure:"perms"`
+	Perms          os.FileMode   `json:"perms" mapstructure:"perms"`
 	Backup         bool          `json:"backup" mapstructure:"backup"`
 	LeftDelim      string        `json:"left_delimiter" mapstructure:"left_delimiter"`
 	RightDelim     string        `json:"right_delimiter" mapstructure:"right_delimiter"`

--- a/mapstructure.go
+++ b/mapstructure.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"os"
+	"reflect"
+	"strconv"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+// StringToFileMode returns a function that converts strings to os.FileMode
+// value. This is designed to be used with mapstructure for parsing out a
+// filemode value.
+func StringToFileMode() mapstructure.DecodeHookFunc {
+	return func(
+		f reflect.Type,
+		t reflect.Type,
+		data interface{}) (interface{}, error) {
+		if f.Kind() != reflect.String {
+			return data, nil
+		}
+		if t != reflect.TypeOf(os.FileMode(0)) {
+			return data, nil
+		}
+
+		// Convert it by parsing
+		v, err := strconv.ParseUint(data.(string), 8, 12)
+		if err != nil {
+			return data, err
+		}
+		return os.FileMode(v), nil
+	}
+}

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+func TestStringToFileMode(t *testing.T) {
+	f := StringToFileMode()
+	strType := reflect.TypeOf("")
+	fmType := reflect.TypeOf(os.FileMode(0))
+	u32Type := reflect.TypeOf(uint32(0))
+
+	cases := []struct {
+		f, t     reflect.Type
+		data     interface{}
+		expected interface{}
+		err      bool
+	}{
+		{strType, fmType, "0600", os.FileMode(0600), false},
+		{strType, fmType, "4600", os.FileMode(04600), false},
+
+		// Prepends 0 automatically
+		{strType, fmType, "600", os.FileMode(0600), false},
+
+		// Invalid file mode
+		{strType, fmType, "12345", "12345", true},
+
+		// Invalid syntax
+		{strType, fmType, "abcd", "abcd", true},
+
+		// Different type
+		{strType, strType, "0600", "0600", false},
+		{strType, u32Type, "0600", "0600", false},
+	}
+
+	for i, tc := range cases {
+		actual, err := mapstructure.DecodeHookExec(f, tc.f, tc.t, tc.data)
+		if (err != nil) != tc.err {
+			t.Errorf("case %d: %s", i, err)
+		}
+		if !reflect.DeepEqual(actual, tc.expected) {
+			t.Errorf("case %d: expected %#v to be %#v", i, actual, tc.expected)
+		}
+	}
+}


### PR DESCRIPTION
This commit adds a new mapstructure function for automatically decoding into os.FileMode. The function expects the value to be a string in json or a string or int in hcl.

Fixes https://github.com/hashicorp/consul-template/issues/623

/cc @slackpad @cbednarski 