### PR TITLE
tests now use an external vault process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,18 @@ jobs:
   build:
     environment:
       CONSUL_VERSION: 1.5.1
+      VAULT_VERSION: 1.1.3
     docker:
       - image: circleci/golang:latest
     working_directory: /go/src/github.com/hashicorp/consul-template
     steps:
       - checkout
       - run: |
-          sudo curl -sLo consul.zip https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip
+          curl -sLo consul.zip https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip
           unzip consul.zip
           sudo cp consul /usr/local/bin/
+      - run: |
+          curl -sLo vault.zip https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip
+          unzip vault.zip
+          sudo cp vault /usr/local/bin/
       - run: make test

--- a/README.md
+++ b/README.md
@@ -2228,7 +2228,7 @@ following to generate all binaries:
 $ make build
 ```
 
-If you want to run the tests, first [install consul locally](https://www.consul.io/docs/install/index.html), then:
+If you want to run the tests, first install [consul](https://www.consul.io/docs/install/index.html) and [vault](https://www.vaultproject.io/docs/install/) locally, then:
 
 ```shell
 $ make test

--- a/dependency/vault_list_test.go
+++ b/dependency/vault_list_test.go
@@ -68,13 +68,16 @@ func TestNewVaultListQuery(t *testing.T) {
 func TestVaultListQuery_Fetch(t *testing.T) {
 	t.Parallel()
 
-	clients, vault := testVaultServer(t)
-	defer vault.Stop()
+	clients, vault := testVaultServer(t, "listfetch", "1")
+	secretsPath := vault.secretsPath
 
-	vault.CreateSecret("foo/bar", map[string]interface{}{
-		"ttl": "2s", // explicitly make this a short duration for testing
+	err := vault.CreateSecret("foo/bar", map[string]interface{}{
+		"ttl": "100ms", // explicitly make this a short duration for testing
 		"zip": "zap",
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	cases := []struct {
 		name string
@@ -83,7 +86,7 @@ func TestVaultListQuery_Fetch(t *testing.T) {
 	}{
 		{
 			"exists",
-			"secret/",
+			secretsPath,
 			[]string{"foo/"},
 		},
 		{
@@ -110,7 +113,7 @@ func TestVaultListQuery_Fetch(t *testing.T) {
 	}
 
 	t.Run("stops", func(t *testing.T) {
-		d, err := NewVaultListQuery("secret/foo/bar")
+		d, err := NewVaultListQuery(secretsPath + "/foo/bar")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -147,7 +150,7 @@ func TestVaultListQuery_Fetch(t *testing.T) {
 	})
 
 	t.Run("fires_changes", func(t *testing.T) {
-		d, err := NewVaultListQuery("secret/")
+		d, err := NewVaultListQuery(secretsPath)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/dependency/vault_write.go
+++ b/dependency/vault_write.go
@@ -173,7 +173,9 @@ func (d *VaultWriteQuery) writeSecret(clients *ClientSet, opts *QueryOptions) (*
 		return nil, errors.Wrap(err, d.String())
 	}
 	if vaultSecret == nil {
-		return nil, fmt.Errorf("no secret exists at %s", d.path)
+		if _, isv2, _ := isKVv2(clients.Vault(), d.path); isv2 {
+			return nil, fmt.Errorf("no secret exists at %s", d.path)
+		}
 	}
 
 	return vaultSecret, nil

--- a/dependency/vault_write_test.go
+++ b/dependency/vault_write_test.go
@@ -74,8 +74,7 @@ func TestNewVaultWriteQuery(t *testing.T) {
 func TestVaultWriteQuery_Fetch(t *testing.T) {
 	t.Parallel()
 
-	clients, vault := testVaultServer(t)
-	defer vault.Stop()
+	clients := testClients
 
 	if err := clients.Vault().Sys().Mount("transit", &api.MountInput{
 		Type: "transit",


### PR DESCRIPTION
Replace use of core vault package for testing with an external vault
process. Previously each set of tests that needed vault would create a
vault service in the test process and all tests would use the default
'secret' kv path. Now it uses a separate kv secrets path for each set of
tests, setting the version for each.

The code for starting up the Vault process was based off what was
already used for Consul via its sdk/testutils package.

In the process various test conflicts were addressed and an external
process (consul and vault) process leak was fixed [1].

[1] the leak was caused by use of log.Fatal which calls os.Exit which
exist the process without running any cleanup code.