### PR TITLE
Fix Child.Kill() waiting for splay if process already dead

### DIFF
--- a/child/child.go
+++ b/child/child.go
@@ -362,9 +362,13 @@ func (c *Child) kill() {
 	exited := false
 	process := c.cmd.Process
 
-	select {
-	case <-c.stopCh:
-	case <-c.randomSplay():
+	if c.cmd.ProcessState == nil {
+		select {
+		case <-c.stopCh:
+		case <-c.randomSplay():
+		}
+	} else {
+		log.Printf("[DEBUG] (runner) Kill() called but process dead; not waiting for splay.")
 	}
 
 	if c.killSignal != nil {


### PR DESCRIPTION
If a child process is already dead, calling Stop() or Kill() will wait for the
splay timeout regardless of if the process is already dead or not. This
doesn't appear to cause any problems in consul-template that I could
find, but it _does_ cause an issue in envconsul, which imports this part
of consul-template as a library.

In envconsul, if an -exec-splay is specified, and the child process dies
for some reason (other than that it is being reloaded by envconsul
itself), envconsul will not itself exit until a random splay has
elapsed. This is a really surprising and undesireable behaviour IMO.

This happens because envconsul tries to gracefully shut down by calling
Stop() on the consul-template child object. That in turn calls kill(),
which waits for the splay to elapse. There seems to be no reason to do
this so I think kill() should check if the cmd object has exited before
waiting.