### PR TITLE
file sandbox: check but don't alter paths passed to 'file'

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,8 +500,8 @@ template {
   function_blacklist = []
 
   # If a sandbox path is provided, any path provided to the `file` function is
-  # prefixed by the sandbox path. Relative paths that try to traverse outside
-  # that prefix will exit with an error.
+  # checked that it falls within the sandbox path. Relative paths that try to
+  # traverse outside the sandbox path will exit with an error.
   sandbox_path = ""
 
   # This is the `minimum(:maximum)` to wait before rendering a new template to

--- a/template/funcs_test.go
+++ b/template/funcs_test.go
@@ -2,12 +2,9 @@ package template
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
-
-	"github.com/pkg/errors"
 )
 
 func TestFileSandbox(t *testing.T) {
@@ -15,18 +12,15 @@ func TestFileSandbox(t *testing.T) {
 	// we need to be able to walk actual symlinks.
 	_, filename, _, _ := runtime.Caller(0)
 	sandboxDir := filepath.Join(filepath.Dir(filename), "testdata", "sandbox")
-	cwd, _ := os.Getwd()
 	cases := []struct {
-		name         string
-		sandbox      string
-		path         string
-		expectedPath string
-		expectedErr  error
+		name     string
+		sandbox  string
+		path     string
+		expected error
 	}{
 		{
 			"absolute_path_no_sandbox",
 			"",
-			"/path/to/file",
 			"/path/to/file",
 			nil,
 		},
@@ -34,59 +28,51 @@ func TestFileSandbox(t *testing.T) {
 			"relative_path_no_sandbox",
 			"",
 			"./path/to/file",
-			filepath.Join(cwd, "path/to/file"),
 			nil,
 		},
 		{
 			"absolute_path_with_sandbox",
 			sandboxDir,
-			"/path/to/file",
 			filepath.Join(sandboxDir, "path/to/file"),
 			nil,
 		},
 		{
 			"relative_path_in_sandbox",
 			sandboxDir,
-			"./path/to/file",
-			filepath.Join(sandboxDir, "path/to/file"),
+			filepath.Join(sandboxDir, "path/to/../to/file"),
 			nil,
 		},
 		{
 			"symlink_path_in_sandbox",
 			sandboxDir,
-			"./path/to/ok-symlink",
 			filepath.Join(sandboxDir, "path/to/ok-symlink"),
 			nil,
 		},
 		{
 			"relative_path_escaping_sandbox",
 			sandboxDir,
-			"/path/../../../funcs_test.go",
-			"",
-			errors.New("'/path/../../../funcs_test.go' is outside of sandbox"),
+			filepath.Join(sandboxDir, "path/../../../funcs_test.go"),
+			fmt.Errorf("'%s' is outside of sandbox",
+				filepath.Join(sandboxDir, "path/../../../funcs_test.go")),
 		},
 		{
 			"symlink_escaping_sandbox",
 			sandboxDir,
-			"/path/to/bad-symlink",
-			"",
-			errors.New("'/path/to/bad-symlink' is outside of sandbox"),
+			filepath.Join(sandboxDir, "path/to/bad-symlink"),
+			fmt.Errorf("'%s' is outside of sandbox",
+				filepath.Join(sandboxDir, "path/to/bad-symlink")),
 		},
 	}
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
-			result, err := sandboxedPath(tc.sandbox, tc.path)
-			if tc.expectedErr != nil {
-				if err == nil {
-					t.Fatalf("expected error %s got nil", tc.expectedErr)
+			err := pathInSandbox(tc.sandbox, tc.path)
+			if err != nil && tc.expected != nil {
+				if err.Error() != tc.expected.Error() {
+					t.Fatalf("expected %v got %v", tc.expected, err)
 				}
-				if err.Error() != tc.expectedErr.Error() {
-					t.Fatalf("expected %s got %s", tc.expectedErr, err)
-				}
-			}
-			if result != tc.expectedPath {
-				t.Fatalf("expected %s got %s", tc.expectedPath, result)
+			} else if err != tc.expected {
+				t.Fatalf("expected %v got %v", tc.expected, err)
 			}
 		})
 	}


### PR DESCRIPTION
During a discussion with @notnoop about https://github.com/hashicorp/nomad/pull/6075, we discovered that _altering_ the path being passed into the `file` function was going to cut off a lot of existing uses of consul-template in Nomad, particularly around the use of the `NOMAD_TASK_DIR` variable.

This PR provides a check but doesn't prefix the path parameter.

cc @schmichael @eikenb 