### PR TITLE
Implement support for K/V version 2 mounts

### DIFF
--- a/dependency/vault_token.go
+++ b/dependency/vault_token.go
@@ -32,7 +32,7 @@ func NewVaultTokenQuery(token string) (*VaultTokenQuery, error) {
 	return &VaultTokenQuery{
 		stopCh:      make(chan struct{}, 1),
 		vaultSecret: vaultSecret,
-		secret:      transformSecret(vaultSecret),
+		secret:      transformSecret(vaultSecret, false),
 	}, nil
 }
 
@@ -71,7 +71,7 @@ func (d *VaultTokenQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interfa
 			case renewal := <-renewer.RenewCh():
 				log.Printf("[TRACE] %s: successfully renewed", d)
 				printVaultWarnings(d, renewal.Secret.Warnings)
-				updateSecret(d.secret, renewal.Secret)
+				updateSecret(d.secret, renewal.Secret, false)
 			case <-d.stopCh:
 				return nil, nil, ErrStopped
 			}


### PR DESCRIPTION
K/V version 2 mounts change the URL path to read and how data is returned.  Within consul-template, it's just harder to get values, but in envconsul it manifests as panics; see hashicorp/envconsul#175

Because I suspect that a dominant use for consul-template and envconsul is reading from secrets mounts, the "correct" behavior seems to be to try to abstract away the presence of version 2 mounts, mutating both the query and how data is returned.  Until now, the Secret object has been strictly agnostic as to the backend, but we got away with that because assuming that `map[string]interface{} == map[string]string` worked for existing backends.  This doesn't hold when K/V v2 puts the data key=value items as keys in a sub-dict of the response.

End-users reading data from Vault shouldn't need to know or care if the mount-point is V1 or V2.

Handling this is complicated by:

1. The `/sys/internal/ui/mounts` being marked internal-only; well, it's the only source of data and is used by the Vault CLI tool.  Unless and until something better comes along, it's our only choice.  Vault was released with v2 mounts by default, forcing the issue for us.
2. consul-template's vendored vault server is old, so doesn't have the sys/internal mount needed, so tests won't pass.  Trying to update the vendored copy leads to a slew of complications.

This commit skips the update of the vendored library, so tests are broken.  Fixing that too was too much yak-shaving for this external contributor when unbreaking the tools.

This commit does not change the vault write logic, only the vault read logic.  That's TBD.

---

## PR notes

Before this can be merged upstream, I think that upstream will need to update their in-repo vendored copy of the Vault library and fix all the resolution issues (protobuf mismatches, etc).  Fixing that too was too much yak-shaving for this external contributor to unbreak the tool.

Once the vendored library has updated, this PR should be mergeable, with the caveat of writes.  I can't really add meaningful tests of v1 vs v2 unless/until there's an updated Vault library to test against, initialized with a v1 and a v2 mount of the secrets backend.

Writes: there's a complete second copy of the read logic in the write path, which seems to be primarily intended for transit backends.  They could be used with K/V backends too, though.  Is this intentional and a desired use-case?  I can update the PR with handling for writes, once I know if they should be rejected or mutated, and if the approach used for the reads is acceptable.
