### PR TITLE
Obtain current hostname of machine/container where consul-template runs.

### DIFF
--- a/template/funcs.go
+++ b/template/funcs.go
@@ -58,6 +58,21 @@ func datacentersFunc(b *Brain, used, missing *dep.Set) func(ignore ...bool) ([]s
 	}
 }
 
+// getHostnameFunc returns a current hostname from /proc/sys/kernel/hostname
+func getHostnameFunc() func() (string, error) {
+	return func() (string, error) {
+		hostname, err := os.Hostname()
+		if err != nil {
+			return "", fmt.Errorf(
+				"hostname: can't get current hostname, reason^ %s",
+				err.Error(),
+			)
+		}
+
+		return hostname, nil
+	}
+}
+
 // envFunc returns a function which checks the value of an environment variable.
 // Invokers can specify their own environment, which takes precedences over any
 // real environment variables

--- a/template/template.go
+++ b/template/template.go
@@ -230,6 +230,7 @@ func funcMap(i *funcMapInput) template.FuncMap {
 		"containsNone":    containsSomeFunc(true, false),
 		"containsNotAll":  containsSomeFunc(false, true),
 		"env":             envFunc(i.env),
+		"hostname":        getHostnameFunc(),
 		"executeTemplate": executeTemplateFunc(i.t),
 		"explode":         explode,
 		"in":              in,

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -128,6 +128,12 @@ func TestTemplate_Execute(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	currentHostname, err := os.Hostname()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	f.WriteString("test")
 	defer os.Remove(f.Name())
 
@@ -1070,6 +1076,15 @@ func TestTemplate_Execute(t *testing.T) {
 				}(),
 			},
 			"",
+			false,
+		},
+		{
+			"helper_hostname",
+			&NewTemplateInput{
+				Contents: `{{ hostname }}`,
+			},
+			nil,
+			currentHostname,
 			false,
 		},
 		{


### PR DESCRIPTION
This PR provides template function - `{{ hostname }}` to set a hostname of machine or container where consul-template executes. I know that hostname can be obtained by ENV variables but in different Linux distributions, these variables are not the same, for example, in Ubuntu hostname stored in $HOSTNAME, but in ArchLinux in $HOST, so, I think the most common way to obtain hostname is read this file -  `/proc/sys/kernel/hostname`.