### PR TITLE
Add "explodeMap" function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1304,6 +1304,17 @@ You will need to have a reasonable format about your data in Consul. Please see
 [Go's text/template package][text-template] for more information.
 
 
+##### `explodeMap`
+
+Takes the value of a map and converts it into a deeply-nested map for parsing/traversing,
+using the same logic as `explode`.
+
+```liquid
+{{ scratch.MapSet "example", "foo/bar", "a" }}
+{{ scratch.MapSet "example", "foo/baz", "b" }}
+{{ scratch.Get "example" | explode | toYAML }}
+```
+
 ##### `indent`
 
 Indents a block of text by prefixing N number of spaces per line.

--- a/README.md
+++ b/README.md
@@ -1312,7 +1312,7 @@ using the same logic as `explode`.
 ```liquid
 {{ scratch.MapSet "example", "foo/bar", "a" }}
 {{ scratch.MapSet "example", "foo/baz", "b" }}
-{{ scratch.Get "example" | explode | toYAML }}
+{{ scratch.Get "example" | explodeMap | toYAML }}
 ```
 
 ##### `indent`

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"reflect"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"text/template"
@@ -601,6 +602,24 @@ func explodeHelper(m map[string]interface{}, k, v, p string) error {
 	}
 
 	return nil
+}
+
+// explodeMap turns a single-level map into a deeply-nested hash.
+func explodeMap(mapIn map[string]interface{}) (map[string]interface{}, error) {
+	mapOut := make(map[string]interface{})
+
+	var keys []string
+	for k := range mapIn {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for i := range keys {
+		if err := explodeHelper(mapOut, keys[i], fmt.Sprintf("%v", mapIn[keys[i]]), keys[i]); err != nil {
+			return nil, errors.Wrap(err, "explodeMap")
+		}
+	}
+	return mapOut, nil
 }
 
 // in searches for a given value in a given interface.

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -580,8 +580,8 @@ func explode(pairs []*dep.KeyPair) (map[string]interface{}, error) {
 	return m, nil
 }
 
-// explodeHelper is a recursive helper for explode.
-func explodeHelper(m map[string]interface{}, k, v, p string) error {
+// explodeHelper is a recursive helper for explode and explodeMap
+func explodeHelper(m map[string]interface{}, k string, v interface{}, p string) error {
 	if strings.Contains(k, "/") {
 		parts := strings.Split(k, "/")
 		top := parts[0]
@@ -615,7 +615,7 @@ func explodeMap(mapIn map[string]interface{}) (map[string]interface{}, error) {
 	sort.Strings(keys)
 
 	for i := range keys {
-		if err := explodeHelper(mapOut, keys[i], fmt.Sprintf("%v", mapIn[keys[i]]), keys[i]); err != nil {
+		if err := explodeHelper(mapOut, keys[i], mapIn[keys[i]], keys[i]); err != nil {
 			return nil, errors.Wrap(err, "explodeMap")
 		}
 	}

--- a/template/template.go
+++ b/template/template.go
@@ -232,6 +232,7 @@ func funcMap(i *funcMapInput) template.FuncMap {
 		"env":             envFunc(i.env),
 		"executeTemplate": executeTemplateFunc(i.t),
 		"explode":         explode,
+		"explodeMap":      explodeMap,
 		"in":              in,
 		"indent":          indent,
 		"loop":            loop,

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1167,6 +1167,17 @@ func TestTemplate_Execute(t *testing.T) {
 			false,
 		},
 		{
+			"helper_explodemap",
+			&NewTemplateInput{
+				Contents: `{{ scratch.MapSet "explode-test" "foo/bar" "a"}}{{ scratch.MapSet "explode-test" "foo/baz" "b"}}{{ scratch.MapSet "explode-test" "qux" "c"}}{{ scratch.MapSet "explode-test" "zip/zap" "d"}}{{ scratch.Get "explode-test" | explodeMap }}`,
+			},
+			&ExecuteInput{
+				Brain: NewBrain(),
+			},
+			"map[foo:map[bar:a baz:b] qux:c zip:map[zap:d]]",
+			false,
+		},
+		{
 			"helper_in",
 			&NewTemplateInput{
 				Contents: `{{ range service "webapp" }}{{ if "prod" | in .Tags }}{{ .Address }}{{ end }}{{ end }}`,

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1169,12 +1169,12 @@ func TestTemplate_Execute(t *testing.T) {
 		{
 			"helper_explodemap",
 			&NewTemplateInput{
-				Contents: `{{ scratch.MapSet "explode-test" "foo/bar" "a"}}{{ scratch.MapSet "explode-test" "foo/baz" "b"}}{{ scratch.MapSet "explode-test" "qux" "c"}}{{ scratch.MapSet "explode-test" "zip/zap" "d"}}{{ scratch.Get "explode-test" | explodeMap }}`,
+				Contents: `{{ scratch.MapSet "explode-test" "foo/bar" "a"}}{{ scratch.MapSet "explode-test" "qux" "c"}}{{ scratch.MapSet "explode-test" "zip/zap" "d"}}{{ scratch.Get "explode-test" | explodeMap }}`,
 			},
 			&ExecuteInput{
 				Brain: NewBrain(),
 			},
-			"map[foo:map[bar:a baz:b] qux:c zip:map[zap:d]]",
+			"map[foo:map[bar:a] qux:c zip:map[zap:d]]",
 			false,
 		},
 		{


### PR DESCRIPTION
``explodeMap`` allows for maps created with ``scratch.MapSet`` to be treated the same way as KeyPair lists. 

My use case is merging Consul KV pairs and Vault KV pairs together in my template, and then converting the scratch map to YAML/JSON/TOML in config files.