### PR TITLE
Ensure trailing slash and no leading slash

### DIFF
--- a/dependency/store_key_prefix.go
+++ b/dependency/store_key_prefix.go
@@ -163,6 +163,21 @@ func ParseStoreKeyPrefix(s string) (*StoreKeyPrefix, error) {
 
 	prefix, datacenter := m["prefix"], m["datacenter"]
 
+	// Empty prefix or nil prefix should default to "/"
+	if len(prefix) == 0 {
+		prefix = "/"
+	}
+
+	// Remove leading slash
+	if len(prefix) > 1 && prefix[0] == '/' {
+		prefix = prefix[1:len(prefix)]
+	}
+
+	// Ensure a trailing slash
+	if prefix[len(prefix)-1] != '/' {
+		prefix = fmt.Sprintf("%s/", prefix)
+	}
+
 	kpd := &StoreKeyPrefix{
 		rawKey:     s,
 		Prefix:     prefix,

--- a/dependency/store_key_prefix_test.go
+++ b/dependency/store_key_prefix_test.go
@@ -95,7 +95,7 @@ func TestParseStoreKeyPrefix_emptyString(t *testing.T) {
 		t.Errorf("expected %q to be %q", kpd.rawKey, "")
 	}
 
-	if kpd.Prefix != "" {
+	if kpd.Prefix != "/" {
 		t.Errorf("expected %q to be %q", kpd.Prefix, "")
 	}
 
@@ -114,7 +114,7 @@ func TestParseStoreKeyPrefix_name(t *testing.T) {
 		t.Errorf("expected %q to be %q", kpd.rawKey, "config/redis")
 	}
 
-	if kpd.Prefix != "config/redis" {
+	if kpd.Prefix != "config/redis/" {
 		t.Errorf("expected %q to be %q", kpd.Prefix, "config/redis")
 	}
 
@@ -133,7 +133,7 @@ func TestParseStoreKeyPrefix_nameColon(t *testing.T) {
 		t.Errorf("expected %q to be %q", kpd.rawKey, "config/redis:magic:80")
 	}
 
-	if kpd.Prefix != "config/redis:magic:80" {
+	if kpd.Prefix != "config/redis:magic:80/" {
 		t.Errorf("expected %q to be %q", kpd.Prefix, "config/redis:magic:80")
 	}
 
@@ -152,7 +152,7 @@ func TestParseStoreKeyPrefix_nameTagDataCenter(t *testing.T) {
 		t.Errorf("expected %q to be %q", kpd.rawKey, "config/redis@nyc1")
 	}
 
-	if kpd.Prefix != "config/redis" {
+	if kpd.Prefix != "config/redis/" {
 		t.Errorf("expected %q to be %q", kpd.Prefix, "config/redis")
 	}
 
@@ -171,11 +171,86 @@ func TestParseStoreKeyPrefix_dataCenter(t *testing.T) {
 		t.Errorf("expected %q to be %q", kpd.rawKey, "@nyc1")
 	}
 
-	if kpd.Prefix != "" {
-		t.Errorf("expected %q to be %q", kpd.Prefix, "")
+	if kpd.Prefix != "/" {
+		t.Errorf("expected %q to be %q", kpd.Prefix, "/")
 	}
 
 	if kpd.DataCenter != "nyc1" {
 		t.Errorf("expected %q to be %q", kpd.DataCenter, "nyc1")
+	}
+}
+
+func TestParseStoreKeyPrefix_leadingSlash(t *testing.T) {
+	kpd, err := ParseStoreKeyPrefix("/config")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if kpd.rawKey != "/config" {
+		t.Errorf("expected %q to be %q", kpd.rawKey, "/config")
+	}
+
+	if kpd.Prefix != "config/" {
+		t.Errorf("expected %q to be %q", kpd.Prefix, "config/")
+	}
+}
+
+func TestParseStoreKeyPrefix_tailingSlash(t *testing.T) {
+	kpd, err := ParseStoreKeyPrefix("config")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if kpd.rawKey != "config" {
+		t.Errorf("expected %q to be %q", kpd.rawKey, "config")
+	}
+
+	if kpd.Prefix != "config/" {
+		t.Errorf("expected %q to be %q", kpd.Prefix, "config/")
+	}
+}
+
+func TestParseStoreKeyPrefix_trailngSlashExist(t *testing.T) {
+	kpd, err := ParseStoreKeyPrefix("config/")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if kpd.rawKey != "config/" {
+		t.Errorf("expected %q to be %q", kpd.rawKey, "config/")
+	}
+
+	if kpd.Prefix != "config/" {
+		t.Errorf("expected %q to be %q", kpd.Prefix, "config/")
+	}
+}
+
+func TestParseStoreKeyPrefix_slash(t *testing.T) {
+	kpd, err := ParseStoreKeyPrefix("/")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if kpd.rawKey != "/" {
+		t.Errorf("expected %q to be %q", kpd.rawKey, "/")
+	}
+
+	if kpd.Prefix != "/" {
+		t.Errorf("expected %q to be %q", kpd.Prefix, "/")
+	}
+}
+
+func TestParseStoreKeyPrefix_slashSlash(t *testing.T) {
+	kpd, err := ParseStoreKeyPrefix("//")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if kpd.rawKey != "//" {
+		t.Errorf("expected %q to be %q", kpd.rawKey, "//")
+	}
+
+	if kpd.Prefix != "/" {
+		t.Errorf("expected %q to be %q", kpd.Prefix, "/")
 	}
 }


### PR DESCRIPTION
This relates to https://github.com/hashicorp/consul-replicate/issues/48 (and should fix it). StoreKeyPrefix always needs to be a folder, but Consul Replicate gets confused if it's not. This will ensure the API call looks like a "folder".