### PR TITLE
Return latest rendered data in result output

### DIFF
--- a/manager/renderer.go
+++ b/manager/renderer.go
@@ -66,7 +66,7 @@ func Render(i *RenderInput) (*RenderResult, error) {
 	return &RenderResult{
 		DidRender:   true,
 		WouldRender: true,
-		Contents:    existing,
+		Contents:    i.Contents,
 	}, nil
 }
 


### PR DESCRIPTION
Currently `manager/renderer.go` always sets render output as `existing`, which is the data it read from disk. This means that the render output is actually either:

- empty, if render output file does not exist
- identical data, if file existed and output has not changed
- stale data, if file existed and output changed

This PR fixes the issue by using the latest rendered output as the result.

I made a simple test program to verify this. It is available here: https://gist.github.com/vtorhonen/90f73577e41abddcd0444723a0bfffc1

Steps to reproduce:

- Write test data to Consul KV:
  - `consul kv put foo bar`
  - `consul kv put foo2 bar2` 
- Download gist and run it `go run render.go`

First run prints out empty data, but it writes the value for key `foo` correctly to file `output`. Next, change template to get key `foo2` and run the program again. Program outputs erroneously `bar`, but `bar2` is written to `output`.