### PR TITLE
Fix Vault read/renewal hot-loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,15 +257,15 @@ vault {
   # of the address is required.
   address = "https://vault.service.consul:8200"
 
-  # This is the grace period between lease renewal and secret re-acquisition.
-  # When renewing a secret, if the remaining lease is less than or equal to the
-  # configured grace, Consul Template will request a new credential. This
-  # prevents Vault from revoking the credential at expiration and Consul
+  # This is the grace period between lease renewal of periodic secrets and secret
+  # re-acquisition. When renewing a secret, if the remaining lease is less than or
+  # equal to the configured grace, Consul Template will request a new credential.
+  # This prevents Vault from revoking the credential at expiration and Consul
   # Template having a stale credential.
   #
   # Note: If you set this to a value that is higher than your default TTL or
   # max TTL, Consul Template will always read a new secret!
-  grace = "15s"
+  grace = "5m"
 
   # This is the token to use when communicating with the Vault server.
   # Like other tools that integrate with Vault, Consul Template makes the

--- a/dependency/vault_read.go
+++ b/dependency/vault_read.go
@@ -85,16 +85,12 @@ func (d *VaultReadQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interfac
 		} else {
 			// The secret isn't renewable, probably the generic secret backend.
 			dur := vaultRenewDuration(d.secret)
-			if dur < opts.VaultGrace {
-				log.Printf("[TRACE] %s: remaining lease %s is less than grace, skipping sleep", d, dur)
-			} else {
-				log.Printf("[TRACE] %s: secret is not renewable, sleeping for %s", d, dur)
-				select {
-				case <-time.After(dur):
-					// The lease is almost expired, it's time to request a new one.
-				case <-d.stopCh:
-					return nil, nil, ErrStopped
-				}
+			log.Printf("[TRACE] %s: secret is not renewable, sleeping for %s", d, dur)
+			select {
+			case <-time.After(dur):
+				// The lease is almost expired, it's time to request a new one.
+			case <-d.stopCh:
+				return nil, nil, ErrStopped
 			}
 		}
 	}

--- a/dependency/vault_read.go
+++ b/dependency/vault_read.go
@@ -85,10 +85,6 @@ func (d *VaultReadQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interfac
 		} else {
 			// The secret isn't renewable, probably the generic secret backend.
 			dur := vaultRenewDuration(d.secret)
-			if dur > opts.VaultGrace {
-				dur = opts.VaultGrace
-			}
-
 			log.Printf("[TRACE] %s: secret is not renewable, sleeping for %s", d, dur)
 			select {
 			case <-time.After(dur):

--- a/dependency/vault_read.go
+++ b/dependency/vault_read.go
@@ -85,6 +85,10 @@ func (d *VaultReadQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interfac
 		} else {
 			// The secret isn't renewable, probably the generic secret backend.
 			dur := vaultRenewDuration(d.secret)
+			if dur > opts.VaultGrace {
+				dur = opts.VaultGrace
+			}
+
 			log.Printf("[TRACE] %s: secret is not renewable, sleeping for %s", d, dur)
 			select {
 			case <-time.After(dur):

--- a/dependency/vault_token.go
+++ b/dependency/vault_token.go
@@ -80,16 +80,12 @@ func (d *VaultTokenQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interfa
 
 	// The secret isn't renewable, probably the generic secret backend.
 	dur := vaultRenewDuration(d.secret)
-	if dur < opts.VaultGrace {
-		log.Printf("[TRACE] %s: remaining lease %s is less than grace, skipping sleep", d, dur)
-	} else {
-		log.Printf("[TRACE] %s: token is not renewable, sleeping for %s", d, dur)
-		select {
-		case <-time.After(dur):
-			// The lease is almost expired, it's time to request a new one.
-		case <-d.stopCh:
-			return nil, nil, ErrStopped
-		}
+	log.Printf("[TRACE] %s: token is not renewable, sleeping for %s", d, dur)
+	select {
+	case <-time.After(dur):
+		// The lease is almost expired, it's time to request a new one.
+	case <-d.stopCh:
+		return nil, nil, ErrStopped
 	}
 
 	return nil, nil, ErrLeaseExpired

--- a/dependency/vault_token.go
+++ b/dependency/vault_token.go
@@ -80,6 +80,10 @@ func (d *VaultTokenQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interfa
 
 	// The secret isn't renewable, probably the generic secret backend.
 	dur := vaultRenewDuration(d.secret)
+	if dur > opts.VaultGrace {
+		dur = opts.VaultGrace
+	}
+
 	log.Printf("[TRACE] %s: token is not renewable, sleeping for %s", d, dur)
 	select {
 	case <-time.After(dur):

--- a/dependency/vault_token.go
+++ b/dependency/vault_token.go
@@ -79,8 +79,10 @@ func (d *VaultTokenQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interfa
 	}
 
 	// The secret isn't renewable, probably the generic secret backend.
+	// TODO This is incorrect when given a non-renewable template. We should
+	// instead to a lookup self to determine the lease duration.
 	dur := vaultRenewDuration(d.secret)
-	if dur > opts.VaultGrace {
+	if dur < opts.VaultGrace {
 		dur = opts.VaultGrace
 	}
 

--- a/dependency/vault_write.go
+++ b/dependency/vault_write.go
@@ -92,16 +92,12 @@ func (d *VaultWriteQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interfa
 		} else {
 			// The secret isn't renewable, probably the generic secret backend.
 			dur := vaultRenewDuration(d.secret)
-			if dur < opts.VaultGrace {
-				log.Printf("[TRACE] %s: remaining lease %s is less than grace, skipping sleep", d, dur)
-			} else {
-				log.Printf("[TRACE] %s: secret is not renewable, sleeping for %s", d, dur)
-				select {
-				case <-time.After(dur):
-					// The lease is almost expired, it's time to request a new one.
-				case <-d.stopCh:
-					return nil, nil, ErrStopped
-				}
+			log.Printf("[TRACE] %s: secret is not renewable, sleeping for %s", d, dur)
+			select {
+			case <-time.After(dur):
+				// The lease is almost expired, it's time to request a new one.
+			case <-d.stopCh:
+				return nil, nil, ErrStopped
 			}
 		}
 	}

--- a/dependency/vault_write.go
+++ b/dependency/vault_write.go
@@ -92,10 +92,6 @@ func (d *VaultWriteQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interfa
 		} else {
 			// The secret isn't renewable, probably the generic secret backend.
 			dur := vaultRenewDuration(d.secret)
-			if dur > opts.VaultGrace {
-				dur = opts.VaultGrace
-			}
-
 			log.Printf("[TRACE] %s: secret is not renewable, sleeping for %s", d, dur)
 			select {
 			case <-time.After(dur):

--- a/dependency/vault_write.go
+++ b/dependency/vault_write.go
@@ -92,6 +92,10 @@ func (d *VaultWriteQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interfa
 		} else {
 			// The secret isn't renewable, probably the generic secret backend.
 			dur := vaultRenewDuration(d.secret)
+			if dur > opts.VaultGrace {
+				dur = opts.VaultGrace
+			}
+
 			log.Printf("[TRACE] %s: secret is not renewable, sleeping for %s", d, dur)
 			select {
 			case <-time.After(dur):


### PR DESCRIPTION
This fixes an issue introduced in
https://github.com/hashicorp/consul-template/commit/e2155b4caa67791e3f98e39cb5842d1033f24cf0
where renewals againsts the generic secret backend that has a TTL close
to the VaultGrace would cause a renewal hotloop.

This fixes https://github.com/hashicorp/nomad/issues/3133