### PR TITLE
Issue a blocking query for "key"

### DIFF
--- a/dependency/file.go
+++ b/dependency/file.go
@@ -48,7 +48,7 @@ func (d *File) Fetch(clients *ClientSet, opts *QueryOptions) (interface{}, *Resp
 	}
 
 	if err != nil {
-		return "", nil, fmt.Errorf("file: error watching: %s", err)
+		return nil, nil, fmt.Errorf("file: error watching: %s", err)
 	}
 
 	d.mutex.Lock()

--- a/watch/view.go
+++ b/watch/view.go
@@ -197,6 +197,13 @@ func (v *View) fetch(doneCh chan<- struct{}, errCh chan<- error) {
 			v.dataLock.Unlock()
 			continue
 		}
+
+		if data == nil {
+			log.Printf("[DEBUG](view) %s data was not present", v.display())
+			v.dataLock.Unlock()
+			continue
+		}
+
 		v.data = data
 		v.receivedData = true
 		v.dataLock.Unlock()


### PR DESCRIPTION
This fixes a commonly confusing issue where the `key` function does not actually issue a blocking query. This is because users have, in the past, used the API like this:

    {{ if key "foo" }}
      feature flag active
    {{ else }}
      default
    {{ end }}

In this model, the existence of a key is the check. With the introduction of `key_or_default`, it makes sense to return `key` to be a blocking query.

/cc @dadgar @slackpad 