### PR TITLE
Add functions for modifying runner out/err streams

### DIFF
--- a/manager/runner.go
+++ b/manager/runner.go
@@ -42,7 +42,8 @@ type Runner struct {
 	dry, once bool
 
 	// outStream and errStream are the io.Writer streams where the runner will
-	// write information.
+	// write information. These can be modified by calling SetOutStream and
+        // SetErrStream accordingly.
 
 	// inStream is the ioReader where the runner will read information.
 	outStream, errStream io.Writer
@@ -1066,6 +1067,16 @@ func (r *Runner) deletePid() error {
 		return fmt.Errorf("runner: could not remove pid file: %s", err)
 	}
 	return nil
+}
+
+// SetOutStream modifies runner output stream. Defaults to stdout.
+func (r *Runner) SetOutStream(out io.Writer) {
+	r.outStream = out
+}
+
+// SetErrStream modifies runner error stream. Defaults to stderr.
+func (r *Runner) SetErrStream(err io.Writer) {
+	r.errStream = err
 }
 
 // spawnChildInput is used as input to spawn a child process.


### PR DESCRIPTION
Currently the template runner writes its output to outStream and errStream. These are hardcoded to `stdout` and `stderr` in the `init()` function. This is particularly problematic when the `manager` package is used in a separate project where stdout/stderr is then polluted by the renderer. I have used a not-so-ideal wrapper as a workaround, which sets `os.Stdout` and `os.Stderr` to `/dev/null` just for a brief moment while calling `manager.NewRunner()`.

This PR adds functions `SetOutStream` and `SetErrStream` making output/error stream customization a lot easier. These functions should be called before starting the runner. If user is not interested in the output/error streams then both streams could be set to for e.g. [`ioutil.Discard`](https://golang.org/pkg/io/ioutil/#pkg-variables).

I also added a test for demonstrating this. This also shows how render contents can be accessed 
 by going through render events without using file-based rendering.

Relates to work done on issues #974 and #987. As mentioned, some time ago the code comments in `Runner` struct already referenced these functions.