### PR TITLE
various Makefile fixes and updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,9 @@ MKFILE_PATH := $(lastword $(MAKEFILE_LIST))
 CURRENT_DIR := $(patsubst %/,%,$(dir $(realpath $(MKFILE_PATH))))
 
 # Ensure GOPATH
-GOPATH ?= $(HOME)/go
-
-# List all our actual files, excluding vendor
-GOFILES ?= $(shell go list $(TEST) | grep -v /vendor/)
+GOPATH ?= $(shell go env GOPATH)
+# assume last entry in GOPATH is home to project
+GOPATH := $(lastword $(subst :, ,${GOPATH}))
 
 # Tags specific for building
 GOTAGS ?=
@@ -15,7 +14,7 @@ GOTAGS ?=
 GOMAXPROCS ?= 4
 
 # Get the project metadata
-GOVERSION := 1.11.5
+GOVERSION := 1.12.5
 PROJECT := $(CURRENT_DIR:$(GOPATH)/src/%=%)
 OWNER := $(notdir $(patsubst %/,%,$(dir $(PROJECT))))
 NAME := $(notdir $(PROJECT))
@@ -58,22 +57,15 @@ define make-xc-target
 		@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT} (excluded)"
   else
 		@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT}"
-		@docker run \
-			--interactive \
-			--rm \
-			--dns="8.8.8.8" \
-			--volume="${CURRENT_DIR}:/go/src/${PROJECT}" \
-			--workdir="/go/src/${PROJECT}" \
-			"golang:${GOVERSION}" \
-			env \
-				CGO_ENABLED="0" \
-				GOOS="${1}" \
-				GOARCH="${2}" \
-				go build \
-				  -a \
-					-o="pkg/${1}_${2}/${NAME}${3}" \
-					-ldflags "${LD_FLAGS}" \
-					-tags "${GOTAGS}"
+		env \
+			CGO_ENABLED="0" \
+			GOOS="${1}" \
+			GOARCH="${2}" \
+			go build \
+				-a \
+				-o="pkg/${1}_${2}/${NAME}${3}" \
+				-ldflags "${LD_FLAGS}" \
+				-tags "${GOTAGS}"
   endif
   .PHONY: $1/$2
 
@@ -84,6 +76,17 @@ define make-xc-target
   .PHONY: build
 endef
 $(foreach goarch,$(XC_ARCH),$(foreach goos,$(XC_OS),$(eval $(call make-xc-target,$(goos),$(goarch),$(if $(findstring windows,$(goos)),.exe,)))))
+
+# Use docker to create pristine builds for release
+pristine:
+	@docker run \
+		--interactive \
+		--user $$(id -u):$$(id -g) \
+		--rm \
+		--dns="8.8.8.8" \
+		--volume="${CURRENT_DIR}:/go/src/${PROJECT}" \
+		--workdir="/go/src/${PROJECT}" \
+		"golang:${GOVERSION}" env GOCACHE=/tmp make -j4 build
 
 # bootstrap installs the necessary go tools for development or build.
 bootstrap:
@@ -114,17 +117,21 @@ dev:
 
 # dist builds the binaries and then signs and packages them for distribution
 dist:
+	@$(MAKE) -f "${MKFILE_PATH}" _cleanup
+	@$(MAKE) -f "${MKFILE_PATH}" pristine
+	@$(MAKE) -f "${MKFILE_PATH}" _compress _checksum
+.PHONY: dist
+
+release: dist
 ifndef GPG_KEY
 	@echo "==> ERROR: No GPG key specified! Without a GPG key, this release cannot"
 	@echo "           be signed. Set the environment variable GPG_KEY to the ID of"
 	@echo "           the GPG key to continue."
 	@exit 127
 else
-	@$(MAKE) -f "${MKFILE_PATH}" _cleanup
-	@$(MAKE) -f "${MKFILE_PATH}" -j4 build
-	@$(MAKE) -f "${MKFILE_PATH}" _compress _checksum _sign
+	@$(MAKE) -f "${MKFILE_PATH}" _sign
 endif
-.PHONY: dist
+.PHONY: release
 
 # Create a docker compile and push target for each container. This will create
 # docker-build/scratch, docker-push/scratch, etc. It will also create two meta
@@ -138,7 +145,6 @@ define make-docker-target
 			--rm \
 			--force-rm \
 			--no-cache \
-			--squash \
 			--compress \
 			--file="docker/${1}/Dockerfile" \
 			--build-arg="LD_FLAGS=${LD_FLAGS}" \
@@ -167,19 +173,23 @@ $(foreach target,$(DOCKER_TARGETS),$(eval $(call make-docker-target,$(target))))
 # test runs the test suite.
 test:
 	@echo "==> Testing ${NAME}"
-	@go test -timeout=30s -parallel=20 -tags="${GOTAGS}" ${GOFILES} ${TESTARGS}
+	@go test -timeout=30s -parallel=20 -tags="${GOTAGS}" ./... ${TESTARGS}
 .PHONY: test
 
 # test-race runs the test suite.
 test-race:
 	@echo "==> Testing ${NAME} (race)"
-	@go test -timeout=60s -race -tags="${GOTAGS}" ${GOFILES} ${TESTARGS}
+	@go test -timeout=60s -race -tags="${GOTAGS}" ./... ${TESTARGS}
 .PHONY: test-race
 
 # _cleanup removes any previous binaries
 _cleanup:
 	@rm -rf "${CURRENT_DIR}/pkg/"
 	@rm -rf "${CURRENT_DIR}/bin/"
+.PHONY: _cleanup
+
+clean: _cleanup
+.PHONY: clean
 
 # _compress compresses all the binaries in pkg/* as tarball and zip.
 _compress:
@@ -197,7 +207,7 @@ _compress:
 		cd "$$platform"; \
 		tar -czf "${CURRENT_DIR}/pkg/dist/${NAME}_${VERSION}_$${osarch}.tgz" "${NAME}$${ext}"; \
 		zip -q "${CURRENT_DIR}/pkg/dist/${NAME}_${VERSION}_$${osarch}.zip" "${NAME}$${ext}"; \
-		cd - &>/dev/null; \
+		cd - >/dev/null; \
 	done
 .PHONY: _compress
 
@@ -205,7 +215,7 @@ _compress:
 _checksum:
 	@cd "${CURRENT_DIR}/pkg/dist" && \
 		shasum --algorithm 256 * > ${CURRENT_DIR}/pkg/dist/${NAME}_${VERSION}_SHA256SUMS && \
-		cd - &>/dev/null
+		cd - >/dev/null
 .PHONY: _checksum
 
 # _sign signs the binaries using the given GPG_KEY. This should not be called


### PR DESCRIPTION
* use `go env` to get GOPATH and handle multiple paths
* changes to build, dist for easier testing
* remove bashisms
* add pristine build setup for release
* use ./... in tests (removed old vendor workaround)