### PR TITLE
Introducing safels and safetree commands to the consul-template.

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,23 @@ maxconns:15
 minconns:5
 ```
 
+##### `safels`
+
+Same as [ls](#ls), but refuse to render template, if the KV prefix query return blank/empty data.
+
+This is especially useful, for rendering mission critical files, that are being populated by consul-template.
+
+For example:
+
+```text
+/root/.ssh/authorized_keys
+/etc/sysconfig/iptables
+```
+
+Using `safels` on empty prefixes will result in template output not being rendered at all.
+
+To learn how `safels` was born see [CT-1131](https://github.com/hashicorp/consul-template/issues/1131) [C-3975](https://github.com/hashicorp/consul/issues/3975) and [CR-82](https://github.com/hashicorp/consul-replicate/issues/82).
+
 ##### `node`
 
 Query [Consul][consul] for a node in the catalog.
@@ -998,6 +1015,23 @@ nested/config/value "value"
 
 Unlike `ls`, `tree` returns **all** keys under the prefix, just like the Unix
 `tree` command.
+
+##### `safetree`
+
+Same as [tree](#tree), but refuse to render template, if the KV prefix query return blank/empty data.
+
+This is especially useful, for rendering mission critical files, that are being populated by consul-template.
+
+For example:
+
+```text
+/root/.ssh/authorized_keys
+/etc/sysconfig/iptables
+```
+
+Using `safetree` on empty prefixes will result in template output not being rendered at all.
+
+To learn how `safetree` was born see [CT-1131](https://github.com/hashicorp/consul-template/issues/1131) [C-3975](https://github.com/hashicorp/consul/issues/3975) and [CR-82](https://github.com/hashicorp/consul-replicate/issues/82).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -680,7 +680,7 @@ maxconns:15
 minconns:5
 ```
 
-##### `safels`
+##### `safeLs`
 
 Same as [ls](#ls), but refuse to render template, if the KV prefix query return blank/empty data.
 
@@ -693,9 +693,9 @@ For example:
 /etc/sysconfig/iptables
 ```
 
-Using `safels` on empty prefixes will result in template output not being rendered at all.
+Using `safeLs` on empty prefixes will result in template output not being rendered at all.
 
-To learn how `safels` was born see [CT-1131](https://github.com/hashicorp/consul-template/issues/1131) [C-3975](https://github.com/hashicorp/consul/issues/3975) and [CR-82](https://github.com/hashicorp/consul-replicate/issues/82).
+To learn how `safeLs` was born see [CT-1131](https://github.com/hashicorp/consul-template/issues/1131) [C-3975](https://github.com/hashicorp/consul/issues/3975) and [CR-82](https://github.com/hashicorp/consul-replicate/issues/82).
 
 ##### `node`
 
@@ -1016,7 +1016,7 @@ nested/config/value "value"
 Unlike `ls`, `tree` returns **all** keys under the prefix, just like the Unix
 `tree` command.
 
-##### `safetree`
+##### `safeTree`
 
 Same as [tree](#tree), but refuse to render template, if the KV prefix query return blank/empty data.
 
@@ -1029,9 +1029,9 @@ For example:
 /etc/sysconfig/iptables
 ```
 
-Using `safetree` on empty prefixes will result in template output not being rendered at all.
+Using `safeTree` on empty prefixes will result in template output not being rendered at all.
 
-To learn how `safetree` was born see [CT-1131](https://github.com/hashicorp/consul-template/issues/1131) [C-3975](https://github.com/hashicorp/consul/issues/3975) and [CR-82](https://github.com/hashicorp/consul-replicate/issues/82).
+To learn how `safeTree` was born see [CT-1131](https://github.com/hashicorp/consul-template/issues/1131) [C-3975](https://github.com/hashicorp/consul/issues/3975) and [CR-82](https://github.com/hashicorp/consul-replicate/issues/82).
 
 ---
 

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -204,7 +204,7 @@ func keyWithDefaultFunc(b *Brain, used, missing *dep.Set) func(string, string) (
 	}
 }
 
-func safelsFunc(b *Brain, used, missing *dep.Set) func(string) ([]*dep.KeyPair, error) {
+func safeLsFunc(b *Brain, used, missing *dep.Set) func(string) ([]*dep.KeyPair, error) {
 	// call lsFunc but explicitly mark that empty data set returned on monitored KV prefix is NOT safe
 	return lsFunc(b, used, missing, false)
 }
@@ -235,7 +235,7 @@ func lsFunc(b *Brain, used, missing *dep.Set, emptyIsSafe bool) func(string) ([]
 
 			if len(result) == 0 {
 				if emptyIsSafe {
-					// Operator used potentially unsafe ls function in the template instead of the safels
+					// Operator used potentially unsafe ls function in the template instead of the safeLs
 					return result, nil
 				}
 			} else {
@@ -244,11 +244,11 @@ func lsFunc(b *Brain, used, missing *dep.Set, emptyIsSafe bool) func(string) ([]
 			}
 
 			// If we reach this part of the code result is completely empty as value returned no KV pairs
-			// Operator selected to use safels on the specific KV prefix so we will refuse to render template
+			// Operator selected to use safeLs on the specific KV prefix so we will refuse to render template
 			// by marking d as missing
 		}
 
-		// b.Recall either returned an error or safels entered unsafe case
+		// b.Recall either returned an error or safeLs entered unsafe case
 		missing.Add(d)
 
 		return result, nil
@@ -421,7 +421,7 @@ func servicesFunc(b *Brain, used, missing *dep.Set) func(...string) ([]*dep.Cata
 	}
 }
 
-func safetreeFunc(b *Brain, used, missing *dep.Set) func(string) ([]*dep.KeyPair, error) {
+func safeTreeFunc(b *Brain, used, missing *dep.Set) func(string) ([]*dep.KeyPair, error) {
 	// call treeFunc but explicitly mark that empty data set returned on monitored KV prefix is NOT safe
 	return treeFunc(b, used, missing, false)
 }
@@ -453,7 +453,7 @@ func treeFunc(b *Brain, used, missing *dep.Set, emptyIsSafe bool) func(string) (
 
 			if len(result) == 0 {
 				if emptyIsSafe {
-					// Operator used potentially unsafe tree function in the template instead of the safetree
+					// Operator used potentially unsafe tree function in the template instead of the safeTree
 					return result, nil
 				}
 			} else {
@@ -462,11 +462,11 @@ func treeFunc(b *Brain, used, missing *dep.Set, emptyIsSafe bool) func(string) (
 			}
 
 			// If we reach this part of the code result is completely empty as value returned no KV pairs
-			// Operator selected to use safetree on the specific KV prefix so we will refuse to render template
+			// Operator selected to use safeTree on the specific KV prefix so we will refuse to render template
 			// by marking d as missing
 		}
 
-		// b.Recall either returned an error or safetree entered unsafe case
+		// b.Recall either returned an error or safeTree entered unsafe case
 		missing.Add(d)
 
 		return result, nil

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -204,8 +204,13 @@ func keyWithDefaultFunc(b *Brain, used, missing *dep.Set) func(string, string) (
 	}
 }
 
+func safelsFunc(b *Brain, used, missing *dep.Set) func(string) ([]*dep.KeyPair, error) {
+	// call lsFunc but explicitly mark that empty data set returned on monitored KV prefix is NOT safe
+	return lsFunc(b, used, missing, false)
+}
+
 // lsFunc returns or accumulates keyPrefix dependencies.
-func lsFunc(b *Brain, used, missing *dep.Set) func(string) ([]*dep.KeyPair, error) {
+func lsFunc(b *Brain, used, missing *dep.Set, emptyIsSafe bool) func(string) ([]*dep.KeyPair, error) {
 	return func(s string) ([]*dep.KeyPair, error) {
 		result := []*dep.KeyPair{}
 
@@ -227,9 +232,23 @@ func lsFunc(b *Brain, used, missing *dep.Set) func(string) ([]*dep.KeyPair, erro
 					result = append(result, pair)
 				}
 			}
-			return result, nil
+
+			if len(result) == 0 {
+				if emptyIsSafe {
+					// Operator used potentially unsafe ls function in the template instead of the safels
+					return result, nil
+				}
+			} else {
+				// non empty result is good so we just return the data
+				return result, nil
+			}
+
+			// If we reach this part of the code result is completely empty as value returned no KV pairs
+			// Operator selected to use safels on the specific KV prefix so we will refuse to render template
+			// by marking d as missing
 		}
 
+		// b.Recall either returned an error or safels entered unsafe case
 		missing.Add(d)
 
 		return result, nil
@@ -402,8 +421,13 @@ func servicesFunc(b *Brain, used, missing *dep.Set) func(...string) ([]*dep.Cata
 	}
 }
 
+func safetreeFunc(b *Brain, used, missing *dep.Set) func(string) ([]*dep.KeyPair, error) {
+	// call treeFunc but explicitly mark that empty data set returned on monitored KV prefix is NOT safe
+	return treeFunc(b, used, missing, false)
+}
+
 // treeFunc returns or accumulates keyPrefix dependencies.
-func treeFunc(b *Brain, used, missing *dep.Set) func(string) ([]*dep.KeyPair, error) {
+func treeFunc(b *Brain, used, missing *dep.Set, emptyIsSafe bool) func(string) ([]*dep.KeyPair, error) {
 	return func(s string) ([]*dep.KeyPair, error) {
 		result := []*dep.KeyPair{}
 
@@ -426,9 +450,23 @@ func treeFunc(b *Brain, used, missing *dep.Set) func(string) ([]*dep.KeyPair, er
 					result = append(result, pair)
 				}
 			}
-			return result, nil
+
+			if len(result) == 0 {
+				if emptyIsSafe {
+					// Operator used potentially unsafe tree function in the template instead of the safetree
+					return result, nil
+				}
+			} else {
+				// non empty result is good so we just return the data
+				return result, nil
+			}
+
+			// If we reach this part of the code result is completely empty as value returned no KV pairs
+			// Operator selected to use safetree on the specific KV prefix so we will refuse to render template
+			// by marking d as missing
 		}
 
+		// b.Recall either returned an error or safetree entered unsafe case
 		missing.Add(d)
 
 		return result, nil

--- a/template/template.go
+++ b/template/template.go
@@ -205,14 +205,16 @@ func funcMap(i *funcMapInput) template.FuncMap {
 		"key":          keyFunc(i.brain, i.used, i.missing),
 		"keyExists":    keyExistsFunc(i.brain, i.used, i.missing),
 		"keyOrDefault": keyWithDefaultFunc(i.brain, i.used, i.missing),
-		"ls":           lsFunc(i.brain, i.used, i.missing),
+		"ls":           lsFunc(i.brain, i.used, i.missing, true),
+		"safels":       safelsFunc(i.brain, i.used, i.missing),
 		"node":         nodeFunc(i.brain, i.used, i.missing),
 		"nodes":        nodesFunc(i.brain, i.used, i.missing),
 		"secret":       secretFunc(i.brain, i.used, i.missing),
 		"secrets":      secretsFunc(i.brain, i.used, i.missing),
 		"service":      serviceFunc(i.brain, i.used, i.missing),
 		"services":     servicesFunc(i.brain, i.used, i.missing),
-		"tree":         treeFunc(i.brain, i.used, i.missing),
+		"tree":         treeFunc(i.brain, i.used, i.missing, true),
+		"safetree":     safetreeFunc(i.brain, i.used, i.missing),
 
 		// Scratch
 		"scratch": func() *Scratch { return &scratch },

--- a/template/template.go
+++ b/template/template.go
@@ -206,7 +206,7 @@ func funcMap(i *funcMapInput) template.FuncMap {
 		"keyExists":    keyExistsFunc(i.brain, i.used, i.missing),
 		"keyOrDefault": keyWithDefaultFunc(i.brain, i.used, i.missing),
 		"ls":           lsFunc(i.brain, i.used, i.missing, true),
-		"safels":       safelsFunc(i.brain, i.used, i.missing),
+		"safeLs":       safeLsFunc(i.brain, i.used, i.missing),
 		"node":         nodeFunc(i.brain, i.used, i.missing),
 		"nodes":        nodesFunc(i.brain, i.used, i.missing),
 		"secret":       secretFunc(i.brain, i.used, i.missing),
@@ -214,7 +214,7 @@ func funcMap(i *funcMapInput) template.FuncMap {
 		"service":      serviceFunc(i.brain, i.used, i.missing),
 		"services":     servicesFunc(i.brain, i.used, i.missing),
 		"tree":         treeFunc(i.brain, i.used, i.missing, true),
-		"safetree":     safetreeFunc(i.brain, i.used, i.missing),
+		"safeTree":     safeTreeFunc(i.brain, i.used, i.missing),
 
 		// Scratch
 		"scratch": func() *Scratch { return &scratch },


### PR DESCRIPTION
This pull request is based on rough idea dropped by Aaron Hurt.

safels and safetree behave exactly like the native ls and tree with one exception. They will *refuse* to render template, if KV prefix query return blank/empty data.

This is especially useful for rendering mission critical files that do not tolerate ls/tree KV queries to return blank data.

safels and safetree work in stale mode just as their ancestors but we get extra safety on top.

safels and safetree commands were born as an attempt to mitigate issues described here:

  https://github.com/hashicorp/consul-template/issues/1131
  https://github.com/hashicorp/consul/issues/3975
  https://github.com/hashicorp/consul-replicate/issues/82