### PR TITLE
If vault token is unspecified, try reading from ~/.vault-token

### DIFF
--- a/config/vault.go
+++ b/config/vault.go
@@ -2,9 +2,12 @@ package config
 
 import (
 	"fmt"
+	"io/ioutil"
 	"time"
+	"strings"
 
 	"github.com/hashicorp/vault/api"
+	"github.com/mitchellh/go-homedir"
 )
 
 const (
@@ -178,7 +181,17 @@ func (c *VaultConfig) Finalize() {
 	c.SSL.Finalize()
 
 	if c.Token == nil {
-		c.Token = String("")
+		// Use the vault CLI's token, if present.
+		homePath, _ := homedir.Dir()
+		tokenBytes, _ := ioutil.ReadFile(homePath + "/.vault-token")
+
+		tokenString := strings.TrimSpace(string(tokenBytes))
+
+		if tokenString != "" {
+			c.Token = String(tokenString)
+		} else {
+			c.Token = String("")
+		}
 	}
 
 	if c.UnwrapToken == nil {


### PR DESCRIPTION
Similar to hashicorp/terraform#11529, if VAULT_TOKEN is unspecified in the ENV or manually, try to use the vault cli's token file, if present.