### PR TITLE
add byMeta function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1250,6 +1250,81 @@ Takes the list of services returned by the [`service`](#service) or
 {{ end }}{{ end }}
 ```
 
+##### `byMeta`
+
+Takes a list of services returned by the [`service`](#service) or
+[`services`](#services) and returns a map that groups services by ServiceMeta values.
+Multiple service meta keys can be passed as a comma separated string. `|int` can be added to
+a meta key to convert numbers from service meta values to padded numbers in `printf "%05d" % value`
+format (useful for sorting as Go Template sorts maps by keys).
+
+**Example**:
+
+If we have the following services registered in Consul:
+
+```json
+{
+  "Services": [
+     {
+       "ID": "redis-dev-1",
+       "Name": "redis",
+       "ServiceMeta": {
+         "environment": "dev",
+         "shard_number": "1"
+       },
+       ...
+     },
+     {
+       "ID": "redis-prod-1",
+       "Name": "redis",
+       "ServiceMeta": {
+         "environment": "prod",
+         "shard_number": "1"
+       },
+       ...
+     },
+     {
+       "ID": "redis-prod-2",
+       "Name": "redis",
+       "ServiceMeta": {
+         "environment": "prod",
+         "shard_number": "2",
+       },
+       ...
+     }
+   ]
+}
+```
+
+```liquid
+{{ service "redis|any" | byMeta "environment,shard_number|int" | toJson }}
+```
+
+The code above will produce a map of services grouped by meta:
+
+```json
+{
+  "dev_00001": [
+    {
+      "ID": "redis-dev-1",
+      ...
+    }
+  ],
+  "prod_00001": [
+    {
+      "ID": "redis-prod-1",
+      ...
+    }
+  ],
+  "prod_00002": [
+    {
+      "ID": "redis-prod-2",
+      ...
+    }
+  ]
+}
+```
+
 ##### `contains`
 
 Determines if a needle is within an iterable element.

--- a/template/funcs_test.go
+++ b/template/funcs_test.go
@@ -3,8 +3,11 @@ package template
 import (
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"testing"
+
+	dep "github.com/hashicorp/consul-template/dependency"
 )
 
 func TestFileSandbox(t *testing.T) {
@@ -73,6 +76,155 @@ func TestFileSandbox(t *testing.T) {
 				}
 			} else if err != tc.expected {
 				t.Fatalf("expected %v got %v", tc.expected, err)
+			}
+		})
+	}
+}
+
+func Test_byMeta(t *testing.T) {
+	svcA := &dep.HealthService{
+		Node:                "",
+		NodeID:              "",
+		NodeAddress:         "",
+		NodeTaggedAddresses: nil,
+		NodeMeta:            nil,
+		ServiceMeta: map[string]string{
+			"version":         "v2",
+			"version_num":     "2",
+			"bad_version_num": "1zz",
+			"env":             "dev",
+		},
+		Address: "",
+		ID:      "svcA",
+		Name:    "",
+		Tags:    nil,
+		Checks:  nil,
+		Status:  "",
+		Port:    0,
+	}
+
+	svcB := &dep.HealthService{
+		Node:                "",
+		NodeID:              "",
+		NodeAddress:         "",
+		NodeTaggedAddresses: nil,
+		NodeMeta:            nil,
+		ServiceMeta: map[string]string{
+			"version":         "v11",
+			"version_num":     "11",
+			"bad_version_num": "1zz",
+			"env":             "prod",
+		},
+		Address: "",
+		ID:      "svcB",
+		Name:    "",
+		Tags:    nil,
+		Checks:  nil,
+		Status:  "",
+		Port:    0,
+	}
+
+	svcC := &dep.HealthService{
+		Node:                "",
+		NodeID:              "",
+		NodeAddress:         "",
+		NodeTaggedAddresses: nil,
+		NodeMeta:            nil,
+		ServiceMeta: map[string]string{
+			"version":         "v11",
+			"version_num":     "11",
+			"bad_version_num": "1zz",
+			"env":             "prod",
+		},
+		Address: "",
+		ID:      "svcC",
+		Name:    "",
+		Tags:    nil,
+		Checks:  nil,
+		Status:  "",
+		Port:    0,
+	}
+
+	type args struct {
+		meta     string
+		services []*dep.HealthService
+	}
+
+	tests := []struct {
+		name       string
+		args       args
+		wantGroups map[string][]*dep.HealthService
+		wantErr    bool
+	}{
+		{
+			name: "version string",
+			args: args{
+				meta:     "version",
+				services: []*dep.HealthService{svcA, svcB, svcC},
+			},
+			wantGroups: map[string][]*dep.HealthService{
+				"v11": {svcB, svcC},
+				"v2":  {svcA},
+			},
+			wantErr: false,
+		},
+		{
+			name: "version number",
+			args: args{
+				meta:     "version_num|int",
+				services: []*dep.HealthService{svcA, svcB, svcC},
+			},
+			wantGroups: map[string][]*dep.HealthService{
+				"00011": {svcB, svcC},
+				"00002": {svcA},
+			},
+			wantErr: false,
+		},
+		{
+			name: "bad version number",
+			args: args{
+				meta:     "bad_version_num|int",
+				services: []*dep.HealthService{svcA, svcB, svcC},
+			},
+			wantGroups: nil,
+			wantErr:    true,
+		},
+		{
+			name: "multiple meta",
+			args: args{
+				meta:     "env,version_num|int,version",
+				services: []*dep.HealthService{svcA, svcB, svcC},
+			},
+			wantGroups: map[string][]*dep.HealthService{
+				"dev_00002_v2":   {svcA},
+				"prod_00011_v11": {svcB, svcC},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotGroups, err := byMeta(tt.args.meta, tt.args.services)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("byMeta() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			onlyIDs := func(groups map[string][]*dep.HealthService) (ids map[string]map[string]int) {
+				ids = make(map[string]map[string]int)
+				for group, svcs := range groups {
+					ids[group] = make(map[string]int)
+					for _, svc := range svcs {
+						ids[group][svc.ID] = 1
+					}
+				}
+				return
+			}
+
+			gotIDs := onlyIDs(gotGroups)
+			wantIDs := onlyIDs(tt.wantGroups)
+			if !reflect.DeepEqual(gotGroups, tt.wantGroups) {
+				t.Errorf("byMeta() = %v, want %v", gotIDs, wantIDs)
 			}
 		})
 	}

--- a/template/template.go
+++ b/template/template.go
@@ -280,6 +280,7 @@ func funcMap(i *funcMapInput) template.FuncMap {
 		"toUpper":         toUpper,
 		"toYAML":          toYAML,
 		"split":           split,
+		"byMeta":          byMeta,
 
 		// Math functions
 		"add":      add,


### PR DESCRIPTION
##### `byMeta`

Takes a list of services returned by the [`service`](#service) or
[`services`](#services) and returns a map that groups services by ServiceMeta values.
Multiple service meta keys can be passed as a comma separated string. `|int` can be added to
a meta key to convert numbers from service meta values to padded numbers in `printf "%05d" % value` format (useful for sorting as Go Template sorts maps by keys).

**Example**:

If we have the following services registered in Consul:

```json
{
  "Services": [
     {
       "ID": "redis-dev-1",
       "Name": "redis",
       "ServiceMeta": {
         "environment": "dev",
         "shard_number": "1"
       },
       ...
     },
     {
       "ID": "redis-prod-1",
       "Name": "redis",
       "ServiceMeta": {
         "environment": "prod",
         "shard_number": "1"
       },
       ...
     },
     {
       "ID": "redis-prod-2",
       "Name": "redis",
       "ServiceMeta": {
         "environment": "prod",
         "shard_number": "2",
       },
       ...
     }
   ]
}
```

```liquid
{{ service "redis|any" | byMeta "environment,shard_number|int" | toJson }}
```

The code above will produce a map of services grouped by meta:

```json
{
  "dev_00001": [
    {
      "ID": "redis-dev-1",
      ...
    }
  ],
  "prod_00001": [
    {
      "ID": "redis-prod-1",
      ...
    }
  ],
  "prod_00002": [
    {
      "ID": "redis-prod-2",
      ...
    }
  ]
}
```