### PR TITLE
Remove the reaping functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ branches:
   only:
     - master
 
-script: make bootstrap test testrace
+script: make test testrace

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Usage
 | `max-stale`       | The maximum staleness of a query. If specified, Consul will distribute work among all servers instead of just the leader. The default value is 1s.
 | `once`            | Run Consul Template once and exit (as opposed to the default behavior of daemon). _(CLI-only)_
 | `pid-file`        | The path on disk to write Consul Template's PID file.
-| `reap`            | Control automatic reaping of child processes, useful if running as PID 1 in a Docker container. By default, if Consul Template detects that it is running as PID 1 it will automatically enable child process reaping. Setting this option to false disables this behavior, and setting it to true enables child process reaping regardless of Consul Template's PID.
 | `retry`           | The amount of time to wait if Consul returns an error when communicating with the API. The default value is 5 seconds.
 | `ssl`             | Use HTTPS while talking to Consul. Requires the Consul server to be configured to serve secure connections. The default value is false.
 | `ssl-ca-cert`     | Path to a CA certificate file, containing one or more CA certificates to use to validate the certificate sent by the consul server to us. This is a handy alternative to setting ```--ssl-verify=false``` if you are using your own CA.
@@ -129,10 +128,6 @@ token = "abcd1234"
 // wait for the cluster to become available, as is customary in distributed
 // systems.
 retry = "10s"
-
-// This option tells Consul Template to reap child processes. The default value
-// is false unless Consul Template is running as PID 1.
-reap = false
 
 // This is the maximum interval to allow "stale" data. By default, only the
 // Consul leader will respond to queries; any requests to a follower will

--- a/cli_test.go
+++ b/cli_test.go
@@ -491,23 +491,6 @@ func TestParseFlags_dry(t *testing.T) {
 	}
 }
 
-func TestParseFlags_reap(t *testing.T) {
-	cli := NewCLI(ioutil.Discard, ioutil.Discard)
-	config, _, _, _, err := cli.parseFlags([]string{
-		"-reap",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if config.Reap != true {
-		t.Errorf("expected reap to be true")
-	}
-	if !config.WasSet("reap") {
-		t.Errorf("expected reap to be set")
-	}
-}
-
 func TestParseFlags_version(t *testing.T) {
 	cli := NewCLI(ioutil.Discard, ioutil.Discard)
 	_, _, _, version, err := cli.parseFlags([]string{

--- a/config.go
+++ b/config.go
@@ -80,9 +80,6 @@ type Config struct {
 	// Deduplicate is used to configure the dedup settings
 	Deduplicate *DeduplicateConfig `mapstructure:"deduplicate"`
 
-	// Reap is used to configure automatic reaping of child processes.
-	Reap bool `mapstructure:"reap"`
-
 	// setKeys is the list of config keys that were set by the user.
 	setKeys map[string]struct{}
 }
@@ -175,7 +172,6 @@ func (c *Config) Copy() *Config {
 		}
 	}
 
-	config.Reap = c.Reap
 	config.setKeys = c.setKeys
 
 	return config
@@ -342,10 +338,6 @@ func (c *Config) Merge(config *Config) {
 		if config.WasSet("deduplicate.prefix") {
 			c.Deduplicate.Prefix = config.Deduplicate.Prefix
 		}
-	}
-
-	if config.WasSet("reap") {
-		c.Reap = config.Reap
 	}
 
 	if c.setKeys == nil {
@@ -558,7 +550,6 @@ func DefaultConfig() *Config {
 		MaxStale:        1 * time.Second,
 		Wait:            &watch.Wait{},
 		LogLevel:        logLevel,
-		Reap:            os.Getpid() == 1,
 		setKeys:         make(map[string]struct{}),
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -308,29 +308,6 @@ func TestMerge_wait(t *testing.T) {
 	}
 }
 
-func TestMerge_reap(t *testing.T) {
-	config := testConfig(`
-		reap = true
-	`, t)
-	if config.Reap != true {
-		t.Fatalf("reap should be true")
-	}
-
-	config.Merge(testConfig(`
-		reap = false
-	`, t))
-	if config.Reap != false {
-		t.Fatalf("reap should be false")
-	}
-
-	config.Merge(testConfig(`
-		reap = true
-	`, t))
-	if config.Reap != true {
-		t.Fatalf("reap should be true")
-	}
-}
-
 // There is a custom mapstructure function that tests this as well, so this is
 // more of an integration test to ensure we are parsing permissions correctly.
 func TestParseConfig_jsonFilePerms(t *testing.T) {
@@ -444,8 +421,6 @@ func TestParseConfig_correctValues(t *testing.T) {
 			prefix = "my-prefix/"
 			enabled = true
 		}
-
-		reap = true
   `), t)
 	defer test.DeleteTempfile(configFile, t)
 
@@ -517,7 +492,6 @@ func TestParseConfig_correctValues(t *testing.T) {
 			Enabled: true,
 			TTL:     15 * time.Second,
 		},
-		Reap:    true,
 		setKeys: config.setKeys,
 	}
 

--- a/runner_test.go
+++ b/runner_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -40,7 +39,7 @@ func TestNewRunner_initialize(t *testing.T) {
 		},
 	})
 
-	runner, err := NewRunner(config, dry, once, &sync.RWMutex{})
+	runner, err := NewRunner(config, dry, once)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,13 +103,13 @@ func TestNewRunner_badTemplate(t *testing.T) {
 		},
 	})
 
-	if _, err := NewRunner(config, false, false, &sync.RWMutex{}); err == nil {
+	if _, err := NewRunner(config, false, false); err == nil {
 		t.Fatal("expected error, but nothing was returned")
 	}
 }
 
 func TestReceive_addsToBrain(t *testing.T) {
-	runner, err := NewRunner(DefaultConfig(), false, false, &sync.RWMutex{})
+	runner, err := NewRunner(DefaultConfig(), false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +132,7 @@ func TestReceive_addsToBrain(t *testing.T) {
 }
 
 func TestReceive_storesBrain(t *testing.T) {
-	runner, err := NewRunner(DefaultConfig(), false, false, &sync.RWMutex{})
+	runner, err := NewRunner(DefaultConfig(), false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,7 +147,7 @@ func TestReceive_storesBrain(t *testing.T) {
 }
 
 func TestReceive_doesNotStoreIfNotWatching(t *testing.T) {
-	runner, err := NewRunner(DefaultConfig(), false, false, &sync.RWMutex{})
+	runner, err := NewRunner(DefaultConfig(), false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -174,7 +173,7 @@ func TestRun_noopIfMissingData(t *testing.T) {
 		},
 	})
 
-	runner, err := NewRunner(config, false, false, &sync.RWMutex{})
+	runner, err := NewRunner(config, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -207,7 +206,7 @@ func TestRun_dry(t *testing.T) {
 		},
 	})
 
-	runner, err := NewRunner(config, true, false, &sync.RWMutex{})
+	runner, err := NewRunner(config, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -257,7 +256,7 @@ func TestRun_singlePass(t *testing.T) {
 		},
 	})
 
-	runner, err := NewRunner(config, true, false, &sync.RWMutex{})
+	runner, err := NewRunner(config, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -294,7 +293,7 @@ func TestRun_singlePassDuplicates(t *testing.T) {
 		},
 	})
 
-	runner, err := NewRunner(config, true, false, &sync.RWMutex{})
+	runner, err := NewRunner(config, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -329,7 +328,7 @@ func TestRun_doublePass(t *testing.T) {
 		},
 	})
 
-	runner, err := NewRunner(config, true, false, &sync.RWMutex{})
+	runner, err := NewRunner(config, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -377,7 +376,7 @@ func TestRun_removesUnusedDependencies(t *testing.T) {
 		},
 	})
 
-	runner, err := NewRunner(config, true, false, &sync.RWMutex{})
+	runner, err := NewRunner(config, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -455,7 +454,7 @@ func TestRun_multipleTemplatesRunsCommands(t *testing.T) {
 		},
 	})
 
-	runner, err := NewRunner(config, false, false, &sync.RWMutex{})
+	runner, err := NewRunner(config, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -607,7 +606,7 @@ func TestRunner_quiescenceIntegrated(t *testing.T) {
 	`, consul.HTTPAddr, in[0].Name(), out[0].Name(),
 		in[1].Name(), out[1].Name()), t)
 
-	runner, err := NewRunner(config, false, false, &sync.RWMutex{})
+	runner, err := NewRunner(config, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -694,7 +693,7 @@ func TestRender_sameContentsDoesNotExecuteCommand(t *testing.T) {
 		},
 	})
 
-	runner, err := NewRunner(config, false, false, &sync.RWMutex{})
+	runner, err := NewRunner(config, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -881,7 +880,7 @@ func TestRun_doesNotExecuteCommandMissingDependencies(t *testing.T) {
 		},
 	})
 
-	runner, err := NewRunner(config, false, false, &sync.RWMutex{})
+	runner, err := NewRunner(config, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -921,7 +920,7 @@ func TestRun_executesCommand(t *testing.T) {
 		},
 	})
 
-	runner, err := NewRunner(config, false, false, &sync.RWMutex{})
+	runner, err := NewRunner(config, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -986,7 +985,7 @@ func TestRun_doesNotExecuteCommandMoreThanOnce(t *testing.T) {
 		},
 	})
 
-	runner, err := NewRunner(config, false, false, &sync.RWMutex{})
+	runner, err := NewRunner(config, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1035,7 +1034,7 @@ func TestRunner_pidCreate(t *testing.T) {
 		pid_file = "%s"
 	`, pidfile.Name()), t)
 
-	runner, err := NewRunner(config, false, false, &sync.RWMutex{})
+	runner, err := NewRunner(config, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1064,7 +1063,7 @@ func TestRunner_pidDelete(t *testing.T) {
 		pid_file = "%s"
 	`, pidfile.Name()), t)
 
-	runner, err := NewRunner(config, false, false, &sync.RWMutex{})
+	runner, err := NewRunner(config, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1124,7 +1123,7 @@ func TestRunner_onceAlreadyRenderedDoesNotHangOrRunCommands(t *testing.T) {
 		},
 	})
 
-	runner, err := NewRunner(config, false, true, &sync.RWMutex{})
+	runner, err := NewRunner(config, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1184,7 +1183,7 @@ func TestExecute_setsEnv(t *testing.T) {
 		}
 	`, t)
 
-	runner, err := NewRunner(config, false, false, &sync.RWMutex{})
+	runner, err := NewRunner(config, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1248,7 +1247,7 @@ func TestExecute_timeout(t *testing.T) {
 		}
 	`, t)
 
-	runner, err := NewRunner(config, false, false, &sync.RWMutex{})
+	runner, err := NewRunner(config, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1312,15 +1311,14 @@ func TestRunner_dedup(t *testing.T) {
 	config2.set("deduplicate.enabled")
 
 	// Create the runners
-	var reapLock sync.RWMutex
-	r1, err := NewRunner(config, false, false, &reapLock)
+	r1, err := NewRunner(config, false, false)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	go r1.Start()
 	defer r1.Stop()
 
-	r2, err := NewRunner(config2, false, false, &reapLock)
+	r2, err := NewRunner(config2, false, false)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}


### PR DESCRIPTION
Just as we did with the official Consul container, we are going to rely on services like dumb-init to handle child process reaping, not the go process itself.

/cc @slackpad