### PR TITLE
change backup to use os.Link

### DIFF
--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -163,12 +163,10 @@ func AtomicWrite(path string, createDestDirs bool, contents []byte, perms os.Fil
 	}
 
 	// If we got this far, it means we are about to save the file. Copy the
-	// current contents of the file onto disk (if it exists) so we have a backup.
+	// current file so we have a backup. Note that os.Link preserves the Mode.
 	if backup {
-		if _, err := os.Stat(path); !os.IsNotExist(err) {
-			if err := copyFile(path, path+".bak"); err != nil {
-				return err
-			}
+		if err := os.Link(path, path+".bak"); err != nil {
+			log.Printf("[WARN] (runner) could not backup %q: %v", path, err)
 		}
 	}
 
@@ -177,34 +175,4 @@ func AtomicWrite(path string, createDestDirs bool, contents []byte, perms os.Fil
 	}
 
 	return nil
-}
-
-// copyFile copies the file at src to the path at dst. Any errors that occur
-// are returned.
-func copyFile(src, dst string) error {
-	s, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer s.Close()
-
-	stat, err := s.Stat()
-	if err != nil {
-		return err
-	}
-
-	d, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, stat.Mode())
-	if err != nil {
-		return err
-	}
-	if _, err := io.Copy(d, s); err != nil {
-		d.Close()
-		return err
-	}
-	if err := d.Close(); err != nil {
-		return err
-	}
-
-	// io.Copy can restrict file permissions based on umask.
-	return os.Chmod(dst, stat.Mode())
 }


### PR DESCRIPTION
Instead of opening a new file and manually copying over the contents,
just use a hard link. This has different tradeoffs vs manually copying
(eg. it isn't supported on plan9), but should generally be more robust
and has no race.

This also changes it to just log an error vs returning it, in the case
of a os.Link returning an error, as that causes consul-template to exit
(which we don't want for this).