### PR TITLE
Knob to blacklist some template functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,10 @@ template {
   left_delimiter  = "{{"
   right_delimiter = "}}"
 
+  # These are functions that are not permitted in the template. If a template
+  # includes one of these functions, it will exit with an error.
+  function_blacklist = []
+
   # This is the `minimum(:maximum)` to wait before rendering a new template to
   # disk and triggering a command, separated by a colon (`:`). If the optional
   # maximum value is omitted, it is assumed to be 4x the required minimum value.

--- a/config/template.go
+++ b/config/template.go
@@ -75,6 +75,10 @@ type TemplateConfig struct {
 	// delimiter is utilized when parsing the template.
 	LeftDelim  *string `mapstructure:"left_delimiter"`
 	RightDelim *string `mapstructure:"right_delimiter"`
+
+	// FunctionBlacklist is a list of functions that this template is not
+	// permitted to run.
+	FunctionBlacklist []string `mapstructure:"function_blacklist"`
 }
 
 // DefaultTemplateConfig returns a configuration that is populated with the
@@ -122,6 +126,10 @@ func (c *TemplateConfig) Copy() *TemplateConfig {
 
 	o.LeftDelim = c.LeftDelim
 	o.RightDelim = c.RightDelim
+
+	for _, fun := range c.FunctionBlacklist {
+		o.FunctionBlacklist = append(o.FunctionBlacklist, fun)
+	}
 
 	return &o
 }
@@ -194,6 +202,10 @@ func (c *TemplateConfig) Merge(o *TemplateConfig) *TemplateConfig {
 
 	if o.RightDelim != nil {
 		r.RightDelim = o.RightDelim
+	}
+
+	for _, fun := range o.FunctionBlacklist {
+		r.FunctionBlacklist = append(r.FunctionBlacklist, fun)
 	}
 
 	return r
@@ -285,6 +297,7 @@ func (c *TemplateConfig) GoString() string {
 		"Wait:%#v, "+
 		"LeftDelim:%s, "+
 		"RightDelim:%s"+
+		"FunctionBlacklist:%s"+
 		"}",
 		BoolGoString(c.Backup),
 		StringGoString(c.Command),
@@ -299,6 +312,7 @@ func (c *TemplateConfig) GoString() string {
 		c.Wait,
 		StringGoString(c.LeftDelim),
 		StringGoString(c.RightDelim),
+		c.FunctionBlacklist,
 	)
 }
 

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -851,11 +851,12 @@ func (r *Runner) init() error {
 	// destinations.
 	for _, ctmpl := range *r.config.Templates {
 		tmpl, err := template.NewTemplate(&template.NewTemplateInput{
-			Source:        config.StringVal(ctmpl.Source),
-			Contents:      config.StringVal(ctmpl.Contents),
-			ErrMissingKey: config.BoolVal(ctmpl.ErrMissingKey),
-			LeftDelim:     config.StringVal(ctmpl.LeftDelim),
-			RightDelim:    config.StringVal(ctmpl.RightDelim),
+			Source:            config.StringVal(ctmpl.Source),
+			Contents:          config.StringVal(ctmpl.Contents),
+			ErrMissingKey:     config.BoolVal(ctmpl.ErrMissingKey),
+			LeftDelim:         config.StringVal(ctmpl.LeftDelim),
+			RightDelim:        config.StringVal(ctmpl.RightDelim),
+			FunctionBlacklist: ctmpl.FunctionBlacklist,
 		})
 		if err != nil {
 			return err

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -1156,3 +1156,8 @@ func modulo(b, a interface{}) (interface{}, error) {
 		return nil, fmt.Errorf("modulo: unknown type for %q (%T)", av, a)
 	}
 }
+
+// blacklisted always returns an error, to be used in place of blacklisted template functions
+func blacklisted(...string) (string, error) {
+	return "", errors.New("function is disabled")
+}

--- a/template/template.go
+++ b/template/template.go
@@ -45,6 +45,10 @@ type Template struct {
 	// errMissingKey causes the template processing to exit immediately if a map
 	// is indexed with a key that does not exist.
 	errMissingKey bool
+
+	// functionBlacklist are functions not permitted to be executed
+	// when we render this template
+	functionBlacklist []string
 }
 
 // NewTemplateInput is used as input when creating the template.
@@ -62,6 +66,10 @@ type NewTemplateInput struct {
 	// LeftDelim and RightDelim are the template delimiters.
 	LeftDelim  string
 	RightDelim string
+
+	// FunctionBlacklist are functions not permitted to be executed
+	// when we render this template
+	FunctionBlacklist []string
 }
 
 // NewTemplate creates and parses a new Consul Template template at the given
@@ -86,6 +94,7 @@ func NewTemplate(i *NewTemplateInput) (*Template, error) {
 	t.leftDelim = i.LeftDelim
 	t.rightDelim = i.RightDelim
 	t.errMissingKey = i.ErrMissingKey
+	t.functionBlacklist = i.FunctionBlacklist
 
 	if i.Source != "" {
 		contents, err := ioutil.ReadFile(i.Source)
@@ -157,13 +166,14 @@ func (t *Template) Execute(i *ExecuteInput) (*ExecuteResult, error) {
 
 	tmpl := template.New("")
 	tmpl.Delims(t.leftDelim, t.rightDelim)
+
 	tmpl.Funcs(funcMap(&funcMapInput{
-		t:                tmpl,
-		brain:            i.Brain,
-		env:              i.Env,
-		used:             &used,
-		missing:          &missing,
-		blacklistedFuncs: i.BlacklistedFunctions,
+		t:                 tmpl,
+		brain:             i.Brain,
+		env:               i.Env,
+		used:              &used,
+		missing:           &missing,
+		functionBlacklist: t.functionBlacklist,
 	}))
 
 	if t.errMissingKey {
@@ -192,12 +202,12 @@ func (t *Template) Execute(i *ExecuteInput) (*ExecuteResult, error) {
 
 // funcMapInput is input to the funcMap, which builds the template functions.
 type funcMapInput struct {
-	t                *template.Template
-	brain            *Brain
-	env              []string
-	blacklistedFuncs []string
-	used             *dep.Set
-	missing          *dep.Set
+	t                 *template.Template
+	brain             *Brain
+	env               []string
+	functionBlacklist []string
+	used              *dep.Set
+	missing           *dep.Set
 }
 
 // funcMap is the map of template functions to their respective functions.
@@ -270,7 +280,7 @@ func funcMap(i *funcMapInput) template.FuncMap {
 		"modulo":   modulo,
 	}
 
-	for _, bf := range i.blacklistedFuncs {
+	for _, bf := range i.functionBlacklist {
 		if _, ok := r[bf]; ok {
 			r[bf] = blacklisted
 		}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1329,11 +1329,11 @@ func TestTemplate_Execute(t *testing.T) {
 		{
 			"helper_plugin_disabled",
 			&NewTemplateInput{
-				Contents: `{{ "1" | plugin "echo" }}`,
+				Contents:          `{{ "1" | plugin "echo" }}`,
+				FunctionBlacklist: []string{"plugin"},
 			},
 			&ExecuteInput{
-				Brain:                NewBrain(),
-				BlacklistedFunctions: []string{"plugin"},
+				Brain: NewBrain(),
 			},
 			"",
 			true,

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1327,6 +1327,18 @@ func TestTemplate_Execute(t *testing.T) {
 			false,
 		},
 		{
+			"helper_plugin_disabled",
+			&NewTemplateInput{
+				Contents: `{{ "1" | plugin "echo" }}`,
+			},
+			&ExecuteInput{
+				Brain:                NewBrain(),
+				BlacklistedFunctions: []string{"plugin"},
+			},
+			"",
+			true,
+		},
+		{
 			"helper_regexMatch",
 			&NewTemplateInput{
 				Contents: `{{ "foo" | regexMatch "[a-z]+" }}`,


### PR DESCRIPTION
Exposes a knob for consul-template library users to disable some template functions.  Functions like `env` and `plugin` may access sensitive values on host and are best disabled unilaterally.