### PR TITLE
Add a datacenter helper function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ BUG FIXES:
 IMPROVEMENTS:
 
 * The Vault grace period in the config is now set to 15 seconds as the default. This matches Vault's default configuration for consistency.
+* Add `datacenter` function
 
 ## v0.19.3 (September 11, 2017)
 

--- a/README.md
+++ b/README.md
@@ -509,6 +509,37 @@ provides the following functions:
 API functions interact with remote API calls, communicating with external
 services like [Consul][consul] and [Vault][vault].
 
+##### `datacenter`
+
+Query [Consul][consul] for the datacenter of a node in the catalog.
+
+```liquid
+{{datacenter "<NAME>@<DATACENTER>"}}
+```
+
+The `<NAME>` attribute is optional; if omitted, the local agent node is used.
+
+The `<DATACENTER>` attribute is optional; if omitted, the local datacenter is
+used.
+
+For example, in the `dc1` datacenter:
+
+```liquid
+{{ datacenter }}
+```
+
+renders
+
+```text
+dc1
+```
+
+To query a different node:
+
+```liquid
+{{ datacenter "node1@dc2" }}
+```
+
 ##### `datacenters`
 
 Query [Consul][consul] for all datacenters in its catalog.

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -25,6 +25,24 @@ import (
 // primarily for the tests to override times.
 var now = func() time.Time { return time.Now().UTC() }
 
+func datacenterFunc(b *Brain, used, missing *dep.Set) func(...string) (string, error) {
+	return func(s ...string) (string, error) {
+		d, err := dep.NewCatalogNodeQuery(strings.Join(s, ""))
+		if err != nil {
+			return "", err
+		}
+
+		used.Add(d)
+
+		if value, ok := b.Recall(d); ok {
+			return value.(*dep.CatalogNode).Node.Datacenter, nil
+		}
+
+		missing.Add(d)
+		return "", nil
+	}
+}
+
 // datacentersFunc returns or accumulates datacenter dependencies.
 func datacentersFunc(b *Brain, used, missing *dep.Set) func(ignore ...bool) ([]string, error) {
 	return func(i ...bool) ([]string, error) {

--- a/template/template.go
+++ b/template/template.go
@@ -200,6 +200,7 @@ func funcMap(i *funcMapInput) template.FuncMap {
 
 	return template.FuncMap{
 		// API functions
+		"datacenter":   datacenterFunc(i.brain, i.used, i.missing),
 		"datacenters":  datacentersFunc(i.brain, i.used, i.missing),
 		"file":         fileFunc(i.brain, i.used, i.missing),
 		"key":          keyFunc(i.brain, i.used, i.missing),

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -246,6 +246,27 @@ func TestTemplate_Execute(t *testing.T) {
 			false,
 		},
 		{
+			"func_datacenter",
+			&NewTemplateInput{
+				Contents: `{{ datacenter }}`,
+			},
+			&ExecuteInput{
+				Brain: func() *Brain {
+					b := NewBrain()
+					d, err := dep.NewCatalogNodeQuery("")
+					if err != nil {
+						t.Fatal(err)
+					}
+					b.Remember(d, &dep.CatalogNode{
+						Node: &dep.Node{Node: "node1", Datacenter: "dc1"},
+					})
+					return b
+				}(),
+			},
+			"dc1",
+			false,
+		},
+		{
 			"func_datacenters",
 			&NewTemplateInput{
 				Contents: `{{ datacenters }}`,


### PR DESCRIPTION
This is primarily a convenience function that makes it easier to get at the local datacenter. While this doesn't add functionality that can be achieved with scratch:

```liquid
{with node}}{{scratch.Set "datacenter" .Node.Datacenter}}{{end}}
```

And then ``{{scratch.Get "datacenter"}}`` to render the value, I figured simply being able to do ``{{datacenter}}`` was easier and more direct.


