### PR TITLE
Make default grace period match Vault's default, this makes it so 

### DIFF
--- a/config/vault.go
+++ b/config/vault.go
@@ -11,7 +11,7 @@ const (
 	// DefaultVaultGrace is the default grace period before which to read a new
 	// secret from Vault. If a lease is due to expire in 5 minutes, Consul
 	// Template will read a new secret at that time minus this value.
-	DefaultVaultGrace = 5 * time.Minute
+	DefaultVaultGrace = 15 * time.Second
 
 	// DefaultVaultRenewToken is the default value for if the Vault token should
 	// be renewed.

--- a/config/vault.go
+++ b/config/vault.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	// DefaultVaultGrace is the default grace period before which to read a new
-	// secret from Vault. If a lease is due to expire in 5 minutes, Consul
+	// secret from Vault. If a lease is due to expire in 15 seconds, Consul
 	// Template will read a new secret at that time minus this value.
 	DefaultVaultGrace = 15 * time.Second
 


### PR DESCRIPTION
users are not surprised by continuous renewals on dynamic secrets with TTLs lower than 5 minutes (the previous default).
