### PR TITLE
Added log-utc option to use local timezone

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -359,6 +359,11 @@ func (cli *CLI) ParseFlags(args []string) (*config.Config, []string, bool, bool,
 		return nil
 	}), "log-level", "")
 
+	flags.Var((funcBoolVar)(func(b bool) error {
+		c.LogUTC = config.Bool(b)
+		return nil
+	}), "log-utc", "")
+
 	flags.Var((funcDurationVar)(func(d time.Duration) error {
 		c.MaxStale = config.TimeDuration(d)
 		return nil
@@ -565,6 +570,7 @@ func (cli *CLI) setup(conf *config.Config) (*config.Config, error) {
 	if err := logging.Setup(&logging.Config{
 		Name:           Name,
 		Level:          config.StringVal(conf.LogLevel),
+		UTC:         config.BoolVal(conf.LogUTC),
 		Syslog:         config.BoolVal(conf.Syslog.Enabled),
 		SyslogFacility: config.StringVal(conf.Syslog.Facility),
 		Writer:         cli.errStream,
@@ -678,6 +684,9 @@ Options:
 
   -log-level=<level>
       Set the logging level - values are "debug", "info", "warn", and "err"
+
+  -log-utc
+      If provided use UTC timezone, if not provided, use local timezone, true by default
 
   -max-stale=<duration>
       Set the maximum staleness and allow stale queries to Consul which will

--- a/cli_test.go
+++ b/cli_test.go
@@ -357,6 +357,14 @@ func TestCLI_ParseFlags(t *testing.T) {
 			false,
 		},
 		{
+			"log-utc",
+			[]string{"-log-utc"},
+			&config.Config{
+				LogUTC: config.Bool(true),
+			},
+			false,
+		},
+		{
 			"max-stale",
 			[]string{"-max-stale", "10s"},
 			&config.Config{

--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,8 @@ const (
 
 	// DefaultKillSignal is the default signal for termination.
 	DefaultKillSignal = syscall.SIGINT
+
+	DefaultLogUTCBehaviour = true
 )
 
 var (
@@ -55,6 +57,9 @@ type Config struct {
 
 	// LogLevel is the level with which to log for this config.
 	LogLevel *string `mapstructure:"log_level"`
+
+	// If LogUTC provided use UTC timezone, if not provided, use local timezone.
+	LogUTC *bool `mapstructure:"log_utc"`
 
 	// MaxStale is the maximum amount of time for staleness from Consul as given
 	// by LastContact. If supplied, Consul Template will query all servers instead
@@ -103,6 +108,8 @@ func (c *Config) Copy() *Config {
 	o.KillSignal = c.KillSignal
 
 	o.LogLevel = c.LogLevel
+
+	o.LogUTC = c.LogUTC
 
 	o.MaxStale = c.MaxStale
 
@@ -163,6 +170,10 @@ func (c *Config) Merge(o *Config) *Config {
 
 	if o.LogLevel != nil {
 		r.LogLevel = o.LogLevel
+	}
+
+	if o.LogUTC != nil {
+		r.LogUTC = o.LogUTC
 	}
 
 	if o.MaxStale != nil {
@@ -374,6 +385,7 @@ func (c *Config) GoString() string {
 		"Exec:%#v, "+
 		"KillSignal:%s, "+
 		"LogLevel:%s, "+
+		"LogUTC:%s, "+
 		"MaxStale:%s, "+
 		"PidFile:%s, "+
 		"ReloadSignal:%s, "+
@@ -387,6 +399,7 @@ func (c *Config) GoString() string {
 		c.Exec,
 		SignalGoString(c.KillSignal),
 		StringGoString(c.LogLevel),
+		BoolGoString(c.LogUTC),
 		TimeDurationGoString(c.MaxStale),
 		StringGoString(c.PidFile),
 		SignalGoString(c.ReloadSignal),
@@ -441,6 +454,10 @@ func (c *Config) Finalize() {
 			"CT_LOG",
 			"CONSUL_TEMPLATE_LOG",
 		}, DefaultLogLevel)
+	}
+
+	if c.LogUTC == nil {
+		c.LogUTC = Bool(DefaultLogUTCBehaviour)
 	}
 
 	if c.MaxStale == nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -484,6 +484,14 @@ func TestParse(t *testing.T) {
 			false,
 		},
 		{
+			"log_utc",
+			`log_utc = true`,
+			&Config{
+				LogUTC: Bool(true),
+			},
+			false,
+		},
+		{
 			"max_stale",
 			`max_stale = "10s"`,
 			&Config{
@@ -1545,6 +1553,18 @@ func TestConfig_Merge(t *testing.T) {
 			},
 			&Config{
 				LogLevel: String("log_level-diff"),
+			},
+		},
+		{
+			"log_utc",
+			&Config{
+				LogUTC: Bool(false),
+			},
+			&Config{
+				LogUTC: Bool(true),
+			},
+			&Config{
+				LogUTC: Bool(true),
 			},
 		},
 		{

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -22,6 +22,9 @@ type Config struct {
 	// Level is the log level to use.
 	Level string `json:"level"`
 
+	// Use UTC timezone
+	UTC bool `json:"UTC"`
+
 	// Syslog and SyslogFacility are the syslog configuration options.
 	Syslog         bool   `json:"syslog"`
 	SyslogFacility string `json:"syslog_facility"`
@@ -61,7 +64,12 @@ func Setup(config *Config) error {
 		logOutput = io.MultiWriter(logFilter)
 	}
 
-	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds | log.LUTC)
+	if config.UTC {
+		log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds | log.LUTC)
+	} else {
+		log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds)
+	}
+
 	log.SetOutput(logOutput)
 
 	return nil


### PR DESCRIPTION
This PR adds new option -log-utc. 
By default it's enabled and logger writes logs in UTC
If set -log-utc to false logger will write logs with server default timezone. 