### PR TITLE
Add POC for a channel that holds template events

### DIFF
--- a/config/retry.go
+++ b/config/retry.go
@@ -25,8 +25,8 @@ type RetryConfig struct {
 	// the error fall through.
 	Attempts *int
 
-	// Backoff is the base of the exponentialbackoff. This number will be multipled
-	// by the next power of 2 on each iteration.
+	// Backoff is the base of the exponentialbackoff. This number will be
+	// multipled by the next power of 2 on each iteration.
 	Backoff *time.Duration
 
 	// Enabled signals if this retry is enabled.


### PR DESCRIPTION
Relates to #799 for early feedback from @dadgar 

This adds a new `TemplateEvents` channel which will push individual template events onto the consumer. The event will include the full list of used dependencies, missing dependencies, and unwatched dependencies, as well as the result of WouldRender and DidRender.

If you like this, I'm fairly certain we can remove the other RenderEvent stuff. Does this give you enough information to do what you need to do?