### PR TITLE
Send signal to watching applications on would render

### DIFF
--- a/manager/runner.go
+++ b/manager/runner.go
@@ -427,7 +427,7 @@ func (r *Runner) Signal(s os.Signal) error {
 func (r *Runner) Run() error {
 	log.Printf("[INFO] (runner) running")
 
-	var renderedAny bool
+	var wouldRenderAny, renderedAny bool
 	var commands []*config.ConfigTemplate
 	depsMap := make(map[string]dep.Dependency)
 
@@ -541,6 +541,9 @@ func (r *Runner) Run() error {
 				// Make a note that we have rendered this template (required for once
 				// mode and just generally nice for debugging purposes).
 				r.markRenderTime(tmpl.ID(), false)
+
+				// Record that at least one template would have been rendered.
+				wouldRenderAny = true
 			}
 
 			// If we _actually_ rendered the template to disk, we want to run the
@@ -572,7 +575,7 @@ func (r *Runner) Run() error {
 	}
 
 	// Check if we need to deliver any rendered signals
-	if renderedAny {
+	if wouldRenderAny || renderedAny {
 		// Send the signal that a template got rendered
 		select {
 		case r.renderedCh <- struct{}{}:


### PR DESCRIPTION
Also saw this panic once during testing. It is unrelated but you may want to look at it:

```
panic: Fail in goroutine after TestDatacentersFetch_blocks has completed

goroutine 473 [running]:
panic(0x963060, 0xc4203a8aa0)
        /usr/local/go/src/runtime/panic.go:500 +0x1a1
testing.(*common).Fail(0xc42025fb00)
        /usr/local/go/src/testing/testing.go:412 +0x11f
testing.(*common).FailNow(0xc42025fb00)
        /usr/local/go/src/testing/testing.go:431 +0x2b
testing.(*common).Fatal(0xc42025fb00, 0xc42035df60, 0x1, 0x1)
        /usr/local/go/src/testing/testing.go:490 +0x6f
github.com/hashicorp/consul-template/dependency.TestDatacentersFetch_blocks.func1(0xc4204d4480, 0xc4204d4330, 0xc42025fb00, 0xc420372300)
        /Users/adadgar/Projects/go/src/github.com/hashicorp/consul-template/dependency/datacenters_test.go:41 +0xf5
created by github.com/hashicorp/consul-template/dependency.TestDatacentersFetch_blocks
        /Users/adadgar/Projects/go/src/github.com/hashicorp/consul-template/dependency/datacenters_test.go:44 +0x119
FAIL    github.com/hashicorp/consul-template/dependency 16.688s
ok      github.com/hashicorp/consul-template/logging    0.018s
```