### PR TITLE
Add key_or_ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,18 @@ Query Consul for the value at the given key. If no key exists at the given path,
 Please note that Consul Template uses a multi-phase evaluation. During the first phase of evaluation, Consul Template will have no data from Consul and thus will _always_ fall back to the default value. Subsequent reads from Consul will pull in the real value from Consul (if the key exists) on the next template pass. This is important because it means that Consul Template will never "block" the rendering of a template due to a missing key from a `key_or_default`. Even if the key exists, if Consul has not yet returned data for the key, the
 default value will be used instead.
 
+##### `key_or_ignore`
+Query Consul for the value at the given key. If no key exists at the given path, no warning will be logged. The existing constraints and usage for keys apply:
+
+```liquid
+{{key_or_ignore "service/redis/maxconns"}}
+```
+
+In the event that the key is not found, logs like this will *not* be generated:
+```liquid
+[WARN] ("key(service/redis/maxconns)") Consul returned no data (does the path exist?)
+```
+
 ##### `ls`
 Query Consul for all top-level key-value pairs at the given prefix. If any of the values cannot be converted to a string-like value, an error will occur:
 

--- a/dependency/store_key.go
+++ b/dependency/store_key.go
@@ -20,6 +20,7 @@ type StoreKey struct {
 
 	defaultValue string
 	defaultGiven bool
+	suppressWarning bool
 
 	stopped bool
 	stopCh  chan struct{}
@@ -80,8 +81,10 @@ func (d *StoreKey) Fetch(clients *ClientSet, opts *QueryOptions) (interface{}, *
 			return d.defaultValue, rm, nil
 		}
 
-		log.Printf("[WARN] (%s) Consul returned no data (does the path exist?)",
-			d.Display())
+		if !d.suppressWarning {
+			log.Printf("[WARN] (%s) Consul returned no data (does the path exist?)",
+				d.Display())
+		}
 		return "", rm, nil
 	}
 
@@ -94,6 +97,16 @@ func (d *StoreKey) Fetch(clients *ClientSet, opts *QueryOptions) (interface{}, *
 func (d *StoreKey) SetDefault(s string) {
 	d.defaultGiven = true
 	d.defaultValue = s
+}
+
+// SetSuppressWarning is used to set whether to suppress logging of a key not being found.
+func (d *StoreKey) SetSuppressWarning(b bool) {
+	d.suppressWarning = b
+}
+
+// IsSuppressWarning returns whether the dependency has been set to ignore key not found warnings
+func (d *StoreKey) IsSuppressWarning() bool {
+	return d.suppressWarning
 }
 
 // CanShare returns a boolean if this dependency is shareable.

--- a/dependency/store_key_test.go
+++ b/dependency/store_key_test.go
@@ -60,6 +60,18 @@ func TestStoreKeyFetch_stopped(t *testing.T) {
 	}
 }
 
+func TestStoreKey_SetSuppressWarning(t *testing.T) {
+	dep, err := ParseStoreKey("conns")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dep.SetSuppressWarning(true)
+
+	if dep.suppressWarning != true {
+		t.Errorf("expected %q to be %q", dep.suppressWarning, true)
+	}
+}
+
 func TestStoreKeySetDefault(t *testing.T) {
 	dep, err := ParseStoreKey("conns")
 	if err != nil {

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -19,7 +19,7 @@ NAME=${NAME:-"$(basename $(pwd))"}
 echo "==> Updating dependencies..."
 
 echo "--> Making tmpdir..."
-tmpdir=$(mktemp -d)
+tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t 'tmpdir')
 function cleanup {
   rm -rf "${tmpdir}"
 }

--- a/template.go
+++ b/template.go
@@ -108,6 +108,7 @@ func funcMap(brain *Brain, used, missing map[string]dep.Dependency) template.Fun
 		"file":           fileFunc(brain, used, missing),
 		"key":            keyFunc(brain, used, missing),
 		"key_or_default": keyWithDefaultFunc(brain, used, missing),
+		"key_or_ignore":  keyOrIgnoreFunc(brain, used, missing),
 		"ls":             lsFunc(brain, used, missing),
 		"node":           nodeFunc(brain, used, missing),
 		"nodes":          nodesFunc(brain, used, missing),

--- a/template_test.go
+++ b/template_test.go
@@ -253,6 +253,7 @@ func TestExecute_renders(t *testing.T) {
 		key: {{ key "config/redis/maxconns" }}
 		key_or_default (exists): {{ key_or_default "config/redis/minconns" "100" }}
 		key_or_default (missing): {{ key_or_default "config/redis/maxconns" "200" }}
+		key_or_ignore: {{ key_or_ignore "config/redis/maxconns" }}
 		ls:{{ range ls "config/redis" }}
 			{{.Key}}={{.Value}}{{ end }}
 		node:{{ with node }}
@@ -501,6 +502,7 @@ func TestExecute_renders(t *testing.T) {
 		key: 5
 		key_or_default (exists): 150
 		key_or_default (missing): 200
+		key_or_ignore: 5
 		ls:
 			maxconns=5
 			minconns=2


### PR DESCRIPTION
This function works identically to `key`, except if the key is found no log will be generated.

The use case (for me) is templating config override files. In the case that a key is found, I would like to use it for setting a value. If the key is not found, I do not want to template anything (to fallback to the default), and wish to avoid logging a warning so as not to dilute warnings for mandatory keys.

With this function, I can achieve that with:
```
{{ with key_or_ignore "/mykey" }}{{printf "setting = %s" .}}{{end}}
``` 

This relates to GH-368
