### PR TITLE
 Fix example for Scratch.Get

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,7 +779,7 @@ Returns the value in the scratchpad at the named key. If the data does not
 exist, this will return "nil".
 
 ```liquid
-{{ scratch.Key "foo" }}
+{{ scratch.Get "foo" }}
 ```
 
 ##### `scratch.Set`


### PR DESCRIPTION
Example syntax for `Scratch.Get` included `Scratch.Key` instead of `Scratch.Get`