### PR TITLE
Set default Vault Grace to 5 minutes

### DIFF
--- a/config/vault.go
+++ b/config/vault.go
@@ -11,7 +11,7 @@ const (
 	// DefaultVaultGrace is the default grace period before which to read a new
 	// secret from Vault. If a lease is due to expire in 5 minutes, Consul
 	// Template will read a new secret at that time minus this value.
-	DefaultVaultGrace = 5 * time.Second
+	DefaultVaultGrace = 5 * time.Minute
 
 	// DefaultVaultRenewToken is the default value for if the Vault token should
 	// be renewed.


### PR DESCRIPTION
This PR changes the default Vault grace from 5 seconds to the originally
intended duration of 5 minutes.