### PR TITLE
runner: notify systemd after all templates have been rendered

### DIFF
--- a/manager/runner_test.go
+++ b/manager/runner_test.go
@@ -14,6 +14,13 @@ import (
 	"github.com/hashicorp/consul-template/template"
 )
 
+type mockNotifier struct{ s string }
+
+func (n *mockNotifier) Notify(state string) error {
+	n.s = state
+	return nil
+}
+
 func TestRunner_Receive(t *testing.T) {
 	t.Parallel()
 
@@ -518,6 +525,51 @@ func TestRunner_Start(t *testing.T) {
 			}
 			if l := len(c); l == 0 {
 				t.Errorf("\nexp: %#v\nact: %#v", "> 0", l)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout")
+		}
+	})
+
+	t.Run("notify", func(t *testing.T) {
+		t.Parallel()
+
+		out, err := ioutil.TempFile("", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(out.Name())
+
+		c := config.DefaultConfig().Merge(&config.Config{
+			Templates: &config.TemplateConfigs{
+				&config.TemplateConfig{
+					Contents:    config.String(`test`),
+					Destination: config.String(out.Name()),
+				},
+			},
+		})
+		c.Finalize()
+
+		r, err := NewRunner(c, false, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		notify := &mockNotifier{}
+		r.notifier = notify
+
+		go r.Start()
+		defer r.Stop()
+
+		select {
+		case err := <-r.ErrCh:
+			t.Fatal(err)
+		case <-r.renderedCh:
+			if !r.ready {
+				t.Errorf("\nexp: %#v\nact: %#v", true, r.ready)
+			}
+			if exp, act := "READY=1", notify.s; exp != act {
+				t.Errorf("\nexp: %#v\nact: %#v", exp, act)
 			}
 		case <-time.After(2 * time.Second):
 			t.Fatal("timeout")

--- a/manager/systemd/notifier.go
+++ b/manager/systemd/notifier.go
@@ -1,0 +1,35 @@
+package systemd
+
+import (
+	"errors"
+	"net"
+	"os"
+)
+
+var NotifyNoSocket = errors.New("No socket")
+
+const Ready = "READY=1"
+
+// Notifier provides a method to send a message to systemd.
+type Notifier struct{}
+
+// Notify sends a message to the init daemon. It is common to ignore the error.
+func (n *Notifier) Notify(state string) error {
+	addr := &net.UnixAddr{
+		Name: os.Getenv("NOTIFY_SOCKET"),
+		Net:  "unixgram",
+	}
+
+	if addr.Name == "" {
+		return NotifyNoSocket
+	}
+
+	conn, err := net.DialUnix(addr.Net, nil, addr)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	_, err = conn.Write([]byte(state))
+	return err
+}


### PR DESCRIPTION
Add support for notifying systemd after consul-template has finished
processing all templates for the first time, so that systemd can delay
starting other units that depend on consul-template until after their
templates have been processed.

Systemd notifications use a socket to avoid creating a library dependency.

See https://github.com/hashicorp/consul-template/issues/1011