### PR TITLE
Support checking if an interface slice contains a value.

### DIFF
--- a/template_functions.go
+++ b/template_functions.go
@@ -485,8 +485,21 @@ func in(l, v interface{}) (bool, error) {
 
 	switch lv.Kind() {
 	case reflect.Array, reflect.Slice:
+		// if the slice contains 'interface' elements, then the element needs to be extracted directly to examine its type,
+		// otherwise it will just resolve to 'interface'.
+		var interfaceSlice []interface{}
+		if reflect.TypeOf(l).Elem().Kind() == reflect.Interface {
+			interfaceSlice = l.([]interface{})
+		}
+
 		for i := 0; i < lv.Len(); i++ {
-			lvv := lv.Index(i)
+			var lvv reflect.Value
+			if interfaceSlice != nil {
+				lvv = reflect.ValueOf(interfaceSlice[i])
+			} else {
+				lvv = lv.Index(i)
+			}
+
 			switch lvv.Kind() {
 			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 				switch vv.Kind() {

--- a/template_functions_test.go
+++ b/template_functions_test.go
@@ -1270,6 +1270,29 @@ func TestIn_string(t *testing.T) {
 	}
 }
 
+func TestIn_string_interfaceSlice(t *testing.T) {
+	var list []interface{}
+	list = append(list, "a", "b", "c", 1, 2, 3)
+
+	result, err := in(list, "a")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result != true {
+		t.Errorf("expected %#v to contain %s", list, "a")
+	}
+
+	result, err = in(list, "z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result != false {
+		t.Errorf("expected %#v to not contain %s", list, "z")
+	}
+}
+
 func TestIn_int(t *testing.T) {
 	list := []int{1, 2, 3}
 
@@ -1292,6 +1315,29 @@ func TestIn_int(t *testing.T) {
 	}
 }
 
+func TestIn_int_interfaceSlice(t *testing.T) {
+	var list []interface{}
+	list = append(list, "a", "b", "c", 1, 2, 3)
+
+	result, err := in(list, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result != true {
+		t.Errorf("expected %#v to contain %s", list, "1")
+	}
+
+	result, err = in(list, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result != false {
+		t.Errorf("expected %#v to not contain %s", list, "5")
+	}
+}
+
 func TestIn_float32(t *testing.T) {
 	list := []float32{1.0, 2.0, 3.0}
 
@@ -1301,7 +1347,7 @@ func TestIn_float32(t *testing.T) {
 	}
 
 	if result != true {
-		t.Errorf("expected %#v to contain %s", list, "a")
+		t.Errorf("expected %#v to contain %s", list, "1.0")
 	}
 
 	result, err = in(list, 5.0)
@@ -1310,7 +1356,30 @@ func TestIn_float32(t *testing.T) {
 	}
 
 	if result != false {
-		t.Errorf("expected %#v to not contain %s", list, "z")
+		t.Errorf("expected %#v to not contain %s", list, "5.0")
+	}
+}
+
+func TestIn_float32_interfaceSlice(t *testing.T) {
+	var list []interface{}
+	list = append(list, "a", "b", "c", 1.0, 2.0, 3.0)
+
+	result, err := in(list, 1.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result != true {
+		t.Errorf("expected %#v to contain %s", list, "1.0")
+	}
+
+	result, err = in(list, 5.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result != false {
+		t.Errorf("expected %#v to not contain %s", list, "5.0")
 	}
 }
 


### PR DESCRIPTION
Previously, elements would just be detected as type `interface`. Extracting the element directly from the slice and then examining the value allows is true type to be revealed.

Fixes #708  