### PR TITLE
allow overriding the default delimiter

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -310,6 +310,16 @@ func (cli *CLI) ParseFlags(args []string) (*config.Config, []string, bool, bool,
 		return nil
 	}), "dedup", "")
 
+	flags.Var((funcVar)(func(s string) error {
+		c.Defaults.LeftDelim = config.String(s)
+		return nil
+	}), "defaults-left-delimiter", "")
+
+	flags.Var((funcVar)(func(s string) error {
+		c.Defaults.RightDelim = config.String(s)
+		return nil
+	}), "defaults-right-delimiter", "")
+
 	flags.BoolVar(&dry, "dry", false, "")
 
 	flags.Var((funcVar)(func(s string) error {
@@ -654,6 +664,12 @@ Options:
   -dedup
       Enable de-duplication mode - reduces load on Consul when many instances of
       Consul Template are rendering a common template
+
+  -defaults-left-delimiter
+      The default left delimiter for templating
+
+  -defaults-right-delimiter
+      The default right delimiter for templating
 
   -dry
       Print generated templates to stdout instead of rendering

--- a/config/config.go
+++ b/config/config.go
@@ -47,6 +47,9 @@ type Config struct {
 	// Dedup is used to configure the dedup settings
 	Dedup *DedupConfig `mapstructure:"deduplicate"`
 
+	// Default is used to configure the defaults for templates
+	Defaults *DefaultsConfig `mapstructure:"defaults"`
+
 	// Exec is the configuration for exec/supervise mode.
 	Exec *ExecConfig `mapstructure:"exec"`
 
@@ -94,6 +97,10 @@ func (c *Config) Copy() *Config {
 
 	if c.Dedup != nil {
 		o.Dedup = c.Dedup.Copy()
+	}
+
+	if c.Defaults != nil {
+		o.Defaults = c.Defaults.Copy()
 	}
 
 	if c.Exec != nil {
@@ -151,6 +158,10 @@ func (c *Config) Merge(o *Config) *Config {
 
 	if o.Dedup != nil {
 		r.Dedup = r.Dedup.Merge(o.Dedup)
+	}
+
+	if o.Defaults != nil {
+		r.Defaults = r.Defaults.Merge(o.Defaults)
 	}
 
 	if o.Exec != nil {
@@ -217,6 +228,7 @@ func Parse(s string) (*Config, error) {
 		"consul.ssl",
 		"consul.transport",
 		"deduplicate",
+		"defaults",
 		"env",
 		"exec",
 		"exec.env",
@@ -371,6 +383,7 @@ func (c *Config) GoString() string {
 	return fmt.Sprintf("&Config{"+
 		"Consul:%#v, "+
 		"Dedup:%#v, "+
+		"Defaults:%#v, "+
 		"Exec:%#v, "+
 		"KillSignal:%s, "+
 		"LogLevel:%s, "+
@@ -384,6 +397,7 @@ func (c *Config) GoString() string {
 		"}",
 		c.Consul,
 		c.Dedup,
+		c.Defaults,
 		c.Exec,
 		SignalGoString(c.KillSignal),
 		StringGoString(c.LogLevel),
@@ -403,6 +417,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		Consul:    DefaultConsulConfig(),
 		Dedup:     DefaultDedupConfig(),
+		Defaults:  DefaultDefaultsConfig(),
 		Exec:      DefaultExecConfig(),
 		Syslog:    DefaultSyslogConfig(),
 		Templates: DefaultTemplateConfigs(),
@@ -426,6 +441,10 @@ func (c *Config) Finalize() {
 		c.Dedup = DefaultDedupConfig()
 	}
 	c.Dedup.Finalize()
+
+	if c.Defaults == nil {
+		c.Defaults = DefaultDefaultsConfig()
+	}
 
 	if c.Exec == nil {
 		c.Exec = DefaultExecConfig()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -300,6 +300,30 @@ func TestParse(t *testing.T) {
 			false,
 		},
 		{
+			"defaults_left_delimiter",
+			`defaults {
+				left_delimiter = "<"
+			}`,
+			&Config{
+				Defaults: &DefaultsConfig{
+					LeftDelim: String("<"),
+				},
+			},
+			false,
+		},
+		{
+			"defaults_right_delimiter",
+			`defaults {
+				right_delimiter = ">"
+			}`,
+			&Config{
+				Defaults: &DefaultsConfig{
+					RightDelim: String(">"),
+				},
+			},
+			false,
+		},
+		{
 			"exec",
 			`exec {}`,
 			&Config{

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -1,0 +1,53 @@
+package config
+
+// DefaultsConfig is used to configure the defaults used for all templates
+type DefaultsConfig struct {
+	// LeftDelim is the left delimiter for templating
+	LeftDelim *string `mapstructure:"left_delimiter"`
+
+	// RightDelim is the right delimiter for templating
+	RightDelim *string `mapstructure:"right_delimiter"`
+}
+
+// DefaultDefaultsConfig returns the default DefaultsConfig
+func DefaultDefaultsConfig() *DefaultsConfig {
+	return &DefaultsConfig{}
+}
+
+// Copy returns a copy of the DefaultsConfig
+func (c *DefaultsConfig) Copy() *DefaultsConfig {
+	if c == nil {
+		return nil
+	}
+
+	return &DefaultsConfig{
+		LeftDelim:  c.LeftDelim,
+		RightDelim: c.RightDelim,
+	}
+}
+
+// Merge merges the DefaultsConfigs
+func (c *DefaultsConfig) Merge(o *DefaultsConfig) *DefaultsConfig {
+	if c == nil {
+		if o == nil {
+			return nil
+		}
+		return o.Copy()
+	}
+
+	if o == nil {
+		return c.Copy()
+	}
+
+	r := c.Copy()
+
+	if o.LeftDelim != nil {
+		r.LeftDelim = o.LeftDelim
+	}
+
+	if o.RightDelim != nil {
+		r.RightDelim = o.RightDelim
+	}
+
+	return r
+}

--- a/config/defaults_test.go
+++ b/config/defaults_test.go
@@ -1,0 +1,118 @@
+package config
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestDefaultsConfig_Copy(t *testing.T) {
+	cases := []struct {
+		name string
+		a    *DefaultsConfig
+	}{
+		{
+			"nil",
+			nil,
+		},
+		{
+			"empty",
+			&DefaultsConfig{},
+		},
+		{
+			"copy",
+			&DefaultsConfig{
+				LeftDelim:  String("<<"),
+				RightDelim: String(">>"),
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			r := tc.a.Copy()
+			if !reflect.DeepEqual(tc.a, r) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.a, r)
+			}
+		})
+	}
+}
+
+func TestDefaultsConfig_Merge(t *testing.T) {
+	cases := []struct {
+		name string
+		a    *DefaultsConfig
+		b    *DefaultsConfig
+		r    *DefaultsConfig
+	}{
+		{
+			"nil_a",
+			nil,
+			&DefaultsConfig{},
+			&DefaultsConfig{},
+		},
+		{
+			"nil_b",
+			&DefaultsConfig{},
+			nil,
+			&DefaultsConfig{},
+		},
+		{
+			"nil_both",
+			nil,
+			nil,
+			nil,
+		},
+		{
+			"empty",
+			&DefaultsConfig{},
+			&DefaultsConfig{},
+			&DefaultsConfig{},
+		},
+		{
+			"left_delim_l",
+			&DefaultsConfig{LeftDelim: String("<<")},
+			&DefaultsConfig{},
+			&DefaultsConfig{LeftDelim: String("<<")},
+		},
+		{
+			"left_delim_r",
+			&DefaultsConfig{},
+			&DefaultsConfig{LeftDelim: String("<<")},
+			&DefaultsConfig{LeftDelim: String("<<")},
+		},
+		{
+			"left_delim_r2",
+			&DefaultsConfig{LeftDelim: String(">>")},
+			&DefaultsConfig{LeftDelim: String("<<")},
+			&DefaultsConfig{LeftDelim: String("<<")},
+		},
+		{
+			"right_delim_l",
+			&DefaultsConfig{RightDelim: String(">>")},
+			&DefaultsConfig{},
+			&DefaultsConfig{RightDelim: String(">>")},
+		},
+		{
+			"right_delim_r",
+			&DefaultsConfig{},
+			&DefaultsConfig{RightDelim: String(">>")},
+			&DefaultsConfig{RightDelim: String(">>")},
+		},
+		{
+			"right_delim_r2",
+			&DefaultsConfig{RightDelim: String("<<")},
+			&DefaultsConfig{RightDelim: String(">>")},
+			&DefaultsConfig{RightDelim: String(">>")},
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			r := tc.a.Merge(tc.b)
+			if !reflect.DeepEqual(tc.r, r) {
+				t.Errorf("\nexp: %#v\nact: %#v", tc.r, r)
+			}
+		})
+	}
+}

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -842,12 +842,21 @@ func (r *Runner) init() error {
 	// config templates is kept so templates can lookup their commands and output
 	// destinations.
 	for _, ctmpl := range *r.config.Templates {
+		leftDelim := config.StringVal(ctmpl.LeftDelim)
+		if leftDelim == "" {
+			leftDelim = config.StringVal(r.config.Defaults.LeftDelim)
+		}
+		rightDelim := config.StringVal(ctmpl.RightDelim)
+		if ctmpl.RightDelim != nil {
+			rightDelim = config.StringVal(r.config.Defaults.RightDelim)
+		}
+
 		tmpl, err := template.NewTemplate(&template.NewTemplateInput{
 			Source:        config.StringVal(ctmpl.Source),
 			Contents:      config.StringVal(ctmpl.Contents),
 			ErrMissingKey: config.BoolVal(ctmpl.ErrMissingKey),
-			LeftDelim:     config.StringVal(ctmpl.LeftDelim),
-			RightDelim:    config.StringVal(ctmpl.RightDelim),
+			LeftDelim:     leftDelim,
+			RightDelim:    rightDelim,
 		})
 		if err != nil {
 			return err

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -847,7 +847,7 @@ func (r *Runner) init() error {
 			leftDelim = config.StringVal(r.config.Defaults.LeftDelim)
 		}
 		rightDelim := config.StringVal(ctmpl.RightDelim)
-		if ctmpl.RightDelim != nil {
+		if rightDelim == "" {
 			rightDelim = config.StringVal(r.config.Defaults.RightDelim)
 		}
 


### PR DESCRIPTION
For: https://github.com/hashicorp/consul-template/issues/1008

This implements a `defaults` section that allows you to overwrite the default delimiters used for all templates.