### PR TITLE
add ca-certificates to light docker image

### DIFF
--- a/docker/light/Dockerfile
+++ b/docker/light/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:latest
 LABEL maintainer "Seth Vargo <seth@sethvargo.com> (@sethvargo)"
 
+RUN apk add --no-cache ca-certificates
 ADD "./pkg/linux_amd64/consul-template" "/bin/consul-template"
 
 ENTRYPOINT ["/bin/consul-template"]


### PR DESCRIPTION
I found that when `hashicorp/consul-template:light` tries to talk to my Vault server that is secured with a Let’s Encrypt cert, it fails. (vault fqdn changed to vault.example.com in logs)

```
2019/03/20 18:13:47.270390 [WARN] (view) vault.read(secret/mydatabase): vault.read(secret/data/database): Get https://vault.example.com/v1/sys/internal/ui/mounts/secret/data/database: x509: certificate signed by unknown authority (retry attempt 1 after "250ms")
2019/03/20 18:13:47.398900 [WARN] vault.token: failed to renew: Put https://vault.example.com/v1/auth/token/renew-self: x509: certificate signed by unknown authority
```

If I run `apk add --no-cache ca-certificates` before running consul-template, the problem is fixed.

```
2019/03/20 18:14:22.207209 [INFO] (runner) rendered "./system.properties.ctmpl" => "./system.properties"
```
