### PR TITLE
Allow commas in the prefix.

### DIFF
--- a/dependency/store_key_prefix.go
+++ b/dependency/store_key_prefix.go
@@ -142,7 +142,7 @@ func (d *StoreKeyPrefix) Stop() {
 func ParseStoreKeyPrefix(s string) (*StoreKeyPrefix, error) {
 	// a(/b(/c))(@datacenter)
 	re := regexp.MustCompile(`\A` +
-		`(?P<prefix>[[:word:]\.\:\-\/]+)?` +
+		`(?P<prefix>[[:word:],\.\:\-\/]+)?` +
 		`(@(?P<datacenter>[[:word:]\.\-]+))?` +
 		`\z`)
 	names := re.SubexpNames()


### PR DESCRIPTION
Spring Cloud Consul has adopted a default prefix that includes a comma
to separate the application name and profile. Prefixes end up looking like
'config/application,profile/'. This commit adds support for these prefixes.

See: http://cloud.spring.io/spring-cloud-consul/spring-cloud-consul.html

```
config/testApp,dev/
config/testApp/
config/application,dev/
config/application/
```