### PR TITLE
Renew the unwrapped token

### DIFF
--- a/dependency/client_set.go
+++ b/dependency/client_set.go
@@ -310,7 +310,7 @@ func (c *ClientSet) Consul() *consulapi.Client {
 	return c.consul.client
 }
 
-// Vault returns the Consul client for this set.
+// Vault returns the Vault client for this set.
 func (c *ClientSet) Vault() *vaultapi.Client {
 	c.RLock()
 	defer c.RUnlock()

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -1252,14 +1252,14 @@ func newWatcher(c *config.Config, clients *dep.ClientSet, once bool) (*watch.Wat
 		Clients:         clients,
 		MaxStale:        config.TimeDurationVal(c.MaxStale),
 		Once:            once,
-		RenewVault:      config.StringPresent(c.Vault.Token) && config.BoolVal(c.Vault.RenewToken),
+		RenewVault:      clients.Vault().Token() != "" && config.BoolVal(c.Vault.RenewToken),
 		RetryFuncConsul: watch.RetryFunc(c.Consul.Retry.RetryFunc()),
 		// TODO: Add a sane default retry - right now this only affects "local"
 		// dependencies like reading a file from disk.
 		RetryFuncDefault: nil,
 		RetryFuncVault:   watch.RetryFunc(c.Vault.Retry.RetryFunc()),
 		VaultGrace:       config.TimeDurationVal(c.Vault.Grace),
-		VaultToken:       config.StringVal(c.Vault.Token),
+		VaultToken:       clients.Vault().Token(),
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "runner")


### PR DESCRIPTION
In cases where both `renew_token=true` and `unwrap_token=true` the watcher is trying to renew the wrapping token and not the wrapped token, this change fixes it. It will create a watcher by getting the vault token from Vault client, which will be the unwrapped token in case `unwrap_token=true` is used.