### PR TITLE
Add CAPath config to SSL and use when creating Consul/Vault clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,10 @@ ssl {
   // useful for self-signed certificates or for organizations using their own
   // internal certificate authority.
   ca_cert = "/path/to/ca"
+
+  // This is the path to a directory of PEM-encoded CA cert files. If both
+  // `ca_cert` and `ca_path` is specified, `ca_cert` is preferred.
+  ca_path = "path/to/certs/"
 }
 
 // This block defines the configuration for connecting to a syslog server for

--- a/config/config.go
+++ b/config/config.go
@@ -144,6 +144,7 @@ func (c *Config) Copy() *Config {
 				Cert:       c.Vault.SSL.Cert,
 				Key:        c.Vault.SSL.Key,
 				CaCert:     c.Vault.SSL.CaCert,
+				CaPath:     c.Vault.SSL.CaPath,
 				ServerName: c.Vault.SSL.ServerName,
 			}
 		}
@@ -156,6 +157,7 @@ func (c *Config) Copy() *Config {
 			Cert:       c.SSL.Cert,
 			Key:        c.SSL.Key,
 			CaCert:     c.SSL.CaCert,
+			CaPath:     c.SSL.CaPath,
 			ServerName: c.SSL.ServerName,
 		}
 	}
@@ -283,6 +285,10 @@ func (c *Config) Merge(config *Config) {
 				c.Vault.SSL.CaCert = config.Vault.SSL.CaCert
 				c.Vault.SSL.Enabled = true
 			}
+			if config.WasSet("vault.ssl.ca_path") {
+				c.Vault.SSL.CaPath = config.Vault.SSL.CaPath
+				c.Vault.SSL.Enabled = true
+			}
 			if config.WasSet("vault.ssl.enabled") {
 				c.Vault.SSL.Enabled = config.Vault.SSL.Enabled
 			}
@@ -327,6 +333,10 @@ func (c *Config) Merge(config *Config) {
 		}
 		if config.WasSet("ssl.ca_cert") {
 			c.SSL.CaCert = config.SSL.CaCert
+			c.SSL.Enabled = true
+		}
+		if config.WasSet("ssl.ca_path") {
+			c.SSL.CaPath = config.SSL.CaPath
 			c.SSL.Enabled = true
 		}
 		if config.WasSet("ssl.enabled") {
@@ -801,6 +811,7 @@ type SSLConfig struct {
 	Cert       string `mapstructure:"cert"`
 	Key        string `mapstructure:"key"`
 	CaCert     string `mapstructure:"ca_cert"`
+	CaPath     string `mapstructure:"ca_path"`
 	ServerName string `mapstructure:"server_name"`
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -108,6 +108,7 @@ func TestMerge_vault(t *testing.T) {
 			Verify:  true,
 			Cert:    "",
 			CaCert:  "",
+			CaPath:  "",
 		},
 	}
 
@@ -124,6 +125,7 @@ func TestMerge_vaultSSL(t *testing.T) {
 				verify = true
 				cert = "1.pem"
 				ca_cert = "ca-1.pem"
+				ca_path = "/path/to/certs/"
 			}
 		}
 	`)
@@ -142,6 +144,7 @@ func TestMerge_vaultSSL(t *testing.T) {
 			Verify:     true,
 			Cert:       "1.pem",
 			CaCert:     "ca-1.pem",
+			CaPath:     "/path/to/certs/",
 			ServerName: "vault.local",
 		},
 	}
@@ -183,6 +186,7 @@ func TestMerge_SSL(t *testing.T) {
 			verify  = true
 			cert    = "1.pem"
 			ca_cert = "ca-1.pem"
+			ca_path = "/path/to/certs/"
 		}
 	`)
 	config.Merge(Must(`
@@ -197,6 +201,7 @@ func TestMerge_SSL(t *testing.T) {
 		Verify:     true,
 		Cert:       "1.pem",
 		CaCert:     "ca-1.pem",
+		CaPath:     "/path/to/certs/",
 		ServerName: "consul.local",
 	}
 
@@ -453,6 +458,7 @@ func TestParse_correctValues(t *testing.T) {
 			verify      = false
 			cert        = "c1.pem"
 			ca_cert     = "c2.pem"
+			ca_path     = "/path/to/certs/"
 			server_name = "consul.local"
 		}
 
@@ -509,6 +515,7 @@ func TestParse_correctValues(t *testing.T) {
 				Verify:  true,
 				Cert:    "",
 				CaCert:  "",
+				CaPath:  "",
 			},
 		},
 		Auth: &AuthConfig{
@@ -521,6 +528,7 @@ func TestParse_correctValues(t *testing.T) {
 			Verify:     false,
 			Cert:       "c1.pem",
 			CaCert:     "c2.pem",
+			CaPath:     "/path/to/certs/",
 			ServerName: "consul.local",
 		},
 		Syslog: &SyslogConfig{
@@ -598,6 +606,7 @@ func TestParse_ssh_key_should_enable_ssl(t *testing.T) {
 			verify  = true
 			cert    = "1.pem"
 			ca_cert = "ca-1.pem"
+			ca_path = "/path/to/certs"
 		}
 	`)
 
@@ -607,6 +616,7 @@ func TestParse_ssh_key_should_enable_ssl(t *testing.T) {
 		Cert:    "1.pem",
 		Key:     "private-key.pem",
 		CaCert:  "ca-1.pem",
+		CaPath:  "/path/to/certs",
 	}
 
 	if !reflect.DeepEqual(config.SSL, expected) {

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -866,7 +866,15 @@ func (r *Runner) execute(command string, timeout time.Duration) error {
 	}
 
 	if r.config.Vault.SSL.Cert != "" {
-		customEnv["VAULT_CAPATH"] = r.config.Vault.SSL.Cert
+		customEnv["VAULT_CLIENT_CERT"] = r.config.Vault.SSL.Cert
+	}
+
+	if r.config.Vault.SSL.Key != "" {
+		customEnv["VAULT_CLIENT_KEY"] = r.config.Vault.SSL.Key
+	}
+
+	if r.config.Vault.SSL.CaPath != "" {
+		customEnv["VAULT_CAPATH"] = r.config.Vault.SSL.CaPath
 	}
 
 	if r.config.Vault.SSL.CaCert != "" {
@@ -1166,6 +1174,7 @@ func newClientSet(config *config.Config) (*dep.ClientSet, error) {
 		SSLCert:      config.SSL.Cert,
 		SSLKey:       config.SSL.Key,
 		SSLCACert:    config.SSL.CaCert,
+		SSLCAPath:    config.SSL.CaPath,
 		ServerName:   config.SSL.ServerName,
 	}); err != nil {
 		return nil, fmt.Errorf("runner: %s", err)
@@ -1180,6 +1189,7 @@ func newClientSet(config *config.Config) (*dep.ClientSet, error) {
 		SSLCert:     config.Vault.SSL.Cert,
 		SSLKey:      config.Vault.SSL.Key,
 		SSLCACert:   config.Vault.SSL.CaCert,
+		SSLCAPath:   config.Vault.SSL.CaPath,
 		ServerName:  config.Vault.SSL.ServerName,
 	}); err != nil {
 		return nil, fmt.Errorf("runner: %s", err)


### PR DESCRIPTION
This PR also fixes the Vault environment variables set during exec