### PR TITLE
RetryConfig: Add MaxBackoff option (fixes #938)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,13 @@ consul {
     # retry sleeps for an exponent of 2 longer than this base. For 5 retries,
     # the sleep times would be: 250ms, 500ms, 1s, 2s, then 4s.
     backoff = "250ms"
+
+    # This is the maximum amount of time to sleep between retry attempts.
+    # When max_backoff is set to zero, there is no upper limit to the
+    # exponential sleep between retry attempts.
+    # If max_backoff is set to 10s and backoff is set to 250ms, sleep times
+    # would be: 250ms, 500ms, 1s, 2s, 4s, 8s, 10s, 10s, ...
+    max_backoff = "0ms"
   }
   # This block configures the SSL options for connecting to the Consul server.
   ssl {

--- a/cli.go
+++ b/cli.go
@@ -232,6 +232,11 @@ func (cli *CLI) ParseFlags(args []string) (*config.Config, []string, bool, bool,
 		return nil
 	}), "consul-retry-backoff", "")
 
+	flags.Var((funcDurationVar)(func(d time.Duration) error {
+		c.Consul.Retry.MaxBackoff = config.TimeDuration(d)
+		return nil
+	}), "consul-retry-max-backoff", "")
+
 	flags.Var((funcBoolVar)(func(b bool) error {
 		c.Consul.SSL.Enabled = config.Bool(b)
 		return nil

--- a/cli.go
+++ b/cli.go
@@ -426,6 +426,11 @@ func (cli *CLI) ParseFlags(args []string) (*config.Config, []string, bool, bool,
 		return nil
 	}), "vault-retry-backoff", "")
 
+	flags.Var((funcDurationVar)(func(d time.Duration) error {
+		c.Vault.Retry.MaxBackoff = config.TimeDuration(d)
+		return nil
+	}), "vault-retry-max-backoff", "")
+
 	flags.Var((funcBoolVar)(func(b bool) error {
 		c.Vault.SSL.Enabled = config.Bool(b)
 		return nil

--- a/cli_test.go
+++ b/cli_test.go
@@ -594,6 +594,18 @@ func TestCLI_ParseFlags(t *testing.T) {
 			false,
 		},
 		{
+			"vault-retry-max-backoff",
+			[]string{"-vault-retry-max-backoff", "60s"},
+			&config.Config{
+				Vault: &config.VaultConfig{
+					Retry: &config.RetryConfig{
+						MaxBackoff: config.TimeDuration(60 * time.Second),
+					},
+				},
+			},
+			false,
+		},
+		{
 			"vault-renew-token",
 			[]string{"-vault-renew-token"},
 			&config.Config{

--- a/cli_test.go
+++ b/cli_test.go
@@ -237,6 +237,18 @@ func TestCLI_ParseFlags(t *testing.T) {
 			false,
 		},
 		{
+			"consul-retry-max-backoff",
+			[]string{"-consul-retry-max-backoff", "60s"},
+			&config.Config{
+				Consul: &config.ConsulConfig{
+					Retry: &config.RetryConfig{
+						MaxBackoff: config.TimeDuration(60 * time.Second),
+					},
+				},
+			},
+			false,
+		},
+		{
 			"consul-ssl",
 			[]string{"-consul-ssl"},
 			&config.Config{

--- a/config/consul_test.go
+++ b/config/consul_test.go
@@ -249,9 +249,10 @@ func TestConsulConfig_Finalize(t *testing.T) {
 					Password: String(""),
 				},
 				Retry: &RetryConfig{
-					Backoff:  TimeDuration(DefaultRetryBackoff),
-					Enabled:  Bool(true),
-					Attempts: Int(DefaultRetryAttempts),
+					Backoff:    TimeDuration(DefaultRetryBackoff),
+					MaxBackoff: TimeDuration(DefaultRetryMaxBackoff),
+					Enabled:    Bool(true),
+					Attempts:   Int(DefaultRetryAttempts),
 				},
 				SSL: &SSLConfig{
 					CaCert:     String(""),

--- a/config/retry.go
+++ b/config/retry.go
@@ -13,6 +13,9 @@ const (
 	// DefaultRetryBackoff is the default base for the exponential backoff
 	// algorithm.
 	DefaultRetryBackoff = 250 * time.Millisecond
+
+	// DefaultRetryMaxBackoff is the default maximum of backoff time
+	DefaultRetryMaxBackoff = 0 * time.Millisecond
 )
 
 // RetryFunc is the signature of a function that supports retries.
@@ -23,11 +26,16 @@ type RetryFunc func(int) (bool, time.Duration)
 type RetryConfig struct {
 	// Attempts is the total number of maximum attempts to retry before letting
 	// the error fall through.
+	// 0 means unlimited.
 	Attempts *int
 
 	// Backoff is the base of the exponentialbackoff. This number will be
 	// multipled by the next power of 2 on each iteration.
 	Backoff *time.Duration
+
+	// MaxBackoff is an upper limit to the sleep time between retries
+	// A MaxBackoff of zero means there is no limit to the exponential growth of the backoff.
+	MaxBackoff *time.Duration
 
 	// Enabled signals if this retry is enabled.
 	Enabled *bool
@@ -50,6 +58,8 @@ func (c *RetryConfig) Copy() *RetryConfig {
 	o.Attempts = c.Attempts
 
 	o.Backoff = c.Backoff
+
+	o.MaxBackoff = c.MaxBackoff
 
 	o.Enabled = c.Enabled
 
@@ -82,6 +92,10 @@ func (c *RetryConfig) Merge(o *RetryConfig) *RetryConfig {
 		r.Backoff = o.Backoff
 	}
 
+	if o.MaxBackoff != nil {
+		r.MaxBackoff = o.MaxBackoff
+	}
+
 	if o.Enabled != nil {
 		r.Enabled = o.Enabled
 	}
@@ -103,6 +117,11 @@ func (c *RetryConfig) RetryFunc() RetryFunc {
 		base := math.Pow(2, float64(retry))
 		sleep := time.Duration(base) * TimeDurationVal(c.Backoff)
 
+		maxSleep := TimeDurationVal(c.MaxBackoff)
+		if maxSleep > 0 && maxSleep < sleep {
+			return true, maxSleep
+		}
+
 		return true, sleep
 	}
 }
@@ -115,6 +134,10 @@ func (c *RetryConfig) Finalize() {
 
 	if c.Backoff == nil {
 		c.Backoff = TimeDuration(DefaultRetryBackoff)
+	}
+
+	if c.MaxBackoff == nil {
+		c.MaxBackoff = TimeDuration(DefaultRetryMaxBackoff)
 	}
 
 	if c.Enabled == nil {
@@ -131,10 +154,12 @@ func (c *RetryConfig) GoString() string {
 	return fmt.Sprintf("&RetryConfig{"+
 		"Attempts:%s, "+
 		"Backoff:%s, "+
+		"MaxBackoff:%s, "+
 		"Enabled:%s"+
 		"}",
 		IntGoString(c.Attempts),
 		TimeDurationGoString(c.Backoff),
+		TimeDurationGoString(c.MaxBackoff),
 		BoolGoString(c.Enabled),
 	)
 }

--- a/config/retry.go
+++ b/config/retry.go
@@ -35,7 +35,7 @@ type RetryConfig struct {
 
 	// MaxBackoff is an upper limit to the sleep time between retries
 	// A MaxBackoff of zero means there is no limit to the exponential growth of the backoff.
-	MaxBackoff *time.Duration
+	MaxBackoff *time.Duration `mapstructure:"max_backoff"`
 
 	// Enabled signals if this retry is enabled.
 	Enabled *bool

--- a/config/retry_test.go
+++ b/config/retry_test.go
@@ -28,6 +28,15 @@ func TestRetryConfig_Copy(t *testing.T) {
 				Enabled:  Bool(true),
 			},
 		},
+		{
+			"max_backoff",
+			&RetryConfig{
+				Attempts:   Int(0),
+				Backoff:    TimeDuration(20 * time.Second),
+				MaxBackoff: TimeDuration(100 * time.Second),
+				Enabled:    Bool(true),
+			},
+		},
 	}
 
 	for i, tc := range cases {
@@ -120,6 +129,32 @@ func TestRetryConfig_Merge(t *testing.T) {
 			&RetryConfig{Backoff: TimeDuration(10 * time.Second)},
 			&RetryConfig{Backoff: TimeDuration(10 * time.Second)},
 		},
+
+		{
+			"maxbackoff_overrides",
+			&RetryConfig{MaxBackoff: TimeDuration(10 * time.Second)},
+			&RetryConfig{MaxBackoff: TimeDuration(20 * time.Second)},
+			&RetryConfig{MaxBackoff: TimeDuration(20 * time.Second)},
+		},
+		{
+			"maxbackoff_empty_one",
+			&RetryConfig{MaxBackoff: TimeDuration(10 * time.Second)},
+			&RetryConfig{},
+			&RetryConfig{MaxBackoff: TimeDuration(10 * time.Second)},
+		},
+		{
+			"maxbackoff_empty_two",
+			&RetryConfig{},
+			&RetryConfig{MaxBackoff: TimeDuration(10 * time.Second)},
+			&RetryConfig{MaxBackoff: TimeDuration(10 * time.Second)},
+		},
+		{
+			"maxbackoff_same",
+			&RetryConfig{MaxBackoff: TimeDuration(10 * time.Second)},
+			&RetryConfig{MaxBackoff: TimeDuration(10 * time.Second)},
+			&RetryConfig{MaxBackoff: TimeDuration(10 * time.Second)},
+		},
+
 		{
 			"enabled_overrides",
 			&RetryConfig{Enabled: Bool(true)},
@@ -166,9 +201,10 @@ func TestRetryConfig_Finalize(t *testing.T) {
 			"empty",
 			&RetryConfig{},
 			&RetryConfig{
-				Attempts: Int(DefaultRetryAttempts),
-				Backoff:  TimeDuration(DefaultRetryBackoff),
-				Enabled:  Bool(true),
+				Attempts:   Int(DefaultRetryAttempts),
+				Backoff:    TimeDuration(DefaultRetryBackoff),
+				MaxBackoff: TimeDuration(DefaultRetryMaxBackoff),
+				Enabled:    Bool(true),
 			},
 		},
 	}

--- a/config/vault_test.go
+++ b/config/vault_test.go
@@ -298,9 +298,10 @@ func TestVaultConfig_Finalize(t *testing.T) {
 				Enabled:    Bool(false),
 				RenewToken: Bool(DefaultVaultRenewToken),
 				Retry: &RetryConfig{
-					Backoff:  TimeDuration(DefaultRetryBackoff),
-					Enabled:  Bool(true),
-					Attempts: Int(DefaultRetryAttempts),
+					Backoff:    TimeDuration(DefaultRetryBackoff),
+					MaxBackoff: TimeDuration(DefaultRetryMaxBackoff),
+					Enabled:    Bool(true),
+					Attempts:   Int(DefaultRetryAttempts),
 				},
 				SSL: &SSLConfig{
 					CaCert:     String(""),
@@ -334,9 +335,10 @@ func TestVaultConfig_Finalize(t *testing.T) {
 				Enabled:    Bool(true),
 				RenewToken: Bool(DefaultVaultRenewToken),
 				Retry: &RetryConfig{
-					Backoff:  TimeDuration(DefaultRetryBackoff),
-					Enabled:  Bool(true),
-					Attempts: Int(DefaultRetryAttempts),
+					Backoff:    TimeDuration(DefaultRetryBackoff),
+					MaxBackoff: TimeDuration(DefaultRetryMaxBackoff),
+					Enabled:    Bool(true),
+					Attempts:   Int(DefaultRetryAttempts),
 				},
 				SSL: &SSLConfig{
 					CaCert:     String(""),
@@ -370,9 +372,10 @@ func TestVaultConfig_Finalize(t *testing.T) {
 				Enabled:    Bool(true),
 				RenewToken: Bool(DefaultVaultRenewToken),
 				Retry: &RetryConfig{
-					Backoff:  TimeDuration(DefaultRetryBackoff),
-					Enabled:  Bool(true),
-					Attempts: Int(DefaultRetryAttempts),
+					Backoff:    TimeDuration(DefaultRetryBackoff),
+					MaxBackoff: TimeDuration(DefaultRetryMaxBackoff),
+					Enabled:    Bool(true),
+					Attempts:   Int(DefaultRetryAttempts),
 				},
 				SSL: &SSLConfig{
 					CaCert:     String(""),


### PR DESCRIPTION
This is a work in progress Pull request so you can have a look already

Questions:
- Should this also be exposed to users via the config file?
- I did not find a test for the RetryFunc itself, did I just overlook it or should I add one?