### PR TITLE
Update vault-pki.md

### DIFF
--- a/examples/vault-pki.md
+++ b/examples/vault-pki.md
@@ -31,7 +31,7 @@ Consider the following two templates:
 ```liquid
 {{- /* /tmp/ca.tpl */ -}}
 {{ with secret "pki/issue/my-domain-dot-com" "common_name=foo.example.com" }}
-{{ .Data.ca_chain }}{{ end }}
+{{ .Data.issuing_ca }}{{ end }}
 ```
 
 ```liquid


### PR DESCRIPTION
Resolves issue #1083 by updating the documentation to use the `issuing_ca` parameter instead of the `ca_chain` parameter. 