### PR TITLE
makefile: add support for arm64 platfrom

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ GOARCH ?= $(shell go env GOARCH)
 
 # Default os-arch combination to build
 XC_OS ?= darwin freebsd linux netbsd openbsd solaris windows
-XC_ARCH ?= 386 amd64 arm
-XC_EXCLUDE ?= darwin/arm solaris/386 solaris/arm windows/arm
+XC_ARCH ?= 386 amd64 arm arm64
+XC_EXCLUDE ?= darwin/arm solaris/386 solaris/arm windows/arm darwin/arm64 freebsd/arm64 netbsd/arm64 openbsd/arm64 solaris/arm64 windows/arm64
 
 # GPG Signing key (blank by default, means no GPG signing)
 GPG_KEY ?=


### PR DESCRIPTION
it works well  on my env
```
# file consul-template
consul-template: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=yBBsvpv1PEzSZNVawlQb/nVRSLofiQGfncQaZ4euB/7hXFeZH6_F2NAJC0gap1/f3JuZNrjcmTkEhzmJfzq, stripped
[root@localhost ~]# ./consul-template -v
consul-template v0.21.0 (0d999b3)

```

Signed-off-by: Liu Hua <sdu.liu@huawei.com>