### PR TITLE
fix sleep on non-renewable vault secrets

### DIFF
--- a/dependency/vault_write_test.go
+++ b/dependency/vault_write_test.go
@@ -292,6 +292,42 @@ func TestVaultWriteQuery_Fetch(t *testing.T) {
 		case <-dataCh:
 		}
 	})
+
+	t.Run("nonrenewable-sleeper", func(t *testing.T) {
+		d, err := NewVaultWriteQuery("transit/encrypt/test",
+			map[string]interface{}{
+				"plaintext": b64("test"),
+			})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, qm, err := d.Fetch(clients, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		errCh := make(chan error, 1)
+		go func() {
+			_, _, err := d.Fetch(clients,
+				&QueryOptions{WaitIndex: qm.LastIndex})
+			if err != nil {
+				errCh <- err
+			}
+			close(errCh)
+		}()
+
+		if err := <-errCh; err != nil {
+			t.Fatal(err)
+		}
+		if len(d.sleepCh) != 1 {
+			t.Fatalf("sleep channel has len %v, expected 1", len(d.sleepCh))
+		}
+		dur := <-d.sleepCh
+		if dur > 0 {
+			t.Fatalf("duration of sleep should be > 0")
+		}
+	})
 }
 
 func TestVaultWriteQuery_String(t *testing.T) {


### PR DESCRIPTION
An over-zealous refactoring resulted in <-time.After() channel used for
non-renewable sleep to be ignored. I originally had channel of the time
channels but "simplified" it too much. This reworks it the way the sleep
is passed to the next iteration to just pass the time.Duration of the
sleep down the channel, then time.Sleep-ing when reading off the
channel. This way it can see it has a sleep to do, then do it instead of
skipping it as the time hadn't passed yet.

This also let me write a test for it as I don't need to actually sleep
to see that there is something in the channel.

Fixes #1272