### PR TITLE
expose and document toTOML function added in #675

### DIFF
--- a/README.md
+++ b/README.md
@@ -1012,6 +1012,22 @@ Takes the argument as a string and converts it to titlecase.
 
 See Go's [strings.Title()](http://golang.org/pkg/strings/#Title) for more information.
 
+##### `toTOML`
+Takes the result from a `tree` or `ls` call and converts it into a TOML object.
+
+```liquid
+{{ tree "config" | explode | toTOML }}
+/*
+maxconns = "5"
+minconns = "2"
+
+[admin]
+  port = "1134"
+*/
+```
+
+Note: This functionality should be considered final. If you need to manipulate keys, combine values, or perform mutations, that should be done _outside_ of Consul. In order to keep the API scope limited, we likely will not accept Pull Requests that focus on customizing the `toTOML` functionality.
+
 ##### `toUpper`
 Takes the argument as a string and converts it to uppercase.
 

--- a/template/template.go
+++ b/template/template.go
@@ -161,6 +161,7 @@ func funcMap(brain *Brain, used, missing map[string]dep.Dependency) template.Fun
 		"toJSON":          toJSON,
 		"toJSONPretty":    toJSONPretty,
 		"toTitle":         toTitle,
+		"toTOML":          toTOML,
 		"toUpper":         toUpper,
 		"toYAML":          toYAML,
 		"split":           split,

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -365,6 +365,8 @@ func TestExecute_renders(t *testing.T) {
 		toJSONPretty:
 {{ tree "config/redis" | explode | toJSONPretty }}
 		toTitle: {{ file "/path/to/file" | toTitle }}
+		toTOML:
+{{ tree "config/redis" | explode | toTOML }}
 		toUpper: {{ file "/path/to/file" | toUpper }}
 		toYAML:
 {{ tree "config/redis" | explode | toYAML }}
@@ -655,6 +657,12 @@ func TestExecute_renders(t *testing.T) {
   "minconns": "2"
 }
 		toTitle: Some Content
+		toTOML:
+maxconns = "5"
+minconns = "2"
+
+[admin]
+  port = "1134"
 		toUpper: SOME CONTENT
 		toYAML:
 admin:


### PR DESCRIPTION
I noticed this function was added recently, but I wasn't able to actually use it.