### PR TITLE
Allow overriding configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ go:
   - 1.7
 
 env:
-  - GOMAXPROCS=7
+  - GOMAXPROCS=4
 
 branches:
   only:
@@ -23,4 +23,4 @@ before_install:
   - mv consul ~/bin
   - export PATH="~/bin:$PATH"
 
-script: make test test-race
+script: make test

--- a/cli_test.go
+++ b/cli_test.go
@@ -168,12 +168,6 @@ func TestCLI_ParseFlags(t *testing.T) {
 			false,
 		},
 		{
-			"config_bad_path",
-			[]string{"-config", "/not/a/real/path"},
-			nil,
-			true,
-		},
-		{
 			"consul_addr",
 			[]string{"-consul-addr", "1.2.3.4"},
 			&config.Config{
@@ -798,15 +792,15 @@ func TestCLI_ParseFlags(t *testing.T) {
 			out := gatedio.NewByteBuffer()
 			cli := NewCLI(out, out)
 
-			a, _, _, _, err := cli.ParseFlags(tc.f)
+			a, _, _, _, _, err := cli.ParseFlags(tc.f)
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}
 
 			if tc.e != nil {
 				tc.e = config.DefaultConfig().Merge(tc.e)
-				tc.e.Finalize()
 			}
+
 			if !reflect.DeepEqual(tc.e, a) {
 				t.Errorf("\nexp: %#v\nact: %#v\nout: %q", tc.e, a, out.String())
 			}

--- a/config/consul.go
+++ b/config/consul.go
@@ -29,12 +29,10 @@ type ConsulConfig struct {
 // default values.
 func DefaultConsulConfig() *ConsulConfig {
 	return &ConsulConfig{
-		Address:   stringFromEnv("CONSUL_HTTP_ADDR"),
 		Auth:      DefaultAuthConfig(),
 		Retry:     DefaultRetryConfig(),
 		SSL:       DefaultSSLConfig(),
 		Transport: DefaultTransportConfig(),
-		Token:     stringFromEnv("CONSUL_TOKEN", "CONSUL_HTTP_TOKEN"),
 	}
 }
 
@@ -117,7 +115,9 @@ func (c *ConsulConfig) Merge(o *ConsulConfig) *ConsulConfig {
 // Finalize ensures there no nil pointers.
 func (c *ConsulConfig) Finalize() {
 	if c.Address == nil {
-		c.Address = String("")
+		c.Address = stringFromEnv([]string{
+			"CONSUL_HTTP_ADDR",
+		}, "")
 	}
 
 	if c.Auth == nil {
@@ -136,7 +136,10 @@ func (c *ConsulConfig) Finalize() {
 	c.SSL.Finalize()
 
 	if c.Token == nil {
-		c.Token = String("")
+		c.Token = stringFromEnv([]string{
+			"CONSUL_TOKEN",
+			"CONSUL_HTTP_TOKEN",
+		}, "")
 	}
 
 	if c.Transport == nil {

--- a/config/vault.go
+++ b/config/vault.go
@@ -58,19 +58,8 @@ type VaultConfig struct {
 // default values.
 func DefaultVaultConfig() *VaultConfig {
 	v := &VaultConfig{
-		Address:     stringFromEnv(api.EnvVaultAddress),
-		RenewToken:  boolFromEnv("VAULT_RENEW_TOKEN"),
-		UnwrapToken: boolFromEnv("VAULT_UNWRAP_TOKEN"),
-		Retry:       DefaultRetryConfig(),
-		SSL: &SSLConfig{
-			CaCert:     stringFromEnv(api.EnvVaultCACert),
-			CaPath:     stringFromEnv(api.EnvVaultCAPath),
-			Cert:       stringFromEnv(api.EnvVaultClientCert),
-			Key:        stringFromEnv(api.EnvVaultClientKey),
-			ServerName: stringFromEnv(api.EnvVaultTLSServerName),
-			Verify:     antiboolFromEnv(api.EnvVaultInsecure),
-		},
-		Token:     stringFromEnv("VAULT_TOKEN"),
+		Retry:     DefaultRetryConfig(),
+		SSL:       DefaultSSLConfig(),
 		Transport: DefaultTransportConfig(),
 	}
 
@@ -167,16 +156,16 @@ func (c *VaultConfig) Merge(o *VaultConfig) *VaultConfig {
 
 // Finalize ensures there no nil pointers.
 func (c *VaultConfig) Finalize() {
-	if c.Enabled == nil {
-		c.Enabled = Bool(StringPresent(c.Address))
-	}
-
 	if c.Address == nil {
-		c.Address = String("")
+		c.Address = stringFromEnv([]string{
+			api.EnvVaultAddress,
+		}, "")
 	}
 
 	if c.RenewToken == nil {
-		c.RenewToken = Bool(DefaultVaultRenewToken)
+		c.RenewToken = boolFromEnv([]string{
+			"VAULT_RENEW_TOKEN",
+		}, DefaultVaultRenewToken)
 	}
 
 	if c.Retry == nil {
@@ -186,11 +175,20 @@ func (c *VaultConfig) Finalize() {
 
 	if c.SSL == nil {
 		c.SSL = DefaultSSLConfig()
+		c.SSL.Enabled = Bool(true)
+		c.SSL.CaCert = stringFromEnv([]string{api.EnvVaultCACert}, "")
+		c.SSL.CaPath = stringFromEnv([]string{api.EnvVaultCAPath}, "")
+		c.SSL.Cert = stringFromEnv([]string{api.EnvVaultClientCert}, "")
+		c.SSL.Key = stringFromEnv([]string{api.EnvVaultClientKey}, "")
+		c.SSL.ServerName = stringFromEnv([]string{api.EnvVaultTLSServerName}, "")
+		c.SSL.Verify = antiboolFromEnv([]string{api.EnvVaultInsecure}, true)
 	}
 	c.SSL.Finalize()
 
 	if c.Token == nil {
-		c.Token = String("")
+		c.Token = stringFromEnv([]string{
+			"VAULT_TOKEN",
+		}, "")
 	}
 
 	if c.Transport == nil {
@@ -199,7 +197,13 @@ func (c *VaultConfig) Finalize() {
 	c.Transport.Finalize()
 
 	if c.UnwrapToken == nil {
-		c.UnwrapToken = Bool(DefaultVaultUnwrapToken)
+		c.UnwrapToken = boolFromEnv([]string{
+			"VAULT_UNWRAP_TOKEN",
+		}, DefaultVaultUnwrapToken)
+	}
+
+	if c.Enabled == nil {
+		c.Enabled = Bool(StringPresent(c.Address))
 	}
 }
 

--- a/config/vault_test.go
+++ b/config/vault_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -304,7 +305,7 @@ func TestVaultConfig_Finalize(t *testing.T) {
 					CaCert:     String(""),
 					CaPath:     String(""),
 					Cert:       String(""),
-					Enabled:    Bool(false),
+					Enabled:    Bool(true),
 					Key:        String(""),
 					ServerName: String(""),
 					Verify:     Bool(true),
@@ -338,7 +339,7 @@ func TestVaultConfig_Finalize(t *testing.T) {
 					CaCert:     String(""),
 					CaPath:     String(""),
 					Cert:       String(""),
-					Enabled:    Bool(false),
+					Enabled:    Bool(true),
 					Key:        String(""),
 					ServerName: String(""),
 					Verify:     Bool(true),
@@ -358,6 +359,9 @@ func TestVaultConfig_Finalize(t *testing.T) {
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			os.Unsetenv("VAULT_ADDR")
+			os.Unsetenv("VAULT_TOKEN")
+
 			tc.i.Finalize()
 			if !reflect.DeepEqual(tc.r, tc.i) {
 				t.Errorf("\nexp: %#v\nact: %#v", tc.r, tc.i)


### PR DESCRIPTION
Previously environment variables would load in the "defaults" section of a configuration, making it impossible to override them during a merge. This PR fixes that and keeps track of the list of configuration paths given on the CLI to fix reloading.

Fixes GH-866