### PR TITLE
fix: by default, if a token is found in Vaults ~/.vault-token, use thi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,8 @@ vault {
 
   # This tells Consul Template to load the Vault token from the contents of a file.
   # If this field is specified:
-  # - Consul Template will not try to renew the Vault token.
+  # - by default Consul Template will not try to renew the Vault token, if you want it
+  # to renew you will nee dto specify renew_token = true as below.
   # - Consul Template will periodically stat the file and update the token if it has
   # changed.
   # vault_agent_token_file = "/tmp/vault/agent/token"
@@ -825,7 +826,7 @@ To access a versioned secret value (for the K/V version 2 backend):
 
 When omitting the `?version` parameter, the latest version of the secret will be
 fetched. Note the nested `.Data.data` syntax when referencing the secret value.
-For more information about using the K/V v2 backend, see the 
+For more information about using the K/V v2 backend, see the
 [Vault Documentation](https://www.vaultproject.io/docs/secrets/kv/kv-v2.html).
 
 When using Vault versions 0.10.0/0.10.1, the secret path will have to be prefixed
@@ -1494,8 +1495,8 @@ plugin.
 {{ plugin "my-plugin" }}
 ```
 
-The plugin can take an arbitrary number of string arguments, and can be the 
-target of a pipeline that produces strings as well. This is most commonly 
+The plugin can take an arbitrary number of string arguments, and can be the
+target of a pipeline that produces strings as well. This is most commonly
 combined with a JSON filter for customization:
 
 ```liquid
@@ -1798,7 +1799,7 @@ $ NAME [INPUT...]
   that is found on the `PATH`.
 
 - `INPUT` - input from the template. There will be one INPUT for every argument passed
-  to the `plugin` function. If the arguments contain whitespace, that whitespace 
+  to the `plugin` function. If the arguments contain whitespace, that whitespace
   will be passed as if the argument were quoted by the shell.
 
 #### Important Notes

--- a/config/vault.go
+++ b/config/vault.go
@@ -266,7 +266,6 @@ func (c *VaultConfig) Finalize() {
 		}
 	} else {
 		c.Token = stringFromFile([]string{*c.VaultAgentTokenFile}, "")
-		c.RenewToken = Bool(false)
 	}
 
 	if c.Transport == nil {

--- a/config/vault.go
+++ b/config/vault.go
@@ -209,9 +209,13 @@ func (c *VaultConfig) Finalize() {
 	}
 
 	if c.RenewToken == nil {
+		default_renew := DefaultVaultRenewToken
+		if c.VaultAgentTokenFile != nil {
+			default_renew = false
+		}
 		c.RenewToken = boolFromEnv([]string{
 			"VAULT_RENEW_TOKEN",
-		}, DefaultVaultRenewToken)
+		}, default_renew)
 	}
 
 	if c.Retry == nil {

--- a/config/vault.go
+++ b/config/vault.go
@@ -256,7 +256,15 @@ func (c *VaultConfig) Finalize() {
 		}, "")
 	}
 
-	if c.VaultAgentTokenFile != nil {
+	if c.VaultAgentTokenFile == nil {
+		if StringVal(c.Token) == "" {
+			if homePath != "" {
+				c.Token = stringFromFile([]string{
+					homePath + "/.vault-token",
+				}, "")
+			}
+		}
+	} else {
 		c.Token = stringFromFile([]string{*c.VaultAgentTokenFile}, "")
 		c.RenewToken = Bool(false)
 	}


### PR DESCRIPTION
…s and renew when necessary...


as per the outrage outlined here which seems to have been ignored;

https://github.com/hashicorp/consul-template/pull/1182