### PR TITLE
Multiple templates, exec, and wait

### DIFF
--- a/manager/runner.go
+++ b/manager/runner.go
@@ -161,6 +161,12 @@ type RenderEvent struct {
 
 	// LastDidRender marks the last time the template was written to disk.
 	LastDidRender time.Time
+
+	// ForQuiescence determines if this event is returned early in the
+	// render loop due to quiescence. When evaluating if all templates have
+	// been rendered we need to know if the event is triggered by quiesence
+	// and if we can skip evaluating it as a render event for those purposes
+	ForQuiescence bool
 }
 
 // NewRunner accepts a slice of TemplateConfigs and returns a pointer to the new
@@ -730,6 +736,8 @@ func (r *Runner) runTemplate(tmpl *template.Template, runCtx *templateRunCtx) (*
 	// We do not want to render the templates yet.
 	if q, ok := r.quiescenceMap[tmpl.ID()]; ok {
 		q.tick()
+		// This event is being returned early for quiescence
+		event.ForQuiescence = true
 		return event, nil
 	}
 
@@ -955,6 +963,13 @@ func (r *Runner) allTemplatesRendered() bool {
 		event, rendered := r.renderEvents[tmpl.ID()]
 		if !rendered {
 			return false
+		}
+
+		// Skip evaluation of events from quiescence as they will
+		// be default unrendered as we are still waiting for the
+		// specified period
+		if event.ForQuiescence {
+			continue
 		}
 
 		// The template might already exist on disk with the exact contents, but

--- a/manager/runner_test.go
+++ b/manager/runner_test.go
@@ -763,6 +763,84 @@ func TestRunner_Start(t *testing.T) {
 		}
 	})
 
+	// verifies that multiple differing templates that share
+	// a wait parameter call an exec function
+	// https://github.com/hashicorp/consul-template/issues/1043
+	t.Run("multi-template-exec", func(t *testing.T) {
+		t.Parallel()
+
+		testConsul.SetKVString(t, "multi-exec-wait-foo", "bar")
+		testConsul.SetKVString(t, "multi-exec-wait-bar", "bat")
+
+		firstOut, err := ioutil.TempFile("", "foo")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(firstOut.Name())
+		secondOut, err := ioutil.TempFile("", "bar")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(secondOut.Name())
+
+		c := config.DefaultConfig().Merge(&config.Config{
+			Consul: &config.ConsulConfig{
+				Address: config.String(testConsul.HTTPAddr),
+			},
+			Wait: &config.WaitConfig{
+				Min: config.TimeDuration(5 * time.Millisecond),
+				Max: config.TimeDuration(10 * time.Millisecond),
+			},
+			Exec: &config.ExecConfig{
+				Command: config.String(`sleep 30`),
+			},
+			Templates: &config.TemplateConfigs{
+				&config.TemplateConfig{
+					Contents:    config.String(`{{ key "multi-exec-wait-foo" }}`),
+					Destination: config.String(firstOut.Name()),
+				},
+				&config.TemplateConfig{
+					Contents:    config.String(`{{ key "multi-exec-wait-bar" }}`),
+					Destination: config.String(secondOut.Name()),
+				},
+			},
+		})
+		c.Finalize()
+
+		r, err := NewRunner(c, false, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		go r.Start()
+		defer r.Stop()
+
+		select {
+		case err := <-r.ErrCh:
+			t.Fatal(err)
+		case <-r.renderedCh:
+			found := false
+			for i := 0; i < 5; i++ {
+				if found {
+					break
+				}
+
+				time.Sleep(100 * time.Millisecond)
+
+				r.childLock.RLock()
+				if r.child != nil {
+					found = true
+				}
+				r.childLock.RUnlock()
+			}
+			if !found {
+				t.Error("missing child process, exec was not called")
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout")
+		}
+	})
+
 	t.Run("render_in_memory", func(t *testing.T) {
 		t.Parallel()
 
@@ -910,77 +988,4 @@ func TestRunner_quiescence(t *testing.T) {
 			t.Fatalf("q should have fired")
 		}
 	})
-}
-
-// multiTemplateExecWait verifies that multiple differing
-// templates that share a wait parameter call an exec function
-// https://github.com/hashicorp/consul-template/issues/1043
-func TestRunner_multiTemplateExecWait(t *testing.T) {
-	t.Parallel()
-
-	testConsul.SetKVString(t, "multi-exec-wait-foo", "bat")
-	testConsul.SetKVString(t, "multi-exec-wait-bar", "bat")
-
-	out, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(out.Name())
-
-	c := config.DefaultConfig().Merge(&config.Config{
-		Consul: &config.ConsulConfig{
-			Address: config.String(testConsul.HTTPAddr),
-		},
-		Wait: &config.WaitConfig{
-			Min: config.TimeDuration(5 * time.Millisecond),
-			Max: config.TimeDuration(10 * time.Millisecond),
-		},
-		Exec: &config.ExecConfig{
-			Command: config.String(`sleep 30`),
-		},
-		Templates: &config.TemplateConfigs{
-			&config.TemplateConfig{
-				Contents:    config.String(`{{ key "multi-exec-wait-foo" }}`),
-				Destination: config.String(out.Name()),
-			},
-			&config.TemplateConfig{
-				Contents:    config.String(`{{ key "multi-exec-wait-bar" }}`),
-				Destination: config.String(out.Name()),
-			},
-		},
-	})
-	c.Finalize()
-
-	r, err := NewRunner(c, false, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	go r.Start()
-	defer r.Stop()
-
-	select {
-	case err := <-r.ErrCh:
-		t.Fatal(err)
-	case <-r.renderedCh:
-		found := false
-		for i := 0; i < 5; i++ {
-			if found {
-				break
-			}
-
-			time.Sleep(100 * time.Millisecond)
-
-			r.childLock.RLock()
-			if r.child != nil {
-				found = true
-			}
-			r.childLock.RUnlock()
-		}
-		if !found {
-			t.Error("missing child process, exec was not called")
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("timeout")
-	}
 }


### PR DESCRIPTION
Fixes #1043 

Many render events can potentially be created and processed. They're stored in a map by template ID so they typically overwrite other render events. I believe this is all intentional in order to support
the right behaviors for waiting for upstream difference before rendering a template, but it led to an issue where the `exec` child process wouldn't ever be created as these render events were being used
to determine completion of rendering.

I believe this current approach could be improved considerably to be less prone to these types of issues, however this patch tries to avoid that by marking render events that are generated
from the quiescence internals as such, allowing us to ignore them later when evaluating if templates have been rendered.

This does not solve the re-rendering at the wait interval as mentioned in #1140. From my work here I believe that is by design of the current system of dependency tracking with the wait interval configured.