### PR TITLE
added "light" docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ LD_FLAGS ?= \
 	-X ${PROJECT}/version.GitCommit=${GIT_COMMIT}
 
 # List of Docker targets to build
-DOCKER_TARGETS ?= alpine scratch
+DOCKER_TARGETS ?= alpine light scratch
 
 # List of tests to run
 TEST ?= ./...

--- a/docker/light/Dockerfile
+++ b/docker/light/Dockerfile
@@ -1,0 +1,6 @@
+FROM busybox
+LABEL maintainer "Seth Vargo <seth@sethvargo.com> (@sethvargo)"
+
+ADD "./pkg/linux_amd64/consul-template" "/"
+
+ENTRYPOINT ["/consul-template"]

--- a/docker/light/Dockerfile
+++ b/docker/light/Dockerfile
@@ -1,6 +1,6 @@
-FROM busybox
+FROM alpine:latest
 LABEL maintainer "Seth Vargo <seth@sethvargo.com> (@sethvargo)"
 
-ADD "./pkg/linux_amd64/consul-template" "/"
+ADD "./pkg/linux_amd64/consul-template" "/bin/consul-template"
 
-ENTRYPOINT ["/consul-template"]
+ENTRYPOINT ["/bin/consul-template"]


### PR DESCRIPTION
This new docker image is suitable for use as a sidecar container in a Kubernetes pod with the `PodShareProcessNamespace` feature. There is more information on why the current images are not a good fit in the linked issue.

Closes #1190 