### PR TITLE
Document consul dependency for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2158,7 +2158,7 @@ following to generate all binaries:
 $ make bin
 ```
 
-If you just want to run the tests:
+If you want to run the tests, first [install consul locally](https://www.consul.io/docs/install/index.html), then:
 
 ```shell
 $ make test

--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 		c.Stderr = ioutil.Discard
 	})
 	if err != nil {
-		log.Fatal("failed to start consul server")
+		log.Fatal(err)
 	}
 	testConsul = consul
 

--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 		c.Stderr = ioutil.Discard
 	})
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(fmt.Errorf("failed to start consul server: %v", err))
 	}
 	testConsul = consul
 

--- a/main_test.go
+++ b/main_test.go
@@ -20,7 +20,7 @@ func TestMain(m *testing.M) {
 		c.Stderr = ioutil.Discard
 	})
 	if err != nil {
-		log.Fatal("failed to start consul server")
+		log.Fatal(err)
 	}
 	testConsul = consul
 

--- a/main_test.go
+++ b/main_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"testing"
+	"fmt"
 
 	dep "github.com/hashicorp/consul-template/dependency"
 	"github.com/hashicorp/consul/testutil"
@@ -20,7 +21,7 @@ func TestMain(m *testing.M) {
 		c.Stderr = ioutil.Discard
 	})
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(fmt.Errorf("failed to start consul server: %v", err))
 	}
 	testConsul = consul
 

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -21,7 +21,7 @@ func TestMain(m *testing.M) {
 		// c.Stderr = ioutil.Discard
 	})
 	if err != nil {
-		log.Fatal("failed to start consul server")
+		log.Fatal(err)
 	}
 	testConsul = consul
 

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 	"testing"
+	"fmt"
 
 	"github.com/hashicorp/consul-template/config"
 	dep "github.com/hashicorp/consul-template/dependency"
@@ -21,7 +22,7 @@ func TestMain(m *testing.M) {
 		// c.Stderr = ioutil.Discard
 	})
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(fmt.Errorf("failed to start consul server: %v", err))
 	}
 	testConsul = consul
 


### PR DESCRIPTION
Test fails with a generic failure message if consul is not installed:
```2018/02/15 20:25:12 failed to start consul server```

The `NewTestServer` helper already supports good error messaging for this, but it is swallowed. I have revealed it:
```2018/02/15 21:43:01 consul not found on $PATH - download and install consul or skip this test```

Also updated docs with link to consul install guide.