### PR TITLE
Adding first-class support for an explicit TLS server name for Vault/Consul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ NEW FEATURES:
       See the breaking change notice before for more information about the
       motivation for this change.
 
+  * Add full support for `VAULT_TLS_SERVER_NAME` (also copied to child process
+      environment), and `server_name` option for TLS configurations to allow
+      specification of the expected certificate common name.
+
 BREAKING CHANGES:
 
   * Consul Template now **blocks on `key` queries**. The previous behavior was

--- a/config/config.go
+++ b/config/config.go
@@ -139,22 +139,24 @@ func (c *Config) Copy() *Config {
 
 		if c.Vault.SSL != nil {
 			config.Vault.SSL = &SSLConfig{
-				Enabled: c.Vault.SSL.Enabled,
-				Verify:  c.Vault.SSL.Verify,
-				Cert:    c.Vault.SSL.Cert,
-				Key:     c.Vault.SSL.Key,
-				CaCert:  c.Vault.SSL.CaCert,
+				Enabled:    c.Vault.SSL.Enabled,
+				Verify:     c.Vault.SSL.Verify,
+				Cert:       c.Vault.SSL.Cert,
+				Key:        c.Vault.SSL.Key,
+				CaCert:     c.Vault.SSL.CaCert,
+				ServerName: c.Vault.SSL.ServerName,
 			}
 		}
 	}
 
 	if c.SSL != nil {
 		config.SSL = &SSLConfig{
-			Enabled: c.SSL.Enabled,
-			Verify:  c.SSL.Verify,
-			Cert:    c.SSL.Cert,
-			Key:     c.SSL.Key,
-			CaCert:  c.SSL.CaCert,
+			Enabled:    c.SSL.Enabled,
+			Verify:     c.SSL.Verify,
+			Cert:       c.SSL.Cert,
+			Key:        c.SSL.Key,
+			CaCert:     c.SSL.CaCert,
+			ServerName: c.SSL.ServerName,
 		}
 	}
 
@@ -284,6 +286,9 @@ func (c *Config) Merge(config *Config) {
 			if config.WasSet("vault.ssl.enabled") {
 				c.Vault.SSL.Enabled = config.Vault.SSL.Enabled
 			}
+			if config.WasSet("vault.ssl.server_name") {
+				c.Vault.SSL.ServerName = config.Vault.SSL.ServerName
+			}
 		}
 	}
 
@@ -326,6 +331,9 @@ func (c *Config) Merge(config *Config) {
 		}
 		if config.WasSet("ssl.enabled") {
 			c.SSL.Enabled = config.SSL.Enabled
+		}
+		if config.WasSet("ssl.server_name") {
+			c.SSL.ServerName = config.SSL.ServerName
 		}
 	}
 
@@ -721,6 +729,10 @@ func DefaultConfig() *Config {
 		config.Vault.SSL.Verify = false
 	}
 
+	if v := os.Getenv("VAULT_TLS_SERVER_NAME"); v != "" {
+		config.Vault.SSL.ServerName = v
+	}
+
 	return config
 }
 
@@ -784,11 +796,12 @@ type DeduplicateConfig struct {
 
 // SSLConfig is the configuration for SSL.
 type SSLConfig struct {
-	Enabled bool   `mapstructure:"enabled"`
-	Verify  bool   `mapstructure:"verify"`
-	Cert    string `mapstructure:"cert"`
-	Key     string `mapstructure:"key"`
-	CaCert  string `mapstructure:"ca_cert"`
+	Enabled    bool   `mapstructure:"enabled"`
+	Verify     bool   `mapstructure:"verify"`
+	Cert       string `mapstructure:"cert"`
+	Key        string `mapstructure:"key"`
+	CaCert     string `mapstructure:"ca_cert"`
+	ServerName string `mapstructure:"server_name"`
 }
 
 // SyslogConfig is the configuration for syslog.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -131,16 +131,18 @@ func TestMerge_vaultSSL(t *testing.T) {
 		vault {
 			ssl {
 				enabled = false
+				server_name = "vault.local"
 			}
 		}
 	`))
 
 	expected := &VaultConfig{
 		SSL: &SSLConfig{
-			Enabled: false,
-			Verify:  true,
-			Cert:    "1.pem",
-			CaCert:  "ca-1.pem",
+			Enabled:    false,
+			Verify:     true,
+			Cert:       "1.pem",
+			CaCert:     "ca-1.pem",
+			ServerName: "vault.local",
 		},
 	}
 
@@ -186,14 +188,16 @@ func TestMerge_SSL(t *testing.T) {
 	config.Merge(Must(`
 		ssl {
 			enabled = false
+			server_name = "consul.local"
 		}
 	`))
 
 	expected := &SSLConfig{
-		Enabled: false,
-		Verify:  true,
-		Cert:    "1.pem",
-		CaCert:  "ca-1.pem",
+		Enabled:    false,
+		Verify:     true,
+		Cert:       "1.pem",
+		CaCert:     "ca-1.pem",
+		ServerName: "consul.local",
 	}
 
 	if !reflect.DeepEqual(config.SSL, expected) {
@@ -445,10 +449,11 @@ func TestParse_correctValues(t *testing.T) {
 		}
 
 		ssl {
-			enabled = true
-			verify  = false
-			cert    = "c1.pem"
-			ca_cert = "c2.pem"
+			enabled     = true
+			verify      = false
+			cert        = "c1.pem"
+			ca_cert     = "c2.pem"
+			server_name = "consul.local"
 		}
 
 		syslog {
@@ -512,10 +517,11 @@ func TestParse_correctValues(t *testing.T) {
 			Password: "test",
 		},
 		SSL: &SSLConfig{
-			Enabled: true,
-			Verify:  false,
-			Cert:    "c1.pem",
-			CaCert:  "c2.pem",
+			Enabled:    true,
+			Verify:     false,
+			Cert:       "c1.pem",
+			CaCert:     "c2.pem",
+			ServerName: "consul.local",
 		},
 		Syslog: &SyslogConfig{
 			Enabled:  true,

--- a/dependency/client_set.go
+++ b/dependency/client_set.go
@@ -47,6 +47,7 @@ type CreateConsulClientInput struct {
 	SSLCert      string
 	SSLKey       string
 	SSLCACert    string
+	ServerName   string
 }
 
 // CreateVaultClientInput is used as input to the CreateVaultClient function.
@@ -59,6 +60,7 @@ type CreateVaultClientInput struct {
 	SSLCert     string
 	SSLKey      string
 	SSLCACert   string
+	ServerName  string
 }
 
 // NewClientSet creates a new client set that is ready to accept clients.
@@ -135,7 +137,11 @@ func (c *ClientSet) CreateConsulClient(i *CreateConsulClientInput) error {
 		tlsConfig.BuildNameToCertificate()
 
 		// SSL verification
-		if !i.SSLVerify {
+		if i.ServerName != "" {
+			tlsConfig.ServerName = i.ServerName
+			tlsConfig.InsecureSkipVerify = false
+			log.Printf("[DEBUG] (clients) using explicit consul TLS server host name: %s", tlsConfig.ServerName)
+		} else if !i.SSLVerify {
 			log.Printf("[WARN] (clients) disabling consul SSL verification")
 			tlsConfig.InsecureSkipVerify = true
 		}
@@ -213,7 +219,11 @@ func (c *ClientSet) CreateVaultClient(i *CreateVaultClientInput) error {
 		tlsConfig.BuildNameToCertificate()
 
 		// SSL verification
-		if !i.SSLVerify {
+		if i.ServerName != "" {
+			tlsConfig.ServerName = i.ServerName
+			tlsConfig.InsecureSkipVerify = false
+			log.Printf("[DEBUG] (clients) using explicit vault TLS server host name: %s", tlsConfig.ServerName)
+		} else if !i.SSLVerify {
 			log.Printf("[WARN] (clients) disabling vault SSL verification")
 			tlsConfig.InsecureSkipVerify = true
 		}

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -873,6 +873,10 @@ func (r *Runner) execute(command string, timeout time.Duration) error {
 		customEnv["VAULT_CACERT"] = r.config.Vault.SSL.CaCert
 	}
 
+	if r.Config.Vault.SSL.ServerName != "" {
+		customEnv["VAULT_TLS_SERVER_NAME"] = r.Config.Vault.SSL.ServerName
+	}
+
 	currentEnv := os.Environ()
 	cmdEnv := make([]string, len(currentEnv), len(currentEnv)+len(customEnv))
 	copy(cmdEnv, currentEnv)
@@ -1162,6 +1166,7 @@ func newClientSet(config *config.Config) (*dep.ClientSet, error) {
 		SSLCert:      config.SSL.Cert,
 		SSLKey:       config.SSL.Key,
 		SSLCACert:    config.SSL.CaCert,
+		ServerName:   config.SSL.ServerName,
 	}); err != nil {
 		return nil, fmt.Errorf("runner: %s", err)
 	}
@@ -1175,6 +1180,7 @@ func newClientSet(config *config.Config) (*dep.ClientSet, error) {
 		SSLCert:     config.Vault.SSL.Cert,
 		SSLKey:      config.Vault.SSL.Key,
 		SSLCACert:   config.Vault.SSL.CaCert,
+		ServerName:  config.Vault.SSL.ServerName,
 	}); err != nil {
 		return nil, fmt.Errorf("runner: %s", err)
 	}


### PR DESCRIPTION
Vault and Consul provide options to allow the specification of an expected server name in a certificate that is different to the provided address.

When using `https://vault.service.consul` and `https://consul.service.consul`, for example, (not to mention variants of these), using a fixed name creates issues with redirects (Vault), public certificate authority certificates (due to private naming) and private-IP-based certificate alternate names. Vault provides the `VAULT_TLS_SERVER_NAME` environment variable and Consul provides the `server_name` configuration option to address these scenarios.

Partial support for `VAULT_TLS_SERVER_NAME` was added implicitly by upgrading the Vault client. This PR extends support to allow values to be placed in configuration and to push `VAULT_TLS_SERVER_NAME` into child process environments.

We are currently working on implementing full TLS features in our own environment and so do not yet have a way to effectively test this PR ourselves. Please review, provide feedback and merge when possible.

Thanks,

Steve