### PR TITLE
added missing backslash in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Query a Consul instance that requires authentication, dumping the templates to s
 ```shell
 $ consul-template \
   -consul my.consul.internal:6124 \
-  -template "/tmp/template.ctmpl:/tmp/result:service nginx restart"
+  -template "/tmp/template.ctmpl:/tmp/result:service nginx restart" \
   -dry
 ```
 


### PR DESCRIPTION
Relates to issue: https://github.com/hashicorp/consul-template/issues/834 where an example in the README.md is missing a `\` to escape the newline.