### PR TITLE
Update cli.go

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -740,7 +740,7 @@ Options:
       increased exponentially for each retry attempt.
 
   -vault-ssl
-      Specifies is communications with Vault should be done via SSL
+      Specifies whether communications with Vault should be done via SSL
 
   -vault-ssl-ca-cert=<string>
       Sets the path to the CA certificate to use for TLS verification


### PR DESCRIPTION
fixed typo by using a more accurate word. Word could be "if" instead of "is".