### PR TITLE
Add support for : and = in service tag values [#1049]

### DIFF
--- a/dependency/catalog_service_test.go
+++ b/dependency/catalog_service_test.go
@@ -116,6 +116,15 @@ func TestNewCatalogServiceQuery(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"tag_name_with_colon",
+			"tag:value.name",
+			&CatalogServiceQuery{
+				name: "name",
+				tag:  "tag:value",
+			},
+			false,
+		},
 	}
 
 	for i, tc := range cases {

--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -18,7 +18,7 @@ const (
 	nodeNameRe    = `(?P<name>[[:word:]\.\-\_]+)`
 	nearRe        = `(~(?P<near>[[:word:]\.\-\_]+))?`
 	prefixRe      = `/?(?P<prefix>[^@]+)`
-	tagRe         = `((?P<tag>[[:word:]\.\-\_]+)\.)?`
+	tagRe         = `((?P<tag>[[:word:]=:\.\-\_]+)\.)?`
 )
 
 type Type int

--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -101,8 +101,8 @@ func TestCanShare(t *testing.T) {
 func TestDeepCopyAndSortTags(t *testing.T) {
 	t.Parallel()
 
-	tags := []string{"hello", "world", "these", "are", "tags"}
-	expected := []string{"are", "hello", "tags", "these", "world"}
+	tags := []string{"hello", "world", "these", "are", "tags", "foo:bar", "baz=qux"}
+	expected := []string{"are", "baz=qux", "foo:bar", "hello", "tags", "these", "world"}
 
 	result := deepCopyAndSortTags(tags)
 	if !reflect.DeepEqual(result, expected) {


### PR DESCRIPTION
Adds support for `=` and `:` in tag values as requested in #1049