### PR TITLE
Return a map instead of an array for parseJSON

### DIFF
--- a/template_functions.go
+++ b/template_functions.go
@@ -607,7 +607,7 @@ func parseInt(s string) (int64, error) {
 // parseJSON returns a structure for valid JSON
 func parseJSON(s string) (interface{}, error) {
 	if s == "" {
-		return make([]interface{}, 0), nil
+		return map[string]interface{}{}, nil
 	}
 
 	var data interface{}

--- a/template_functions_test.go
+++ b/template_functions_test.go
@@ -1440,7 +1440,7 @@ func TestParseJSON_empty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := []interface{}{}
+	expected := map[string]interface{}{}
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("expected %#v to be %#v", result, expected)
 	}


### PR DESCRIPTION
The default function for parseJSON currently returns an array. This is problematic.

Fixes GH-635 because it makes using functions like `index` more difficult due to arrays being unable to have string indexes. This should be backwards compatible because one can still index a map using a string (thus treating it as an array).

/cc @slackpad