### PR TITLE
Add Vault grace periods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ branches:
     - master
 
 env:
-  - CONSUL_VERSION=0.8.2
+  - CONSUL_VERSION=0.8.4
 
 before_install:
   - curl -sLo consul.zip https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ vault {
   #
   # Note: If you set this to a value that is higher than your default TTL or
   # max TTL, Consul Template will always read a new secret!
-  grace = "30s"
+  grace = "15s"
 
   # This is the token to use when communicating with the Vault server.
   # Like other tools that integrate with Vault, Consul Template makes the

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ consul {
     enabled = true
 
     # This specifies the number of attempts to make before giving up. Each
-    # attempt adds the exponential backoff sleep time. Setting this to 
+    # attempt adds the exponential backoff sleep time. Setting this to
     # zero will implement an unlimited number of retries.
     attempts = 12
 
@@ -261,6 +261,16 @@ vault {
   # This is the address of the Vault leader. The protocol (http(s)) portion
   # of the address is required.
   address = "https://vault.service.consul:8200"
+
+  # This is the grace period between lease renewal and secret re-acquisition.
+  # When renewing a secret, if the remaining lease is less than or equal to the
+  # configured grace, Consul Template will request a new credential. This
+  # prevents Vault from revoking the credential at expiration and Consul
+  # Template having a stale credential.
+  #
+  # Note: If you set this to a value that is higher than your default TTL or
+  # max TTL, Consul Template will always read a new secret!
+  grace = "30s"
 
   # This is the token to use when communicating with the Vault server.
   # Like other tools that integrate with Vault, Consul Template makes the

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1166,6 +1166,18 @@ func TestParse(t *testing.T) {
 			false,
 		},
 		{
+			"vault_grace",
+			`vault {
+				grace = "5m"
+			}`,
+			&Config{
+				Vault: &VaultConfig{
+					Grace: TimeDuration(5 * time.Minute),
+				},
+			},
+			false,
+		},
+		{
 			"vault_token",
 			`vault {
 				token = "token"

--- a/config/vault.go
+++ b/config/vault.go
@@ -11,7 +11,7 @@ const (
 	// DefaultVaultGrace is the default grace period before which to read a new
 	// secret from Vault. If a lease is due to expire in 5 minutes, Consul
 	// Template will read a new secret at that time minus this value.
-	DefaultVaultGrace = 30 * time.Second
+	DefaultVaultGrace = 15 * time.Second
 
 	// DefaultVaultRenewToken is the default value for if the Vault token should
 	// be renewed.

--- a/config/vault.go
+++ b/config/vault.go
@@ -8,6 +8,11 @@ import (
 )
 
 const (
+	// DefaultVaultGrace is the default grace period before which to read a new
+	// secret from Vault. If a lease is due to expire in 5 minutes, Consul
+	// Template will read a new secret at that time minus this value.
+	DefaultVaultGrace = 30 * time.Second
+
 	// DefaultVaultRenewToken is the default value for if the Vault token should
 	// be renewed.
 	DefaultVaultRenewToken = true
@@ -32,6 +37,10 @@ type VaultConfig struct {
 
 	// Enabled controls whether the Vault integration is active.
 	Enabled *bool `mapstructure:"enabled"`
+
+	// Grace is the amount of time before a lease is about to expire to force a
+	// new secret to be read.
+	Grace *time.Duration `mapstructure:"grace"`
 
 	// RenewToken renews the Vault token.
 	RenewToken *bool `mapstructure:"renew_token"`
@@ -80,6 +89,8 @@ func (c *VaultConfig) Copy() *VaultConfig {
 
 	o.Enabled = c.Enabled
 
+	o.Grace = c.Grace
+
 	o.RenewToken = c.RenewToken
 
 	if c.Retry != nil {
@@ -127,6 +138,10 @@ func (c *VaultConfig) Merge(o *VaultConfig) *VaultConfig {
 		r.Enabled = o.Enabled
 	}
 
+	if o.Grace != nil {
+		r.Grace = o.Grace
+	}
+
 	if o.RenewToken != nil {
 		r.RenewToken = o.RenewToken
 	}
@@ -160,6 +175,10 @@ func (c *VaultConfig) Finalize() {
 		c.Address = stringFromEnv([]string{
 			api.EnvVaultAddress,
 		}, "")
+	}
+
+	if c.Grace == nil {
+		c.Grace = TimeDuration(DefaultVaultGrace)
 	}
 
 	if c.RenewToken == nil {
@@ -239,6 +258,7 @@ func (c *VaultConfig) GoString() string {
 	return fmt.Sprintf("&VaultConfig{"+
 		"Address:%s, "+
 		"Enabled:%s, "+
+		"Grace:%s, "+
 		"RenewToken:%s, "+
 		"Retry:%#v, "+
 		"SSL:%#v, "+
@@ -247,6 +267,7 @@ func (c *VaultConfig) GoString() string {
 		"UnwrapToken:%s"+
 		"}",
 		StringGoString(c.Address),
+		TimeDurationGoString(c.Grace),
 		BoolGoString(c.Enabled),
 		BoolGoString(c.RenewToken),
 		c.Retry,

--- a/config/vault_test.go
+++ b/config/vault_test.go
@@ -27,6 +27,7 @@ func TestVaultConfig_Copy(t *testing.T) {
 			&VaultConfig{
 				Address:    String("address"),
 				Enabled:    Bool(true),
+				Grace:      TimeDuration(1 * time.Minute),
 				RenewToken: Bool(true),
 				Retry:      &RetryConfig{Enabled: Bool(true)},
 				SSL:        &SSLConfig{Enabled: Bool(true)},
@@ -127,6 +128,30 @@ func TestVaultConfig_Merge(t *testing.T) {
 			&VaultConfig{Address: String("address")},
 			&VaultConfig{Address: String("address")},
 			&VaultConfig{Address: String("address")},
+		},
+		{
+			"grace_overrides",
+			&VaultConfig{Grace: TimeDuration(5 * time.Minute)},
+			&VaultConfig{Grace: TimeDuration(10 * time.Minute)},
+			&VaultConfig{Grace: TimeDuration(10 * time.Minute)},
+		},
+		{
+			"grace_empty_one",
+			&VaultConfig{Grace: TimeDuration(5 * time.Minute)},
+			&VaultConfig{},
+			&VaultConfig{Grace: TimeDuration(5 * time.Minute)},
+		},
+		{
+			"grace_empty_two",
+			&VaultConfig{},
+			&VaultConfig{Grace: TimeDuration(5 * time.Minute)},
+			&VaultConfig{Grace: TimeDuration(5 * time.Minute)},
+		},
+		{
+			"grace_same",
+			&VaultConfig{Grace: TimeDuration(5 * time.Minute)},
+			&VaultConfig{Grace: TimeDuration(5 * time.Minute)},
+			&VaultConfig{Grace: TimeDuration(5 * time.Minute)},
 		},
 		{
 			"token_overrides",
@@ -296,6 +321,7 @@ func TestVaultConfig_Finalize(t *testing.T) {
 			&VaultConfig{
 				Address:    String(""),
 				Enabled:    Bool(false),
+				Grace:      TimeDuration(DefaultVaultGrace),
 				RenewToken: Bool(DefaultVaultRenewToken),
 				Retry: &RetryConfig{
 					Backoff:    TimeDuration(DefaultRetryBackoff),
@@ -333,6 +359,7 @@ func TestVaultConfig_Finalize(t *testing.T) {
 			&VaultConfig{
 				Address:    String("address"),
 				Enabled:    Bool(true),
+				Grace:      TimeDuration(DefaultVaultGrace),
 				RenewToken: Bool(DefaultVaultRenewToken),
 				Retry: &RetryConfig{
 					Backoff:    TimeDuration(DefaultRetryBackoff),
@@ -370,6 +397,7 @@ func TestVaultConfig_Finalize(t *testing.T) {
 			&VaultConfig{
 				Address:    String("address"),
 				Enabled:    Bool(true),
+				Grace:      TimeDuration(DefaultVaultGrace),
 				RenewToken: Bool(DefaultVaultRenewToken),
 				Retry: &RetryConfig{
 					Backoff:    TimeDuration(DefaultRetryBackoff),

--- a/config/vault_test.go
+++ b/config/vault_test.go
@@ -433,6 +433,7 @@ func TestVaultConfig_Finalize(t *testing.T) {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
 			os.Unsetenv("VAULT_ADDR")
 			os.Unsetenv("VAULT_TOKEN")
+			os.Unsetenv("VAULT_DEV_ROOT_TOKEN_ID")
 			homePath, _ = ioutil.TempDir("", "")
 
 			tc.i.Finalize()

--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -63,6 +63,7 @@ type QueryOptions struct {
 	Datacenter        string
 	Near              string
 	RequireConsistent bool
+	VaultGrace        time.Duration
 	WaitIndex         uint64
 	WaitTime          time.Duration
 }

--- a/dependency/vault_common.go
+++ b/dependency/vault_common.go
@@ -26,3 +26,14 @@ func leaseDurationOrDefault(d int) int {
 	}
 	return d
 }
+
+// vaultRenewDuration accepts a given renew duration (lease duration) and
+// returns the cooresponding time.Duration. If the duration is 0 (not provided),
+// this falls back to the VaultDefaultLeaseDuration.
+func vaultRenewDuration(d int) time.Duration {
+	dur := time.Duration(d/2.0) * time.Second
+	if dur == 0 {
+		dur = VaultDefaultLeaseDuration
+	}
+	return dur
+}

--- a/dependency/vault_read.go
+++ b/dependency/vault_read.go
@@ -73,6 +73,9 @@ func (d *VaultReadQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interfac
 		if err == nil {
 			log.Printf("[TRACE] %s: successfully renewed %s", d, d.secret.LeaseID)
 
+			// Print any warnings
+			d.printWarnings(renewal.Warnings)
+
 			secret := &Secret{
 				RequestID:     renewal.RequestID,
 				LeaseID:       renewal.LeaseID,
@@ -91,6 +94,13 @@ func (d *VaultReadQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interfac
 
 	// If we got this far, we either didn't have a secret to renew, the secret was
 	// not renewable, or the renewal failed, so attempt a fresh read.
+
+func (d *VaultReadQuery) printWarnings(warnings []string) {
+	for _, w := range warnings {
+		log.Printf("[WARN] %s: %s", d, w)
+	}
+}
+
 	log.Printf("[TRACE] %s: GET %s", d, &url.URL{
 		Path:     "/v1/" + d.path,
 		RawQuery: opts.String(),

--- a/dependency/vault_read.go
+++ b/dependency/vault_read.go
@@ -50,10 +50,7 @@ func (d *VaultReadQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interfac
 	// If this is not the first query and we have a lease duration, sleep until we
 	// try to renew.
 	if opts.WaitIndex != 0 && d.secret != nil && d.secret.LeaseDuration != 0 {
-		dur := time.Duration(d.secret.LeaseDuration/2.0) * time.Second
-		if dur == 0 {
-			dur = VaultDefaultLeaseDuration
-		}
+		dur := vaultRenewDuration(d.secret.LeaseDuration)
 
 		log.Printf("[TRACE] %s: long polling for %s", d, dur)
 

--- a/dependency/vault_token.go
+++ b/dependency/vault_token.go
@@ -46,10 +46,7 @@ func (d *VaultTokenQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interfa
 	// If this is not the first query and we have a lease duration, sleep until we
 	// try to renew.
 	if opts.WaitIndex != 0 && d.leaseDuration != 0 {
-		dur := time.Duration(d.leaseDuration/2.0) * time.Second
-		if dur == 0 {
-			dur = VaultDefaultLeaseDuration
-		}
+		dur := vaultRenewDuration(d.leaseDuration)
 
 		log.Printf("[TRACE] %s: long polling for %s", d, dur)
 

--- a/dependency/vault_write.go
+++ b/dependency/vault_write.go
@@ -57,10 +57,7 @@ func (d *VaultWriteQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interfa
 	// If this is not the first query and we have a lease duration, sleep until we
 	// try to renew.
 	if opts.WaitIndex != 0 && d.secret != nil && d.secret.LeaseDuration != 0 {
-		dur := time.Duration(d.secret.LeaseDuration/2.0) * time.Second
-		if dur == 0 {
-			dur = VaultDefaultLeaseDuration
-		}
+		dur := vaultRenewDuration(d.secret.LeaseDuration)
 
 		log.Printf("[TRACE] %s: long polling for %s", d, dur)
 

--- a/dependency/vault_write.go
+++ b/dependency/vault_write.go
@@ -80,6 +80,9 @@ func (d *VaultWriteQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interfa
 		if err == nil {
 			log.Printf("[TRACE] %s: successfully renewed %s", d, d.secret.LeaseID)
 
+			// Print any warnings
+			d.printWarnings(renewal.Warnings)
+
 			secret := &Secret{
 				RequestID:     renewal.RequestID,
 				LeaseID:       renewal.LeaseID,
@@ -166,4 +169,10 @@ func sha1Map(m map[string]interface{}) string {
 	}
 
 	return fmt.Sprintf("%.4x", h.Sum(nil))
+}
+
+func (d *VaultWriteQuery) printWarnings(warnings []string) {
+	for _, w := range warnings {
+		log.Printf("[WARN] %s: %s", d, w)
+	}
 }

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -1173,6 +1173,7 @@ func newWatcher(c *config.Config, clients *dep.ClientSet, once bool) (*watch.Wat
 		// dependencies like reading a file from disk.
 		RetryFuncDefault: nil,
 		RetryFuncVault:   watch.RetryFunc(c.Vault.Retry.RetryFunc()),
+		VaultGrace:       config.TimeDurationVal(c.Vault.Grace),
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "runner")

--- a/watch/view.go
+++ b/watch/view.go
@@ -44,6 +44,11 @@ type View struct {
 
 	// stopCh is used to stop polling on this View
 	stopCh chan struct{}
+
+	// vaultGrace is the grace period between a lease and the max TTL for which
+	// Consul Template will generate a new secret instead of renewing an existing
+	// one.
+	vaultGrace time.Duration
 }
 
 // NewViewInput is used as input to the NewView function.
@@ -65,6 +70,11 @@ type NewViewInput struct {
 	// RetryFunc is a function which dictates how this view should retry on
 	// upstream errors.
 	RetryFunc RetryFunc
+
+	// VaultGrace is the grace period between a lease and the max TTL for which
+	// Consul Template will generate a new secret instead of renewing an existing
+	// one.
+	VaultGrace time.Duration
 }
 
 // NewView constructs a new view with the given inputs.
@@ -76,6 +86,7 @@ func NewView(i *NewViewInput) (*View, error) {
 		once:       i.Once,
 		retryFunc:  i.RetryFunc,
 		stopCh:     make(chan struct{}, 1),
+		vaultGrace: i.VaultGrace,
 	}, nil
 }
 
@@ -200,6 +211,7 @@ func (v *View) fetch(doneCh, successCh chan<- struct{}, errCh chan<- error) {
 			AllowStale: allowStale,
 			WaitTime:   defaultWaitTime,
 			WaitIndex:  v.lastIndex,
+			VaultGrace: v.vaultGrace,
 		})
 		if err != nil {
 			if err == dep.ErrStopped {

--- a/watch/watcher.go
+++ b/watch/watcher.go
@@ -42,6 +42,11 @@ type Watcher struct {
 	retryFuncConsul  RetryFunc
 	retryFuncDefault RetryFunc
 	retryFuncVault   RetryFunc
+
+	// vaultGrace is the grace period between a lease and the max TTL for which
+	// Consul Template will generate a new secret instead of renewing an existing
+	// one.
+	vaultGrace time.Duration
 }
 
 type NewWatcherInput struct {
@@ -61,6 +66,11 @@ type NewWatcherInput struct {
 	RetryFuncConsul  RetryFunc
 	RetryFuncDefault RetryFunc
 	RetryFuncVault   RetryFunc
+
+	// VaultGrace is the grace period between a lease and the max TTL for which
+	// Consul Template will generate a new secret instead of renewing an existing
+	// one.
+	VaultGrace time.Duration
 }
 
 // NewWatcher creates a new watcher using the given API client.
@@ -75,6 +85,7 @@ func NewWatcher(i *NewWatcherInput) (*Watcher, error) {
 		retryFuncConsul:  i.RetryFuncConsul,
 		retryFuncDefault: i.RetryFuncDefault,
 		retryFuncVault:   i.RetryFuncVault,
+		vaultGrace:       i.VaultGrace,
 	}
 
 	// Start a watcher for the Vault renew if that config was specified
@@ -138,6 +149,7 @@ func (w *Watcher) Add(d dep.Dependency) (bool, error) {
 		MaxStale:   w.maxStale,
 		Once:       w.once,
 		RetryFunc:  retryFunc,
+		VaultGrace: w.vaultGrace,
 	})
 	if err != nil {
 		return false, errors.Wrap(err, "watcher")


### PR DESCRIPTION
This fixes #949 by allowing a configurable Vault grace period. When renewing a secret, if the remaining lease is less than or equal to the configured grace, CT will request a new credential. This prevents Vault from revoking the credential at expiration and CT having to play catchup.