### PR TITLE
Added rate_limit support to avoid sending too many requests to Consul Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ consul {
   token = "abcd1234"
 
   rate_limit {
-    # Enable rate limit with throttle max requests/sec per endpoint.
+    # Enable rate limit with throttle max requests/sec to consul agent.
     enabled = true
 
     # Adds a random delay between consecutive calls
@@ -160,9 +160,9 @@ consul {
 
     # When watching a resource, if the resource is fetched before that amount
     # of time, do not try to fetch the resource again until this timeout occurs.
-    # Setting this value to 30 minute, means you will never be notified of changes
-    # faster than every 30 seconds between 2 updates.
-    min_delay_between_updates = "30s"
+    # Setting this value to 10 seconds means you will never be notified of changes
+    # faster than every 10 seconds between 2 updates.
+    min_delay_between_updates = "10s"
   }
   # This controls the retry behavior when an error is returned from Consul.
   # Consul Template is highly fault tolerant, meaning it does not exit in the

--- a/README.md
+++ b/README.md
@@ -151,6 +151,19 @@ consul {
   # This option is also available via the environment variable CONSUL_TOKEN.
   token = "abcd1234"
 
+  rate_limit {
+    # Enable rate limit with throttle max requests/sec per endpoint.
+    enabled = true
+
+    # Adds a random delay between consecutive calls
+    random_backoff = "33ms"
+
+    # When watching a resource, if the resource is fetched before that amount
+    # of time, do not try to fetch the resource again until this timeout occurs.
+    # Setting this value to 30 minute, means you will never be notified of changes
+    # faster than every 30 seconds between 2 updates.
+    min_delay_between_updates = "30s"
+  }
   # This controls the retry behavior when an error is returned from Consul.
   # Consul Template is highly fault tolerant, meaning it does not exit in the
   # face of failure. Instead, it uses exponential back-off and retry functions

--- a/config/config.go
+++ b/config/config.go
@@ -213,6 +213,7 @@ func Parse(s string) (*Config, error) {
 		"auth",
 		"consul",
 		"consul.auth",
+		"consul.rate_limit",
 		"consul.retry",
 		"consul.ssl",
 		"consul.transport",

--- a/config/consul.go
+++ b/config/consul.go
@@ -11,6 +11,9 @@ type ConsulConfig struct {
 	// Auth is the HTTP basic authentication for communicating with Consul.
 	Auth *AuthConfig `mapstructure:"auth"`
 
+	// RateLimit is the configuration for re-query on success.
+	RateLimit *RateLimitConfig `mapstructure:"rate_limit"`
+
 	// Retry is the configuration for specifying how to behave on failure.
 	Retry *RetryConfig `mapstructure:"retry"`
 
@@ -30,6 +33,7 @@ type ConsulConfig struct {
 func DefaultConsulConfig() *ConsulConfig {
 	return &ConsulConfig{
 		Auth:      DefaultAuthConfig(),
+		RateLimit: DefaultRateLimitConfig(),
 		Retry:     DefaultRetryConfig(),
 		SSL:       DefaultSSLConfig(),
 		Transport: DefaultTransportConfig(),
@@ -48,6 +52,10 @@ func (c *ConsulConfig) Copy() *ConsulConfig {
 
 	if c.Auth != nil {
 		o.Auth = c.Auth.Copy()
+	}
+
+	if c.RateLimit != nil {
+		o.RateLimit = c.RateLimit.Copy()
 	}
 
 	if c.Retry != nil {
@@ -93,6 +101,10 @@ func (c *ConsulConfig) Merge(o *ConsulConfig) *ConsulConfig {
 		r.Auth = r.Auth.Merge(o.Auth)
 	}
 
+	if o.RateLimit != nil {
+		r.RateLimit = r.RateLimit.Merge(o.RateLimit)
+	}
+
 	if o.Retry != nil {
 		r.Retry = r.Retry.Merge(o.Retry)
 	}
@@ -124,6 +136,11 @@ func (c *ConsulConfig) Finalize() {
 		c.Auth = DefaultAuthConfig()
 	}
 	c.Auth.Finalize()
+
+	if c.RateLimit == nil {
+		c.RateLimit = DefaultRateLimitConfig()
+	}
+	c.RateLimit.Finalize()
 
 	if c.Retry == nil {
 		c.Retry = DefaultRetryConfig()
@@ -157,6 +174,7 @@ func (c *ConsulConfig) GoString() string {
 	return fmt.Sprintf("&ConsulConfig{"+
 		"Address:%s, "+
 		"Auth:%#v, "+
+		"RateLimit:%#v,"+
 		"Retry:%#v, "+
 		"SSL:%#v, "+
 		"Token:%t, "+
@@ -164,6 +182,7 @@ func (c *ConsulConfig) GoString() string {
 		"}",
 		StringGoString(c.Address),
 		c.Auth,
+		c.RateLimit,
 		c.Retry,
 		c.SSL,
 		StringPresent(c.Token),

--- a/config/consul_test.go
+++ b/config/consul_test.go
@@ -23,11 +23,12 @@ func TestConsulConfig_Copy(t *testing.T) {
 		{
 			"same_enabled",
 			&ConsulConfig{
-				Address: String("1.2.3.4"),
-				Auth:    &AuthConfig{Enabled: Bool(true)},
-				Retry:   &RetryConfig{Enabled: Bool(true)},
-				SSL:     &SSLConfig{Enabled: Bool(true)},
-				Token:   String("abcd1234"),
+				Address:   String("1.2.3.4"),
+				Auth:      &AuthConfig{Enabled: Bool(true)},
+				RateLimit: &RateLimitConfig{Enabled: Bool(true)},
+				Retry:     &RetryConfig{Enabled: Bool(true)},
+				SSL:       &SSLConfig{Enabled: Bool(true)},
+				Token:     String("abcd1234"),
 				Transport: &TransportConfig{
 					DialKeepAlive: TimeDuration(20 * time.Second),
 				},
@@ -247,6 +248,11 @@ func TestConsulConfig_Finalize(t *testing.T) {
 					Enabled:  Bool(false),
 					Username: String(""),
 					Password: String(""),
+				},
+				RateLimit: &RateLimitConfig{
+					MinDelayBetweenUpdates: TimeDuration(DefaultMinDelayBetweenUpdates),
+					RandomBackoff:          TimeDuration(DefaultRandomBackoff),
+					Enabled:                Bool(true),
 				},
 				Retry: &RetryConfig{
 					Backoff:    TimeDuration(DefaultRetryBackoff),

--- a/config/ratelimit.go
+++ b/config/ratelimit.go
@@ -1,0 +1,136 @@
+package config
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+const (
+	// DefaultRandomBackoff is the default max delay added between successful calls.
+	DefaultRandomBackoff = 33 * time.Millisecond
+	// DefaultMinDelayBetweenUpdates is the default delay between successful.
+	DefaultMinDelayBetweenUpdates = 500 * time.Millisecond
+)
+
+// RateLimitFunc is the signature of a function to sleep between calls
+type RateLimitFunc func(time.Duration) (bool, time.Duration)
+
+// RateLimitConfig is a shared configuration
+type RateLimitConfig struct {
+
+	// Minimum Delay between 2 consecutive HTTP calls
+	RandomBackoff *time.Duration `mapstructure:"random_backoff"`
+
+	// Minimum Delay of 2 calls (includes download)
+	MinDelayBetweenUpdates *time.Duration `mapstructure:"min_delay_between_updates"`
+
+	// Enabled signals if this retry is enabled.
+	Enabled *bool
+}
+
+// DefaultRateLimitConfig returns a configuration that is populated with the
+// default values.
+func DefaultRateLimitConfig() *RateLimitConfig {
+	return &RateLimitConfig{}
+}
+
+// Copy returns a deep copy of this configuration.
+func (c *RateLimitConfig) Copy() *RateLimitConfig {
+	if c == nil {
+		return nil
+	}
+
+	var o RateLimitConfig
+
+	o.RandomBackoff = c.RandomBackoff
+
+	o.MinDelayBetweenUpdates = c.MinDelayBetweenUpdates
+
+	o.Enabled = c.Enabled
+
+	return &o
+}
+
+// Merge combines all values in this configuration with the values in the other
+// configuration, with values in the other configuration taking precedence.
+// Maps and slices are merged, most other values are overwritten. Complex
+// structs define their own merge functionality.
+func (c *RateLimitConfig) Merge(o *RateLimitConfig) *RateLimitConfig {
+	if c == nil {
+		if o == nil {
+			return nil
+		}
+		return o.Copy()
+	}
+
+	if o == nil {
+		return c.Copy()
+	}
+
+	r := c.Copy()
+
+	if o.RandomBackoff != nil {
+		r.RandomBackoff = o.RandomBackoff
+	}
+	if o.MinDelayBetweenUpdates != nil {
+		r.MinDelayBetweenUpdates = o.MinDelayBetweenUpdates
+	}
+
+	if o.Enabled != nil {
+		r.Enabled = o.Enabled
+	}
+
+	return r
+}
+
+// RateLimitFunc returns the RateLimit function associated with this configuration.
+func (c *RateLimitConfig) RateLimitFunc() RateLimitFunc {
+	return func(lastCallDuration time.Duration) (bool, time.Duration) {
+		if !BoolVal(c.Enabled) {
+			return false, 0
+		}
+		remaining := *c.MinDelayBetweenUpdates - lastCallDuration
+		if remaining < 0 {
+			remaining = 0
+		}
+		if c.RandomBackoff.Nanoseconds() < 1 {
+			return remaining > 0, remaining
+		}
+		random := time.Duration(rand.Int63n(int64(c.RandomBackoff.Nanoseconds())))
+		return true, (remaining + random)
+	}
+}
+
+// Finalize ensures there no nil pointers.
+func (c *RateLimitConfig) Finalize() {
+
+	if c.RandomBackoff == nil {
+		c.RandomBackoff = TimeDuration(DefaultRandomBackoff)
+	}
+
+	if c.MinDelayBetweenUpdates == nil {
+		c.MinDelayBetweenUpdates = TimeDuration(DefaultMinDelayBetweenUpdates)
+	}
+
+	if c.Enabled == nil {
+		c.Enabled = Bool(true)
+	}
+}
+
+// GoString defines the printable version of this struct.
+func (c *RateLimitConfig) GoString() string {
+	if c == nil {
+		return "(*RateLimitConfig)(nil)"
+	}
+
+	return fmt.Sprintf("&RateLimitConfig{"+
+		"RandomBackoff:%s, "+
+		"MinDelayBetweenUpdates:%s, "+
+		"Enabled:%s"+
+		"}",
+		TimeDurationGoString(c.RandomBackoff),
+		TimeDurationGoString(c.MinDelayBetweenUpdates),
+		BoolGoString(c.Enabled),
+	)
+}

--- a/config/ratelimit.go
+++ b/config/ratelimit.go
@@ -10,7 +10,7 @@ const (
 	// DefaultRandomBackoff is the default max delay added between successful calls.
 	DefaultRandomBackoff = 33 * time.Millisecond
 	// DefaultMinDelayBetweenUpdates is the default delay between successful.
-	DefaultMinDelayBetweenUpdates = 500 * time.Millisecond
+	DefaultMinDelayBetweenUpdates = 100 * time.Millisecond
 )
 
 // RateLimitFunc is the signature of a function to sleep between calls

--- a/config/ratelimit_test.go
+++ b/config/ratelimit_test.go
@@ -1,0 +1,172 @@
+package config
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestRateLimitFunc(t *testing.T) {
+	cases := []struct {
+		name string
+		c    *RateLimitConfig
+		t    *time.Duration
+		rc   *bool
+		rs   *time.Duration
+	}{
+		{
+			"default, 0 duration",
+			&RateLimitConfig{
+				RandomBackoff: TimeDuration(0 * time.Millisecond),
+			},
+			TimeDuration(0 * time.Millisecond),
+			Bool(true),
+			TimeDuration(DefaultMinDelayBetweenUpdates),
+		},
+		{
+			"default, 5 duration",
+			&RateLimitConfig{
+				RandomBackoff: TimeDuration(0 * time.Millisecond),
+			},
+			TimeDuration(5 * time.Millisecond),
+			Bool(true),
+			TimeDuration(DefaultMinDelayBetweenUpdates - 5*time.Millisecond),
+		},
+		{
+			"default, Min duration between calls",
+			&RateLimitConfig{
+				RandomBackoff: TimeDuration(0 * time.Millisecond),
+			},
+			TimeDuration(DefaultMinDelayBetweenUpdates - 1),
+			Bool(true),
+			TimeDuration(1),
+		},
+		{
+			"default, Min duration between calls",
+			&RateLimitConfig{
+				RandomBackoff: TimeDuration(0 * time.Millisecond),
+			},
+			TimeDuration(DefaultMinDelayBetweenUpdates + 10),
+			Bool(false),
+			TimeDuration(0),
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			tc.c.Finalize()
+			wait, s := tc.c.RateLimitFunc()(*tc.t)
+			if wait != *tc.rc {
+				t.Errorf("\nexp sleep wait: %#v\nact: %#v", *tc.rc, wait)
+			}
+			if (*tc.rs) != s {
+				t.Errorf("\nexp sleep time: %#v\nact: %#v", *tc.rs, s)
+			}
+		})
+	}
+
+}
+
+func TestRateLimitConfig_Copy(t *testing.T) {
+	cases := []struct {
+		name string
+		a    *RateLimitConfig
+	}{
+		{
+			"nil",
+			nil,
+		},
+		{
+			"empty",
+			&RateLimitConfig{},
+		},
+		{
+			"same_enabled",
+			&RateLimitConfig{
+				RandomBackoff:          TimeDuration(DefaultRandomBackoff),
+				MinDelayBetweenUpdates: TimeDuration(DefaultMinDelayBetweenUpdates),
+				Enabled:                Bool(true),
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			r := tc.a.Copy()
+			if !reflect.DeepEqual(tc.a, r) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.a, r)
+			}
+		})
+	}
+}
+
+func TestRateLimitConfig_Merge(t *testing.T) {
+	cases := []struct {
+		name string
+		a    *RateLimitConfig
+		b    *RateLimitConfig
+		r    *RateLimitConfig
+	}{
+		{
+			"nil_a",
+			nil,
+			&RateLimitConfig{},
+			&RateLimitConfig{},
+		},
+		{
+			"nil_b",
+			&RateLimitConfig{},
+			nil,
+			&RateLimitConfig{},
+		},
+		{
+			"nil_both",
+			nil,
+			nil,
+			nil,
+		},
+		{
+			"empty",
+			&RateLimitConfig{},
+			&RateLimitConfig{},
+			&RateLimitConfig{},
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			r := tc.a.Merge(tc.b)
+			if !reflect.DeepEqual(tc.r, r) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.r, r)
+			}
+		})
+	}
+}
+
+func TestRateLimitConfig_Finalize(t *testing.T) {
+	cases := []struct {
+		name string
+		i    *RateLimitConfig
+		r    *RateLimitConfig
+	}{
+		{
+			"empty",
+			&RateLimitConfig{},
+			&RateLimitConfig{
+				RandomBackoff:          TimeDuration(DefaultRandomBackoff),
+				MinDelayBetweenUpdates: TimeDuration(DefaultMinDelayBetweenUpdates),
+				Enabled:                Bool(true),
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			tc.i.Finalize()
+			if !reflect.DeepEqual(tc.r, tc.i) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.r, tc.i)
+			}
+		})
+	}
+}

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -1250,17 +1250,19 @@ func newWatcher(c *config.Config, clients *dep.ClientSet, once bool) (*watch.Wat
 	log.Printf("[INFO] (runner) creating watcher")
 
 	w, err := watch.NewWatcher(&watch.NewWatcherInput{
-		Clients:         clients,
-		MaxStale:        config.TimeDurationVal(c.MaxStale),
-		Once:            once,
-		RenewVault:      clients.Vault().Token() != "" && config.BoolVal(c.Vault.RenewToken),
-		RetryFuncConsul: watch.RetryFunc(c.Consul.Retry.RetryFunc()),
+		Clients:             clients,
+		MaxStale:            config.TimeDurationVal(c.MaxStale),
+		Once:                once,
+		RenewVault:          clients.Vault().Token() != "" && config.BoolVal(c.Vault.RenewToken),
+		RateLimitFuncConsul: watch.RateLimitFunc(c.Consul.RateLimit.RateLimitFunc()),
+		RetryFuncConsul:     watch.RetryFunc(c.Consul.Retry.RetryFunc()),
 		// TODO: Add a sane default retry - right now this only affects "local"
 		// dependencies like reading a file from disk.
-		RetryFuncDefault: nil,
-		RetryFuncVault:   watch.RetryFunc(c.Vault.Retry.RetryFunc()),
-		VaultGrace:       config.TimeDurationVal(c.Vault.Grace),
-		VaultToken:       clients.Vault().Token(),
+		RateLimitFuncDefault: nil,
+		RetryFuncDefault:     nil,
+		RetryFuncVault:       watch.RetryFunc(c.Vault.Retry.RetryFunc()),
+		VaultGrace:           config.TimeDurationVal(c.Vault.Grace),
+		VaultToken:           clients.Vault().Token(),
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "runner")

--- a/watch/view_test.go
+++ b/watch/view_test.go
@@ -119,6 +119,9 @@ func TestPoll_once(t *testing.T) {
 func TestPoll_retries(t *testing.T) {
 	view, err := NewView(&NewViewInput{
 		Dependency: &TestDepRetry{},
+		RateLimitFunc: func(delay time.Duration) (bool, time.Duration) {
+			return true, 0 * time.Millisecond
+		},
 		RetryFunc: func(retry int) (bool, time.Duration) {
 			return retry < 1, 250 * time.Millisecond
 		},


### PR DESCRIPTION
This PR adds support for:
* waiting at least <duration> between 2 downloads when watching a file controlled by `rate_limit.min_delay_between_updates`
* add a random delay between fetching data with param `rate_limit.random_backoff`

This should avoid allow limiting the bandwidth used by consul-template on large clusters with lots of services when watching many services (and X-Consul-Index being updated very frequently)

cf https://github.com/hashicorp/consul-template/issues/1065