### PR TITLE
Adds query function

### DIFF
--- a/dependency/catalog_query.go
+++ b/dependency/catalog_query.go
@@ -1,0 +1,120 @@
+package dependency
+
+import (
+	"encoding/gob"
+	"fmt"
+	"regexp"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	// Ensure implements
+	_ Dependency = (*CatalogPreparedQuery)(nil)
+
+	// CatalogPreparedQueryRe is the regular expression to use.
+	CatalogPreparedQueryRe = regexp.MustCompile(`\A` + serviceNameRe + `\z`)
+)
+
+func init() {
+	gob.Register([]*CatalogQuery{})
+}
+
+// CatalogQuery is a catalog entry in Consul.
+type CatalogQuery struct {
+	ID              string
+	Node            string
+	Address         string
+	Datacenter      string
+	TaggedAddresses map[string]string
+	NodeMeta        map[string]string
+	ServiceID       string
+	ServiceName     string
+	ServiceAddress  string
+	ServiceTags     ServiceTags
+	ServiceMeta     map[string]string
+	ServicePort     int
+}
+
+// CatalogPreparedQuery is the representation of a requested prepared query executions
+// dependency from inside a template.
+type CatalogPreparedQuery struct {
+	stopCh chan struct{}
+
+	name string
+}
+
+// NewCatalogPreparedQuery parses a string into a CatalogPreparedQuery.
+func NewCatalogPreparedQuery(s string) (*CatalogPreparedQuery, error) {
+	if !CatalogPreparedQueryRe.MatchString(s) {
+		return nil, fmt.Errorf("catalog.query: invalid format: %q", s)
+	}
+
+	m := regexpMatch(CatalogPreparedQueryRe, s)
+	return &CatalogPreparedQuery{
+		stopCh: make(chan struct{}, 1),
+		name:   m["name"],
+	}, nil
+}
+
+// Fetch queries the Consul API defined by the given client and returns a slice
+// of CatalogService objects.
+func (d *CatalogPreparedQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interface{}, *ResponseMetadata, error) {
+	select {
+	case <-d.stopCh:
+		return nil, nil, ErrStopped
+	default:
+	}
+
+	entries, qm, err := clients.Consul().PreparedQuery().Execute(d.name, opts.ToConsulOpts())
+	if err != nil {
+		return nil, nil, errors.Wrap(err, d.String())
+	}
+
+	var list []*CatalogQuery
+	for _, s := range entries.Nodes {
+
+		list = append(list, &CatalogQuery{
+			ID:              s.Service.ID,
+			Node:            s.Node.Node,
+			Address:         s.Service.Address,
+			Datacenter:      s.Node.Datacenter,
+			TaggedAddresses: s.Node.TaggedAddresses,
+			NodeMeta:        s.Node.Meta,
+			ServiceID:       s.Service.ID,
+			ServiceName:     s.Service.Service,
+			ServiceAddress:  s.Service.Address,
+			ServiceTags:     ServiceTags(deepCopyAndSortTags(s.Service.Tags)),
+			ServiceMeta:     s.Service.Meta,
+			ServicePort:     s.Service.Port,
+		})
+	}
+
+	rm := &ResponseMetadata{
+		LastIndex:   qm.LastIndex,
+		LastContact: qm.LastContact,
+	}
+
+	return list, rm, nil
+}
+
+// CanShare returns a boolean if this dependency is shareable.
+func (d *CatalogPreparedQuery) CanShare() bool {
+	return true
+}
+
+// String returns the human-friendly version of this dependency.
+func (d *CatalogPreparedQuery) String() string {
+	name := d.name
+	return fmt.Sprintf("query(%s)", name)
+}
+
+// Stop halts the dependency's fetch function.
+func (d *CatalogPreparedQuery) Stop() {
+	close(d.stopCh)
+}
+
+// Type returns the type of this dependency.
+func (d *CatalogPreparedQuery) Type() Type {
+	return TypeConsul
+}

--- a/dependency/catalog_query_test.go
+++ b/dependency/catalog_query_test.go
@@ -1,0 +1,75 @@
+package dependency
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCatalogPreparedQuery(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		i    string
+		exp  *CatalogPreparedQuery
+		err  bool
+	}{
+		{
+			"empty",
+			"",
+			nil,
+			true,
+		},
+		{
+			"name",
+			"name",
+			&CatalogPreparedQuery{
+				name: "name",
+			},
+			false,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			act, err := NewCatalogPreparedQuery(tc.i)
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+
+			if act != nil {
+				act.stopCh = nil
+			}
+
+			assert.Equal(t, tc.exp, act)
+		})
+	}
+}
+
+func TestCatalogPreparedQuery_String(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		i    string
+		exp  string
+	}{
+		{
+			"name",
+			"name",
+			"query(name)",
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			d, err := NewCatalogPreparedQuery(tc.i)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, tc.exp, d.String())
+		})
+	}
+}

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -472,6 +472,28 @@ func servicesFunc(b *Brain, used, missing *dep.Set) func(...string) ([]*dep.Cata
 	}
 }
 
+// queryFunc returns or accumulates catalog services dependencies.
+func queryFunc(b *Brain, used, missing *dep.Set) func(...string) ([]*dep.CatalogQuery, error) {
+	return func(s ...string) ([]*dep.CatalogQuery, error) {
+		result := []*dep.CatalogQuery{}
+
+		d, err := dep.NewCatalogPreparedQuery(strings.Join(s, ""))
+		if err != nil {
+			return nil, err
+		}
+
+		used.Add(d)
+
+		if value, ok := b.Recall(d); ok {
+			return value.([]*dep.CatalogQuery), nil
+		}
+
+		missing.Add(d)
+
+		return result, nil
+	}
+}
+
 func safeTreeFunc(b *Brain, used, missing *dep.Set) func(string) ([]*dep.KeyPair, error) {
 	// call treeFunc but explicitly mark that empty data set returned on monitored KV prefix is NOT safe
 	return treeFunc(b, used, missing, false)

--- a/template/template.go
+++ b/template/template.go
@@ -238,6 +238,7 @@ func funcMap(i *funcMapInput) template.FuncMap {
 		"secrets":      secretsFunc(i.brain, i.used, i.missing),
 		"service":      serviceFunc(i.brain, i.used, i.missing),
 		"services":     servicesFunc(i.brain, i.used, i.missing),
+		"query":        queryFunc(i.brain, i.used, i.missing),
 		"tree":         treeFunc(i.brain, i.used, i.missing, true),
 		"safeTree":     safeTreeFunc(i.brain, i.used, i.missing),
 


### PR DESCRIPTION
Allows to get services from prepared queries. Accepts query name as parameter:
```
{{ query "myquery" }}
```
returns a list of services using the same format as the "service" function. 
Fixes https://github.com/hashicorp/consul-template/issues/530