### PR TITLE
dep: Fix goroutine leak in file watcher

### DIFF
--- a/dependency/file.go
+++ b/dependency/file.go
@@ -112,6 +112,7 @@ func (d *FileQuery) watch(lastStat os.FileInfo) <-chan *watchResult {
 				case <-d.stopCh:
 					return
 				case ch <- &watchResult{stat: stat}:
+					return
 				}
 			}
 


### PR DESCRIPTION
The goroutine would never terminate when the file changes and would just
continue looping.