### PR TITLE
Make exec_once test more reliable

### DIFF
--- a/manager/runner_test.go
+++ b/manager/runner_test.go
@@ -757,7 +757,23 @@ func TestRunner_Start(t *testing.T) {
 		case err := <-r.ErrCh:
 			t.Fatal(err)
 		case <-r.renderedCh:
-			// Just assert there is no panic
+			found := false
+			for i := 0; i < 5; i++ {
+				if found {
+					break
+				}
+
+				time.Sleep(100 * time.Millisecond)
+
+				r.childLock.RLock()
+				if r.child != nil {
+					found = true
+				}
+				r.childLock.RUnlock()
+			}
+			if !found {
+				t.Error("missing child")
+			}
 		case <-time.After(2 * time.Second):
 			t.Fatal("timeout")
 		}


### PR DESCRIPTION
This just uses the same approach as in the exec test where it retries with a sleep for the child process to exist.

Builds on the work and closes #1160.
Fixes #1159.