### PR TITLE
fix test issues due to meta data added to consul

### DIFF
--- a/dependency/catalog_node_test.go
+++ b/dependency/catalog_node_test.go
@@ -108,6 +108,7 @@ func TestCatalogNodeQuery_Fetch(t *testing.T) {
 						Service: "consul",
 						Port:    testConsul.Config.Ports.Server,
 						Tags:    ServiceTags([]string{}),
+						Meta:    map[string]string{},
 					},
 					&CatalogNodeService{
 						ID:      "service-meta",
@@ -142,6 +143,11 @@ func TestCatalogNodeQuery_Fetch(t *testing.T) {
 			if act != nil {
 				if n := act.(*CatalogNode).Node; n != nil {
 					n.ID = ""
+				}
+				// delete any version data from ServiceMeta
+				services := act.(*CatalogNode).Services
+				for i := range services {
+					services[i].Meta = filterVersionMeta(services[i].Meta)
 				}
 			}
 

--- a/dependency/catalog_service_test.go
+++ b/dependency/catalog_service_test.go
@@ -209,6 +209,13 @@ func TestCatalogServiceQuery_Fetch(t *testing.T) {
 				}
 			}
 
+			// delete any version data from ServiceMeta
+			act_list := act.([]*CatalogService)
+			for i := range act_list {
+				act_list[i].ServiceMeta = filterVersionMeta(
+					act_list[i].ServiceMeta)
+			}
+
 			assert.Equal(t, tc.exp, act)
 		})
 	}

--- a/dependency/consul_common_test.go
+++ b/dependency/consul_common_test.go
@@ -1,0 +1,19 @@
+package dependency
+
+var filtered_meta = []string{"raft_version", "serf_protocol_current",
+	"serf_protocol_min", "serf_protocol_max", "version",
+}
+
+// filterVersionMeta filters out all version information from the returned
+// metadata. It allocates the meta map if it is nil to make the tests backward
+// compatible with versions < 1.5.2. Once this is no longer needed the returned
+// value can be removed (along with its assignment).
+func filterVersionMeta(meta map[string]string) map[string]string {
+	if meta == nil {
+		return make(map[string]string)
+	}
+	for _, k := range filtered_meta {
+		delete(meta, k)
+	}
+	return meta
+}

--- a/dependency/health_service_test.go
+++ b/dependency/health_service_test.go
@@ -164,12 +164,13 @@ func TestHealthServiceQuery_Fetch(t *testing.T) {
 					NodeMeta: map[string]string{
 						"consul-network-segment": "",
 					},
-					Address: testConsul.Config.Bind,
-					ID:      "consul",
-					Name:    "consul",
-					Tags:    []string{},
-					Status:  "passing",
-					Port:    testConsul.Config.Ports.Server,
+					ServiceMeta: map[string]string{},
+					Address:     testConsul.Config.Bind,
+					ID:          "consul",
+					Name:        "consul",
+					Tags:        []string{},
+					Status:      "passing",
+					Port:        testConsul.Config.Ports.Server,
 				},
 			},
 		},
@@ -192,12 +193,13 @@ func TestHealthServiceQuery_Fetch(t *testing.T) {
 					NodeMeta: map[string]string{
 						"consul-network-segment": "",
 					},
-					Address: testConsul.Config.Bind,
-					ID:      "consul",
-					Name:    "consul",
-					Tags:    []string{},
-					Status:  "passing",
-					Port:    testConsul.Config.Ports.Server,
+					ServiceMeta: map[string]string{},
+					Address:     testConsul.Config.Bind,
+					ID:          "consul",
+					Name:        "consul",
+					Tags:        []string{},
+					Status:      "passing",
+					Port:        testConsul.Config.Ports.Server,
 				},
 			},
 		},
@@ -244,6 +246,8 @@ func TestHealthServiceQuery_Fetch(t *testing.T) {
 				for _, v := range act.([]*HealthService) {
 					v.NodeID = ""
 					v.Checks = nil
+					// delete any version data from ServiceMeta
+					v.ServiceMeta = filterVersionMeta(v.ServiceMeta)
 				}
 			}
 


### PR DESCRIPTION
Several calls had version meta-data added in consul 1.5.2 [1]. This
fixes those tests and bumps circleci tests to use consul 1.5.2.

[1] https://github.com/hashicorp/consul/pull/5455