### PR TITLE
 Add wrapper function for go-sockaddr templating

### DIFF
--- a/README.md
+++ b/README.md
@@ -1705,6 +1705,18 @@ minconns: "2"
 
 Note: Consul stores all KV data as strings. Thus true is "true", 1 is "1", etc.
 
+##### `sockaddr`
+
+Takes a quote-escaped template string as an argument and passes it on to
+[hashicorp/go-sockaddr](https://github.com/hashicorp/go-sockaddr) templating engine.
+
+```liquid
+{{ sockaddr "GetPrivateIP" }}
+```
+
+See [hashicorp/go-sockaddr documentation](https://godoc.org/github.com/hashicorp/go-sockaddr)
+for more information.
+
 ---
 
 #### Math Functions

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/hashicorp/go-msgpack v0.5.5 // indirect
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/go-rootcerts v1.0.1
+	github.com/hashicorp/go-sockaddr v1.0.2
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/hashicorp/hcl v1.0.0

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	dep "github.com/hashicorp/consul-template/dependency"
+	socktmpl "github.com/hashicorp/go-sockaddr/template"
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -1188,4 +1189,14 @@ func sandboxedPath(sandbox, s string) (string, error) {
 		}
 	}
 	return path, nil
+}
+
+// sockaddr wraps go-sockaddr templating
+func sockaddr(args ...string) (string, error) {
+	t := fmt.Sprintf("{{ %s }} ", strings.Join(args, " "))
+	k, err := socktmpl.Parse(t)
+	if err != nil {
+		return "", err
+	}
+	return k, nil
 }

--- a/template/template.go
+++ b/template/template.go
@@ -280,6 +280,7 @@ func funcMap(i *funcMapInput) template.FuncMap {
 		"toUpper":         toUpper,
 		"toYAML":          toYAML,
 		"split":           split,
+		"sockaddr":        sockaddr,
 
 		// Math functions
 		"add":      add,

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1482,6 +1482,17 @@ func TestTemplate_Execute(t *testing.T) {
 			false,
 		},
 		{
+			"helper_sockaddr",
+			&NewTemplateInput{
+				Contents: `{{ sockaddr "GetAllInterfaces | include \"type\" \"IPv4\"" | contains "127.0.0.1" }}`,
+			},
+			&ExecuteInput{
+				Brain: NewBrain(),
+			},
+			"true",
+			false,
+		},
+		{
 			"math_add",
 			&NewTemplateInput{
 				Contents: `{{ 2 | add 2 }}`,


### PR DESCRIPTION
This PR bundles the many templating functionalities offered by [hashicorp/go-sockaddr](https://github.com/hashicorp/go-sockaddr) to consul-template. These template functionalities are especially useful in cases where consul-template is run upon system startup, for example by cloud-init, to render interface IP addresses to configuration files.

Also adds vendoring for `go-sockaddr`, which might make this PR look like a bit daunting (1,1M additions).

Documentation updated as well.