### PR TITLE
fix child process is retained in UT

### DIFF
--- a/manager/runner_test.go
+++ b/manager/runner_test.go
@@ -758,6 +758,9 @@ func TestRunner_Start(t *testing.T) {
 			t.Fatal(err)
 		case <-r.renderedCh:
 			// Just assert there is no panic
+			// wait a while in case r.child is retained for not being
+			// initailzed before r.stop()
+			time.Sleep(100 * time.Millisecond)
 		case <-time.After(2 * time.Second):
 			t.Fatal("timeout")
 		}


### PR DESCRIPTION
r.stop() maybe called before r.child is initialized, and as a result `sleep 30` process is retained 
and cause `TestRunner_Start/exec_once` which runs in parallel with other tests, to fail by adding
taking one more `sleep` process into consideration

fix this by adding some sleep time before r.stop() is called

CLOSE-ISSUE: #[1159](https://github.com/hashicorp/consul-template/issues/1159)