### PR TITLE
Consume CT_LOCAL_CONFIG in Go

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -193,6 +193,14 @@ func (cli *CLI) ParseFlags(args []string) (*config.Config, []string, bool, bool,
 
 	c := config.DefaultConfig()
 
+	if s := os.Getenv("CT_LOCAL_CONFIG"); s != "" {
+		envConfig, err := config.Parse(s)
+		if err != nil {
+			return nil, nil, false, false, false, err
+		}
+		c = c.Merge(envConfig)
+	}
+
 	// configPaths stores the list of configuration paths on disk
 	configPaths := make([]string, 0, 6)
 

--- a/docker/alpine/docker-entrypoint.sh
+++ b/docker/alpine/docker-entrypoint.sh
@@ -12,12 +12,6 @@ set -e
 CT_DATA_DIR=/consul-template/config
 CT_CONFIG_DIR=/consul-template/config
 
-# You can also set the CT_LOCAL_CONFIG environment variable to pass some
-# Consul Template configuration JSON without having to bind any volumes.
-if [ -n "$CT_LOCAL_CONFIG" ]; then
-  echo "$CT_LOCAL_CONFIG" > "$CT_CONFIG_DIR/local-config.hcl"
-fi
-
 # If the user is trying to run consul-template directly with some arguments, then
 # pass them to consul-template.
 if [ "${1:0:1}" = '-' ]; then


### PR DESCRIPTION
Instead of relying on the entrypoint to do this, we can just read this in Go, which will make it work in the scratch containers or containers without a shell.

/cc @pearkes 