### PR TITLE
Ignore anonymous request failures checking kv status

### DIFF
--- a/dependency/vault_common.go
+++ b/dependency/vault_common.go
@@ -225,6 +225,12 @@ func isKVv2(client *api.Client, path string) (string, bool, error) {
 			return "", false, nil
 		}
 
+		// anonymous requests may fail to access /sys/internal/ui path
+		// Vault v1.1.3 returns 500 status code but may return 4XX in future
+		if client.Token() == "" {
+			return "", false, nil
+		}
+
 		return "", false, err
 	}
 


### PR DESCRIPTION
When making unauthenticated secret lookup requests, ignore errors that
result from checking the secret mount type.  If it's a persistent error,
the error on the actual lookup.

This restores behavior prior to #1180 .
