### PR TITLE
Check if the template actually rendered

### DIFF
--- a/manager/runner.go
+++ b/manager/runner.go
@@ -249,11 +249,15 @@ func (r *Runner) Start() {
 		}
 
 		if r.allTemplatesRendered() {
+			log.Printf("[DEBUG] (runner) all templates rendered")
+
 			// If an exec command was given and a command is not currently running,
 			// spawn the child process for supervision.
 			if config.StringPresent(r.config.Exec.Command) {
 				// Lock the child because we are about to check if it exists.
 				r.childLock.Lock()
+
+				log.Printf("[TRACE] (runner) acquired child lock for command, spawning")
 
 				if r.child == nil {
 					env := r.config.Exec.Env.Copy()
@@ -946,7 +950,11 @@ func (r *Runner) allTemplatesRendered() bool {
 	defer r.renderEventsLock.RUnlock()
 
 	for _, tmpl := range r.templates {
-		if _, rendered := r.renderEvents[tmpl.ID()]; !rendered {
+		event, rendered := r.renderEvents[tmpl.ID()]
+		if !rendered {
+			return false
+		}
+		if !event.DidRender {
 			return false
 		}
 	}

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -951,10 +951,7 @@ func (r *Runner) allTemplatesRendered() bool {
 
 	for _, tmpl := range r.templates {
 		event, rendered := r.renderEvents[tmpl.ID()]
-		if !rendered {
-			return false
-		}
-		if !event.DidRender {
+		if !rendered || !event.DidRender {
 			return false
 		}
 	}


### PR DESCRIPTION
Previously we could check if an event existed, but now we keep track of more data, meaning we might have an event for an unrendered template. This ensures the event exists AND the template did render.

Fixes GH-991

/cc @dadgar