### PR TITLE
readme: fix indentation of quick example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,33 +38,33 @@ This short example assumes Consul is installed locally.
 
 1. Start a Consul cluster in dev mode:
 
-  ```shell
-  $ consul agent -dev
-  ```
+    ```shell
+    $ consul agent -dev
+    ```
 
 1. Author a template `in.tpl` to query the kv store:
 
-  ```liquid
-  {{ key "foo" }}
-  ```
+    ```liquid
+    {{ key "foo" }}
+    ```
 
 1. Start Consul Template:
 
-  ```shell
-  $ consul-template -template "in.tpl:out.txt" -once
-  ```
+    ```shell
+    $ consul-template -template "in.tpl:out.txt" -once
+    ```
 
 1. Write data to the key in Consul:
 
-  ```shell
-  $ consul kv put foo bar
-  ```
+    ```shell
+    $ consul kv put foo bar
+    ```
 
 1. Observe Consul Template has written the file `out.txt`:
 
-   ```shell
-   $ cat out.txt
-   ```
+    ```shell
+    $ cat out.txt
+    ```
 
 For more examples and use cases, please see the [examples folder][examples] in
 this repository.


### PR DESCRIPTION
list content must be indented by exactly 4 spaces:
https://markdown-guide.readthedocs.io/en/latest/basics.html#lists-nested

preview:
https://github.com/balupton/consul-template/blob/f98230b26c6eaa6e78dafbbd08e35243922555fc/README.md