### PR TITLE
Allow colons in the template command on the command line

### DIFF
--- a/config/template.go
+++ b/config/template.go
@@ -399,7 +399,8 @@ func ParseTemplateConfig(s string) (*TemplateConfig, error) {
 	case 3:
 		source, destination, command = parts[0], parts[1], parts[2]
 	default:
-		return nil, ErrTemplateInvalidFormat
+		source, destination = parts[0], parts[1]
+		command = strings.Join(parts[2:], ":")
 	}
 
 	var sourcePtr, destinationPtr, commandPtr *string

--- a/config/template.go
+++ b/config/template.go
@@ -25,10 +25,6 @@ var (
 	// are empty.
 	ErrTemplateStringEmpty = errors.New("template: cannot be empty")
 
-	// ErrTemplateInvalidFormat is the error returned with the template is not
-	// a valid format.
-	ErrTemplateInvalidFormat = errors.New("template: invalid format")
-
 	// configTemplateRe is the pattern to split the config template syntax.
 	configTemplateRe = regexp.MustCompile("([a-zA-Z]:)?([^:]+)")
 )

--- a/config/template_test.go
+++ b/config/template_test.go
@@ -498,12 +498,6 @@ func TestParseTemplateConfig(t *testing.T) {
 			true,
 		},
 		{
-			"too_many_args",
-			"foo:bar:zip:zap",
-			nil,
-			true,
-		},
-		{
 			"default",
 			"/tmp/a.txt:/tmp/b.txt:command",
 			&TemplateConfig{
@@ -514,12 +508,38 @@ func TestParseTemplateConfig(t *testing.T) {
 			false,
 		},
 		{
+			"single",
+			"/tmp/a.txt",
+			&TemplateConfig{
+				Source: String("/tmp/a.txt"),
+			},
+			false,
+		},
+		{
+			"single_windows_drive",
+			`z:\foo`,
+			&TemplateConfig{
+				Source: String(`z:\foo`),
+			},
+			false,
+		},
+		{
 			"windows_drives",
 			`C:\abc\123:D:\xyz\789:command`,
 			&TemplateConfig{
 				Source:      String(`C:\abc\123`),
 				Destination: String(`D:\xyz\789`),
 				Command:     String(`command`),
+			},
+			false,
+		},
+		{
+			"windows_drives_with_colon",
+			`C:\abc\123:D:\xyz\789:sub:command`,
+			&TemplateConfig{
+				Source:      String(`C:\abc\123`),
+				Destination: String(`D:\xyz\789`),
+				Command:     String(`sub:command`),
 			},
 			false,
 		},


### PR DESCRIPTION
This allows you to write something like:

```shell
consul-template -template "in.ctmpl:out:curl https://google.com:443"
```