### PR TITLE
dump_signal configuration option was removed in 0.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,11 +218,6 @@ consul {
 # to not listen for any reload signals.
 reload_signal = "SIGHUP"
 
-# This is the signal to listen for to trigger a core dump event. The default
-# value is shown below. Setting this value to the empty string will cause CT
-# to not listen for any core dump signals.
-dump_signal = "SIGQUIT"
-
 # This is the signal to listen for to trigger a graceful stop. The default
 # value is shown below. Setting this value to the empty string will cause CT
 # to not listen for any graceful stop signals.


### PR DESCRIPTION
https://github.com/hashicorp/consul-template/commit/4eb346a15a1450f14cf8824098e1ed731377e401#diff-2a66a49ce9a1ffa85b6805fbf4d82b6a

Fixed #970