### PR TITLE
Do not require a trailing slash for store key prefix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: go
 
 go:
-  - 1.6
+  - 1.7
 
 branches:
   only:

--- a/dependency/store_key_prefix.go
+++ b/dependency/store_key_prefix.go
@@ -173,11 +173,6 @@ func ParseStoreKeyPrefix(s string) (*StoreKeyPrefix, error) {
 		prefix = prefix[1:len(prefix)]
 	}
 
-	// Ensure a trailing slash
-	if prefix[len(prefix)-1] != '/' {
-		prefix = fmt.Sprintf("%s/", prefix)
-	}
-
 	kpd := &StoreKeyPrefix{
 		rawKey:     s,
 		Prefix:     prefix,

--- a/dependency/store_key_prefix_test.go
+++ b/dependency/store_key_prefix_test.go
@@ -114,7 +114,7 @@ func TestParseStoreKeyPrefix_name(t *testing.T) {
 		t.Errorf("expected %q to be %q", kpd.rawKey, "config/redis")
 	}
 
-	if kpd.Prefix != "config/redis/" {
+	if kpd.Prefix != "config/redis" {
 		t.Errorf("expected %q to be %q", kpd.Prefix, "config/redis")
 	}
 
@@ -133,7 +133,7 @@ func TestParseStoreKeyPrefix_nameColon(t *testing.T) {
 		t.Errorf("expected %q to be %q", kpd.rawKey, "config/redis:magic:80")
 	}
 
-	if kpd.Prefix != "config/redis:magic:80/" {
+	if kpd.Prefix != "config/redis:magic:80" {
 		t.Errorf("expected %q to be %q", kpd.Prefix, "config/redis:magic:80")
 	}
 
@@ -152,7 +152,7 @@ func TestParseStoreKeyPrefix_nameTagDataCenter(t *testing.T) {
 		t.Errorf("expected %q to be %q", kpd.rawKey, "config/redis@nyc1")
 	}
 
-	if kpd.Prefix != "config/redis/" {
+	if kpd.Prefix != "config/redis" {
 		t.Errorf("expected %q to be %q", kpd.Prefix, "config/redis")
 	}
 
@@ -190,23 +190,8 @@ func TestParseStoreKeyPrefix_leadingSlash(t *testing.T) {
 		t.Errorf("expected %q to be %q", kpd.rawKey, "/config")
 	}
 
-	if kpd.Prefix != "config/" {
-		t.Errorf("expected %q to be %q", kpd.Prefix, "config/")
-	}
-}
-
-func TestParseStoreKeyPrefix_tailingSlash(t *testing.T) {
-	kpd, err := ParseStoreKeyPrefix("config")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if kpd.rawKey != "config" {
-		t.Errorf("expected %q to be %q", kpd.rawKey, "config")
-	}
-
-	if kpd.Prefix != "config/" {
-		t.Errorf("expected %q to be %q", kpd.Prefix, "config/")
+	if kpd.Prefix != "config" {
+		t.Errorf("expected %q to be %q", kpd.Prefix, "config")
 	}
 }
 


### PR DESCRIPTION
Fixes #706