### PR TITLE
Provide a mechanism for unwrapping a token

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ vault {
   // This value can also be specified via the environment variable VAULT_TOKEN.
   token = "abcd1234"
 
+  // This tells Consul Template that the provided token is actually a wrapped
+  // token that should be unwrapped using Vault's cubbyhole response wrapping
+  // before being used. Please see Vault's cubbyhole response wrapping
+  // documentation for more information.
+  unwrap_token = true
+
   // This option tells Consul Template to automatically renew the Vault token
   // given. If you are unfamiliar with Vault's architecture, Vault requires
   // tokens be renewed at some regular interval or they will be revoked. Consul

--- a/cli.go
+++ b/cli.go
@@ -403,6 +403,18 @@ func (cli *CLI) parseFlags(args []string) (*Config, bool, bool, bool, error) {
 		return nil
 	}), "log-level", "")
 
+	flags.Var((funcVar)(func(s string) error {
+		config.Vault.Token = s
+		config.set("vault.token")
+		return nil
+	}), "vault-token", "")
+
+	flags.Var((funcBoolVar)(func(b bool) error {
+		config.Vault.UnwrapToken = b
+		config.set("vault.unwrap_token")
+		return nil
+	}), "vault-unwrap-token", "")
+
 	flags.BoolVar(&once, "once", false, "")
 	flags.BoolVar(&dry, "dry", false, "")
 	flags.BoolVar(&version, "v", false, "")
@@ -553,6 +565,13 @@ Options:
 
   -token=<token>
       Sets the Consul API token
+
+  -vault-token=<token>
+      Sets the Vault API token
+
+  -vault-unwrap-token
+      Unwrap the provided Vault API token (see Vault documentation for more
+      information on this feature)
 
   -wait=<duration>
       Sets the 'min(:max)' amount of time to wait before writing a template (and

--- a/cli_test.go
+++ b/cli_test.go
@@ -553,6 +553,41 @@ func TestParseFlags_syslogFacility(t *testing.T) {
 	}
 }
 
+func TestParseFlags_vaultToken(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-vault-token", "abcd1234",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "abcd1234"
+	if config.Vault.Token != expected {
+		t.Errorf("expected %v to be %v", config.Vault.Token, expected)
+	}
+	if !config.WasSet("vault.token") {
+		t.Errorf("expected vault.token to be set")
+	}
+}
+
+func TestParseFlags_vaultUnwrapToken(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-vault-unwrap-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if config.Vault.UnwrapToken != true {
+		t.Errorf("expected %v to be %v", config.Vault.UnwrapToken, true)
+	}
+	if !config.WasSet("vault.unwrap_token") {
+		t.Errorf("expected vault.unwrap_token to be set")
+	}
+}
+
 func TestParseFlags_wait(t *testing.T) {
 	cli := NewCLI(ioutil.Discard, ioutil.Discard)
 	config, _, _, _, err := cli.parseFlags([]string{

--- a/config.go
+++ b/config.go
@@ -128,9 +128,10 @@ func (c *Config) Copy() *Config {
 
 	if c.Vault != nil {
 		config.Vault = &VaultConfig{
-			Address: c.Vault.Address,
-			Token:   c.Vault.Token,
-			Renew:   c.Vault.Renew,
+			Address:     c.Vault.Address,
+			Token:       c.Vault.Token,
+			UnwrapToken: c.Vault.UnwrapToken,
+			Renew:       c.Vault.Renew,
 		}
 
 		if c.Vault.SSL != nil {
@@ -249,6 +250,9 @@ func (c *Config) Merge(config *Config) {
 		}
 		if config.WasSet("vault.token") {
 			c.Vault.Token = config.Vault.Token
+		}
+		if config.WasSet("vault.unwrap_token") {
+			c.Vault.UnwrapToken = config.Vault.UnwrapToken
 		}
 		if config.WasSet("vault.renew") {
 			c.Vault.Renew = config.Vault.Renew
@@ -672,6 +676,10 @@ func DefaultConfig() *Config {
 		config.Vault.Token = v
 	}
 
+	if v := os.Getenv("VAULT_UNWRAP_TOKEN"); v != "" {
+		config.Vault.UnwrapToken = true
+	}
+
 	if v := os.Getenv("VAULT_CAPATH"); v != "" {
 		config.Vault.SSL.Cert = v
 	}
@@ -776,9 +784,10 @@ type ConfigTemplate struct {
 
 // VaultConfig is the configuration for connecting to a vault server.
 type VaultConfig struct {
-	Address string `mapstructure:"address"`
-	Token   string `mapstructure:"token" json:"-"`
-	Renew   bool   `mapstructure:"renew"`
+	Address     string `mapstructure:"address"`
+	Token       string `mapstructure:"token" json:"-"`
+	UnwrapToken bool   `mapstructure:"unwrap_token"`
+	Renew       bool   `mapstructure:"renew"`
 
 	// SSL indicates we should use a secure connection while talking to Vault.
 	SSL *SSLConfig `mapstructure:"ssl"`

--- a/config_test.go
+++ b/config_test.go
@@ -105,6 +105,7 @@ func TestMerge_vault(t *testing.T) {
 		vault {
 			address = "1.1.1.1"
 			token = "1"
+			unwrap_token = true
 			renew = true
 		}
 	`, t)
@@ -116,9 +117,10 @@ func TestMerge_vault(t *testing.T) {
 	`, t))
 
 	expected := &VaultConfig{
-		Address: "2.2.2.2",
-		Token:   "1",
-		Renew:   false,
+		Address:     "2.2.2.2",
+		Token:       "1",
+		UnwrapToken: true,
+		Renew:       false,
 		SSL: &SSLConfig{
 			Enabled: true,
 			Verify:  true,

--- a/dependency/client_set_test.go
+++ b/dependency/client_set_test.go
@@ -1,0 +1,53 @@
+package dependency
+
+import (
+	"testing"
+
+	"github.com/hashicorp/vault/api"
+)
+
+func TestClientSet_unwrapVaultToken(t *testing.T) {
+	clients, server := testVaultServer(t)
+	defer server.Stop()
+
+	vault := clients.vault.client
+
+	// Grab the original token
+	originalToken, err := vault.Auth().Token().LookupSelf()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a wrapped token
+	vault.SetWrappingLookupFunc(func(operation, path string) string {
+		return "30s"
+	})
+	wrappedToken, err := vault.Auth().Token().Create(&api.TokenCreateRequest{
+		Lease: "1h",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := clients.CreateVaultClient(&CreateVaultClientInput{
+		Address:     server.Address,
+		Token:       wrappedToken.WrapInfo.Token,
+		UnwrapToken: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	newToken := clients.vault.client.Token()
+
+	if newToken == originalToken.Data["id"] {
+		t.Errorf("expected %q to not be %q", newToken, originalToken.Data["id"])
+	}
+
+	if newToken == wrappedToken.WrapInfo.Token {
+		t.Errorf("expected %q to not be %q", newToken, wrappedToken.WrapInfo.Token)
+	}
+
+	if _, err := vault.Auth().Token().LookupSelf(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -65,7 +65,8 @@ func testConsulServer(t *testing.T) (*ClientSet, *testutil.TestServer) {
 }
 
 type vaultServer struct {
-	Token string
+	Address string
+	Token   string
 
 	core *vault.Core
 	ln   net.Listener
@@ -103,5 +104,12 @@ func testVaultServer(t *testing.T) (*ClientSet, *vaultServer) {
 		t.Fatal(err)
 	}
 
-	return clients, &vaultServer{Token: token, core: core, ln: ln}
+	server := &vaultServer{
+		Address: addr,
+		Token:   token,
+		core:    core,
+		ln:      ln,
+	}
+
+	return clients, server
 }

--- a/runner.go
+++ b/runner.go
@@ -1060,13 +1060,14 @@ func newClientSet(config *Config) (*dep.ClientSet, error) {
 	}
 
 	if err := clients.CreateVaultClient(&dep.CreateVaultClientInput{
-		Address:    config.Vault.Address,
-		Token:      config.Vault.Token,
-		SSLEnabled: config.Vault.SSL.Enabled,
-		SSLVerify:  config.Vault.SSL.Verify,
-		SSLCert:    config.Vault.SSL.Cert,
-		SSLKey:     config.Vault.SSL.Key,
-		SSLCACert:  config.Vault.SSL.CaCert,
+		Address:     config.Vault.Address,
+		Token:       config.Vault.Token,
+		UnwrapToken: config.Vault.UnwrapToken,
+		SSLEnabled:  config.Vault.SSL.Enabled,
+		SSLVerify:   config.Vault.SSL.Verify,
+		SSLCert:     config.Vault.SSL.Cert,
+		SSLKey:      config.Vault.SSL.Key,
+		SSLCACert:   config.Vault.SSL.CaCert,
 	}); err != nil {
 		return nil, fmt.Errorf("runner: %s", err)
 	}

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -26,7 +26,7 @@ if [ -z $NOBUILD ]; then
     --rm \
     --workdir="/go/src/github.com/hashicorp/${NAME}" \
     --volume="$(pwd):/go/src/github.com/hashicorp/${NAME}" \
-    golang:1.6.2 /bin/sh -c "make bootstrap && make bin"
+    golang:1.7 /bin/sh -c "make bootstrap && make bin"
 fi
 
 # Generate the tag.


### PR DESCRIPTION
This PR adds a method for unwrapping a wrapped token. The user must specify that the provided token is wrapped either via the CLI or configuration file.

Fixes GH-712