### PR TITLE
Read paths unmodified if KVv2 status check fails

### DIFF
--- a/dependency/vault_read.go
+++ b/dependency/vault_read.go
@@ -147,10 +147,10 @@ func (d *VaultReadQuery) readSecret(clients *ClientSet, opts *QueryOptions) (*ap
 	if d.isKVv2 == nil {
 		mountPath, isKVv2, err := isKVv2(vaultClient, d.rawPath)
 		if err != nil {
-			return nil, errors.Wrap(err, d.String())
-		}
-
-		if isKVv2 {
+			log.Printf("[WARN] %s: failed to check if %s is KVv2, assume not: %s", d, d.rawPath, err)
+			isKVv2 = false
+			d.secretPath = d.rawPath
+		} else if isKVv2 {
 			d.secretPath = addPrefixToVKVPath(d.rawPath, mountPath, "data")
 		} else {
 			d.secretPath = d.rawPath


### PR DESCRIPTION
When vault.read fails to determine whether a path is KVv2, assume it's
KVv1 and read from the path as passed from user.

Here we fallback to behavior prior to https://github.com/hashicorp/consul-template/pull/1180,
so KVv2 check is for enhancement only.  If user truely lacks access, the
secret lookup call would fail and we report error back.

A customer hit a regression after they upgraded nomad with updated
consul-template, where their templates failed to read approle info
because isKVv2 returned an error.  The case is reproduced in
`TestVaultReadQuery_Fetch_NonSecrets` test.