### PR TITLE
Remove AllRendered and push the logic to the user and expose more detail

### DIFF
--- a/manager/runner.go
+++ b/manager/runner.go
@@ -344,6 +344,7 @@ func (r *Runner) TemplateRenderedCh() <-chan struct{} {
 func (r *Runner) RenderEvents() map[string]*RenderEvent {
 	r.renderEventsLock.RLock()
 	defer r.renderEventsLock.RUnlock()
+
 	times := make(map[string]*RenderEvent, len(r.renderEvents))
 	for k, v := range r.renderEvents {
 		times[k] = v
@@ -769,17 +770,23 @@ func (r *Runner) allTemplatesRendered() bool {
 // stores it as would have been rendered.
 func (r *Runner) markRenderTime(tmplID string, didRender bool) {
 	r.renderEventsLock.Lock()
+	defer r.renderEventsLock.Unlock()
+
+	// Get the current time
+	now := time.Now()
+
+	// Create the event for the template ID if it is the first time
 	event, ok := r.renderEvents[tmplID]
 	if !ok {
 		event = &RenderEvent{}
 		r.renderEvents[tmplID] = event
 	}
+
 	if didRender {
-		event.LastDidRender = time.Now()
+		event.LastDidRender = now
 	} else {
-		event.LastWouldRender = time.Now()
+		event.LastWouldRender = now
 	}
-	r.renderEventsLock.Unlock()
 }
 
 // Render accepts a Template and a destination on disk. The first return

--- a/template/template.go
+++ b/template/template.go
@@ -56,7 +56,7 @@ func NewTemplate(path, contents, leftDelim, rightDelim string) (*Template, error
 
 // ID returns an identifier for the template
 func (t *Template) ID() string {
-	return t.Path + t.HexMD5
+	return t.HexMD5
 }
 
 // Execute evaluates this template in the context of the given brain.


### PR DESCRIPTION
This PR address the fact that the destination is not always needed (in dry mode) and accounts for the fact that wouldRender is triggered even if the content is empty, this makes the old AllRendered implementation broken.

This current implementation gives the caller of the `Runner` all the information they need to track it themselves