### PR TITLE
Fix vault APi change for Skipping TLS Verification const

### DIFF
--- a/config/vault.go
+++ b/config/vault.go
@@ -242,7 +242,7 @@ func (c *VaultConfig) Finalize() {
 		c.SSL.ServerName = stringFromEnv([]string{api.EnvVaultTLSServerName}, "")
 	}
 	if c.SSL.Verify == nil {
-		c.SSL.Verify = antiboolFromEnv([]string{api.EnvVaultInsecure}, true)
+		c.SSL.Verify = antiboolFromEnv([]string{api.EnvVaultSkipVerify}, true)
 	}
 	c.SSL.Finalize()
 


### PR DESCRIPTION
Looks like this was changed in [6ce09bae6a8c443bfc64e0fd5e8461db79433a96](https://github.com/hashicorp/vault/commits/6ce09bae6a8c443bfc64e0fd5e8461db79433a96)