### PR TITLE
Maintain template-specified order

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -543,7 +543,7 @@ func (r *Runner) init() error {
 	}
 	r.watcher = watcher
 
-	templatesMap := make(map[string]*Template)
+	templates := make([]*Template, 0, len(r.config.ConfigTemplates))
 	ctemplatesMap := make(map[string][]*ConfigTemplate)
 
 	// Iterate over each ConfigTemplate, creating a new Template resource for each
@@ -556,8 +556,8 @@ func (r *Runner) init() error {
 			return err
 		}
 
-		if _, ok := templatesMap[tmpl.Path]; !ok {
-			templatesMap[tmpl.Path] = tmpl
+		if _, ok := ctemplatesMap[tmpl.Path]; !ok {
+			templates = append(templates, tmpl)
 		}
 
 		if _, ok := ctemplatesMap[tmpl.Path]; !ok {
@@ -568,10 +568,6 @@ func (r *Runner) init() error {
 
 	// Convert the map of templates (which was only used to ensure uniqueness)
 	// back into an array of templates.
-	templates := make([]*Template, 0, len(templatesMap))
-	for _, tmpl := range templatesMap {
-		templates = append(templates, tmpl)
-	}
 	r.templates = templates
 
 	r.renderedTemplates = make(map[string]struct{})

--- a/runner_test.go
+++ b/runner_test.go
@@ -60,6 +60,17 @@ func TestNewRunner_initialize(t *testing.T) {
 		t.Errorf("expected %d to be %d", len(runner.templates), 3)
 	}
 
+	// Check maintain order
+	if runner.templates[0].Path != in1.Name() {
+		t.Errorf("expected %s to be %s", runner.templates[0].Path, in1.Name())
+	}
+	if runner.templates[1].Path != in2.Name() {
+		t.Errorf("expected %s to be %s", runner.templates[1].Path, in1.Name())
+	}
+	if runner.templates[2].Path != in3.Name() {
+		t.Errorf("expected %s to be %s", runner.templates[2].Path, in1.Name())
+	}
+
 	if runner.renderedTemplates == nil {
 		t.Errorf("expected %#v to be %#v", runner.renderedTemplates, nil)
 	}


### PR DESCRIPTION
Previously order was not guaranteed because a map was used to ensure
uniqueness. This commit changes the behavior to maintain order, so the
order templates are specified in config are the order they are run.

Fixes GH-683