### PR TITLE
Obtain services filtered by their name and tag or multiple tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+tags
+consul-template

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -539,6 +539,108 @@ func byTag(in interface{}) (map[string][]interface{}, error) {
 	return m, nil
 }
 
+// withTag is a template func that takes services and filter them
+// by tag.
+//
+// {{ $s := service "service-name" | withTag "tagone" | withTag "tagtwo" }}
+//
+func withTag(tag string, in interface{}) ([]interface{}, error) {
+	var (
+		m   []interface{}
+		err error
+	)
+
+	switch typed := in.(type) {
+	case nil:
+	case []*dep.CatalogSnippet:
+		for _, snippet := range typed {
+			if isTagExists(snippet.Tags, tag) {
+				m = append(m, snippet)
+			}
+		}
+
+	case []*dep.CatalogService:
+		for _, service := range typed {
+			if isTagExists(service.ServiceTags, tag) {
+				m = append(m, service)
+			}
+		}
+
+	case []*dep.HealthService:
+		for _, service := range typed {
+			if isTagExists(service.Tags, tag) {
+				m = append(m, service)
+			}
+		}
+
+	case []interface{}:
+		m, err = filterServicesByTag(
+			typed,
+			tag,
+		)
+
+		if err != nil {
+			return nil, fmt.Errorf(
+				"withTag: can't filter services by tag %s, reason: %s",
+				tag,
+				err.Error(),
+			)
+		}
+
+	default:
+		return nil, fmt.Errorf(
+			"withTag: wrong argument type %T",
+			in,
+		)
+	}
+
+	return m, nil
+}
+
+// withTags is a template func that takes services and filter them
+// by tags.
+//
+// {{ $s := service "service-name" | withTags $requiredTags }}
+//
+func withTags(tags []string, in interface{}) ([]interface{}, error) {
+	var (
+		m []interface{}
+	)
+
+	switch typed := in.(type) {
+
+	case nil:
+	case []*dep.CatalogSnippet:
+		for _, snippet := range typed {
+			if isTagsExists(snippet.Tags, tags) {
+				m = append(m, snippet)
+			}
+		}
+
+	case []*dep.CatalogService:
+		for _, service := range typed {
+			if isTagsExists(service.ServiceTags, tags) {
+				m = append(m, service)
+			}
+		}
+
+	case []*dep.HealthService:
+		for _, service := range typed {
+			if isTagsExists(service.Tags, tags) {
+				m = append(m, service)
+			}
+		}
+
+	default:
+		return nil, fmt.Errorf(
+			"withTags: wrong argument type %T",
+			in,
+		)
+	}
+
+	return m, nil
+}
+
 // contains is a function that have reverse arguments of "in" and is designed to
 // be used as a pipe instead of a function:
 //

--- a/template/template.go
+++ b/template/template.go
@@ -224,6 +224,8 @@ func funcMap(i *funcMapInput) template.FuncMap {
 		"base64URLEncode": base64URLEncode,
 		"byKey":           byKey,
 		"byTag":           byTag,
+		"withTag":         withTag,
+		"withTags":        withTags,
 		"contains":        contains,
 		"containsAll":     containsSomeFunc(true, true),
 		"containsAny":     containsSomeFunc(false, false),

--- a/template/utils.go
+++ b/template/utils.go
@@ -1,0 +1,69 @@
+package template
+
+import (
+	"fmt"
+
+	dep "github.com/hashicorp/consul-template/dependency"
+)
+
+func isTagExists(
+	serviceTags dep.ServiceTags,
+	filterTag string,
+) bool {
+	for _, serviceTag := range serviceTags {
+		if filterTag == serviceTag {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isTagsExists(
+	serviceTags dep.ServiceTags,
+	requiredTags []string,
+) bool {
+	for _, requiredTag := range requiredTags {
+		if !isTagExists(serviceTags, requiredTag) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func filterServicesByTag(
+	services []interface{},
+	tag string,
+) ([]interface{}, error) {
+	var m []interface{}
+
+	for _, service := range services {
+		switch s := service.(type) {
+		case nil:
+		case *dep.CatalogSnippet:
+			if isTagExists(s.Tags, tag) {
+				m = append(m, s)
+			}
+
+		case *dep.CatalogService:
+			if isTagExists(s.ServiceTags, tag) {
+				m = append(m, s)
+			}
+
+		case *dep.HealthService:
+			if isTagExists(s.Tags, tag) {
+				m = append(m, s)
+			}
+
+		default:
+			return nil, fmt.Errorf(
+				"withTag: wrong argument type %T",
+				service,
+			)
+
+		}
+	}
+
+	return m, nil
+}

--- a/template/utils_test.go
+++ b/template/utils_test.go
@@ -1,0 +1,136 @@
+package template
+
+import (
+	"testing"
+
+	dep "github.com/hashicorp/consul-template/dependency"
+)
+
+func TestIsTagExists(t *testing.T) {
+	availableTags := dep.ServiceTags{"tagone", "tagtwo", "tagthree"}
+	requiredTag := "required"
+
+	if isTagExists(availableTags, requiredTag) {
+		t.Errorf(
+			"required tag `%s` exists in %s",
+			requiredTag,
+			availableTags,
+		)
+	}
+
+	availableTags = dep.ServiceTags{"required", "tagone", "tagtwo"}
+	if !isTagExists(availableTags, requiredTag) {
+		t.Errorf(
+			"required tag `%s` not exists in %v",
+			requiredTag,
+			availableTags,
+		)
+	}
+}
+
+func TestIsTagsExists(t *testing.T) {
+	availableTags := dep.ServiceTags{"tagone", "tagtwo", "tagthree"}
+	requiredTags := []string{"required", "uniquetag"}
+
+	if isTagsExists(availableTags, requiredTags) {
+		t.Errorf(
+			"required tags `%v` exists in `%v`",
+			requiredTags,
+			availableTags,
+		)
+	}
+
+	availableTags = dep.ServiceTags{"required", "uniquetag", "tagtwo"}
+	if !isTagsExists(availableTags, requiredTags) {
+		t.Errorf(
+			"required tags`%s` not exists in %v",
+			requiredTags,
+			availableTags,
+		)
+	}
+}
+
+func TestFilterServicesByTag(t *testing.T) {
+	services := []interface{}{
+		&dep.HealthService{
+			Node:    "one",
+			Address: "1.1.1.1",
+			Tags:    dep.ServiceTags{"one", "two"},
+		},
+		&dep.HealthService{
+			Node:    "two",
+			Address: "2.2.2.2",
+			Tags:    dep.ServiceTags{"three", "four"},
+		},
+		&dep.HealthService{
+			Node:    "three",
+			Address: "3.3.3.3",
+			Tags:    dep.ServiceTags{"five", "six", "one"},
+		},
+		&dep.CatalogService{
+			Node:        "four",
+			Address:     "4.4.4.4",
+			ServiceTags: dep.ServiceTags{"seven", "eight", "six"},
+		},
+		&dep.CatalogService{
+			Node:        "five",
+			Address:     "5.5.5.5",
+			ServiceTags: dep.ServiceTags{"nine", "ten"},
+		},
+		&dep.CatalogSnippet{
+			Name: "six",
+			Tags: dep.ServiceTags{"eleven", "twelve", "six", "one"},
+		},
+	}
+
+	requiredTag := "six"
+	successServiceCount := 3
+
+	filteredServices, err := filterServicesByTag(services, requiredTag)
+	if err != nil {
+		t.Errorf(
+			"got error %s", err.Error(),
+		)
+	}
+
+	if len(filteredServices) != successServiceCount {
+		t.Errorf(
+			"unexpected count of filtered services, got %d, expected %d",
+			len(filteredServices),
+			successServiceCount,
+		)
+	}
+
+	for _, service := range filteredServices {
+		switch s := service.(type) {
+		case *dep.CatalogService:
+			if s.Address != "4.4.4.4" && s.Node != "four" {
+				t.Errorf(
+					"wrong filtered catalog service, got: node %s and "+
+						"address %s expected: node `four` and "+
+						"address `4.4.4.4`",
+					s.Node, s.Address,
+				)
+			}
+		case *dep.HealthService:
+			if s.Address != "3.3.3.3" && s.Node != "three" {
+				t.Errorf(
+					"wrong filtered health service, got: node %s and "+
+						"address %s expected: node `three` and "+
+						"address `3.3.3.3`",
+					s.Node, s.Address,
+				)
+			}
+		case *dep.CatalogSnippet:
+			if s.Name != "six" {
+				t.Errorf(
+					"wrong filtered catalog snippet, got: name %s "+
+						"expected: name `six`",
+					s.Name,
+				)
+			}
+		default:
+			t.Errorf("unexpected service type %T", s)
+		}
+	}
+}


### PR DESCRIPTION
Hi

This PR provides two template functions - `withTag` and `withTags` which helps to filter services with name and with tag or with multiple tags by way:
```
{{ $filtered := service "webapp" | withTag "supertag" }}

or you can use pipe to combine multiple tags
{{ $filtered := service "webapp" | withTag "supertag" | withTag "uniquetag" }}

or you can create required tag and filter by them
{{ $requiredTags := "tagone tagtwo tagthree" | slpit " " }}
{{ $filtered := service "webapp" | withTags $requiredTags }}
```

So, the main problem which I try to solve - it's an impossibility to determine required services without `range` directive and `if` condition on .Tags inside `range`. I want to know exists services or not by required name and tags before I do `range` on them.

Where it may help. I use `consul-template` with argument `-once` for the initial render of templates (nginx upstream and/or haproxy configs) when a container starts and if the required services are not yet available in the consul catalog I want to add stubs in nginx or haproxy configuration files and start the service. With current template functions, this is not possible or I can't find the solution because to determine required service I must do `range` and inside `range` I must use `if` condition on `.Tags` and Go templates don't support `break` statement to stop `range` loop over services if I can't find required service and add stub in `{{ else }} condition.

With that solution I can do that:
```
{{ $filtered := service "webapp" | withTag "supertag" }}

{{ if eq (len $filtered) 0 }}
add stub here
{{ else }}
    {{ range $service := $filtered }}
        range over available and non empty services
    {{ end }}
{{ end }}
```