### PR TITLE
Wait longer when refreshing secrets without renewable leases

### DIFF
--- a/dependency/vault_common.go
+++ b/dependency/vault_common.go
@@ -86,7 +86,7 @@ func vaultRenewDuration(s *Secret) time.Duration {
 		// at least one more time should the first renewal fail.
 		sleep = sleep / 3.0
 
-		// Use a randomness so many clients do not hit Vault simultaneously.
+		// Use some randomness so many clients do not hit Vault simultaneously.
 		sleep = sleep * (rand.Float64() + 1) / 2.0
 	} else {
 		// For non-renewable leases set the renew duration to use much of the secret

--- a/dependency/vault_common_test.go
+++ b/dependency/vault_common_test.go
@@ -1,5 +1,21 @@
 package dependency
 
+import "testing"
+
 func init() {
 	VaultDefaultLeaseDuration = 0
+}
+
+func TestVaultRenewDuration(t *testing.T) {
+	renewable := Secret{LeaseDuration: 100, Renewable: true}
+	renewableDur := vaultRenewDuration(&renewable).Seconds()
+	if renewableDur < 16 || renewableDur >= 34 {
+		t.Fatalf("renewable duration is not within 1/6 to 1/3 of lease duration: %f", renewableDur)
+	}
+
+	nonRenewable := Secret{LeaseDuration: 100}
+	nonRenewableDur := vaultRenewDuration(&nonRenewable).Seconds()
+	if nonRenewableDur < 85 || nonRenewableDur > 95 {
+		t.Fatalf("renewable duration is not within 85%% to 95%% of lease duration: %f", nonRenewableDur)
+	}
 }


### PR DESCRIPTION
This PR changes the behavior around refreshing secrets with non-renewable leases to wait for 85-95% of the lease time (rather than 1/6-1/3rd, as with renewable leases). We could also probably increase the range on renewable leases as well to something like 25-35% instead of 16-33%, to eliminate some unnecessarily early refreshing.

Fixes #1126.