### PR TITLE
Error out on negative indentation instead of panicing

### DIFF
--- a/template/funcs.go
+++ b/template/funcs.go
@@ -657,6 +657,9 @@ func in(l, v interface{}) (bool, error) {
 
 // Indent prefixes each line of a string with the specified number of spaces
 func indent(spaces int, s string) (string, error) {
+        if spaces < 0 {
+           return "", fmt.Errorf("indent cannot be called with a negative number of spaces") 
+        }
 	var output, prefix []byte
 	var sp bool
 	var size int

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1206,6 +1206,17 @@ func TestTemplate_Execute(t *testing.T) {
 			false,
 		},
 		{
+			"negative_indent",
+			&NewTemplateInput{
+				Contents: `{{ "hello\nhello\r\nHELLO\r\nhello\nHELLO" | indent -4 }}`,
+			},
+			&ExecuteInput{
+				Brain: NewBrain(),
+			},
+			"",
+			true,
+		},
+		{
 			"helper_loop",
 			&NewTemplateInput{
 				Contents: `{{ range loop 3 }}1{{ end }}`,


### PR DESCRIPTION
Fixes #1127 

This is a pretty simple fix. Before the call to strings.Repeat was panicing. Now the function returns an error.