### PR TITLE
Remove code/logic for working with Vault grace

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -423,11 +423,6 @@ func (cli *CLI) ParseFlags(args []string) (
 		return nil
 	}), "vault-addr", "")
 
-	flags.Var((funcDurationVar)(func(t time.Duration) error {
-		c.Vault.Grace = config.TimeDuration(t)
-		return nil
-	}), "vault-grace", "")
-
 	flags.Var((funcBoolVar)(func(b bool) error {
 		c.Vault.RenewToken = config.Bool(b)
 		return nil

--- a/cli_test.go
+++ b/cli_test.go
@@ -435,16 +435,6 @@ func TestCLI_ParseFlags(t *testing.T) {
 			false,
 		},
 		{
-			"vault-grace",
-			[]string{"-vault-grace", "10s"},
-			&config.Config{
-				Vault: &config.VaultConfig{
-					Grace: config.TimeDuration(10 * time.Second),
-				},
-			},
-			false,
-		},
-		{
 			"vault-retry",
 			[]string{"-vault-retry"},
 			&config.Config{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1032,18 +1032,6 @@ func TestParse(t *testing.T) {
 			false,
 		},
 		{
-			"vault_grace",
-			`vault {
-				grace = "5m"
-			}`,
-			&Config{
-				Vault: &VaultConfig{
-					Grace: TimeDuration(5 * time.Minute),
-				},
-			},
-			false,
-		},
-		{
 			"vault_token",
 			`vault {
 				token = "token"

--- a/config/vault.go
+++ b/config/vault.go
@@ -12,11 +12,6 @@ const (
 	// vault to version 1.1.0 or newer.
 	EnvVaultSkipVerify = "VAULT_SKIP_VERIFY"
 
-	// DefaultVaultGrace is the default grace period before which to read a new
-	// secret from Vault. If a lease is due to expire in 15 seconds, Consul
-	// Template will read a new secret at that time minus this value.
-	DefaultVaultGrace = 15 * time.Second
-
 	// DefaultVaultRenewToken is the default value for if the Vault token should
 	// be renewed.
 	DefaultVaultRenewToken = true
@@ -41,10 +36,6 @@ type VaultConfig struct {
 
 	// Enabled controls whether the Vault integration is active.
 	Enabled *bool `mapstructure:"enabled"`
-
-	// Grace is the amount of time before a lease is about to expire to force a
-	// new secret to be read.
-	Grace *time.Duration `mapstructure:"grace"`
 
 	// Namespace is the Vault namespace to use for reading/writing secrets. This can
 	// also be set via the VAULT_NAMESPACE environment variable.
@@ -104,8 +95,6 @@ func (c *VaultConfig) Copy() *VaultConfig {
 
 	o.Enabled = c.Enabled
 
-	o.Grace = c.Grace
-
 	o.Namespace = c.Namespace
 
 	o.RenewToken = c.RenewToken
@@ -157,10 +146,6 @@ func (c *VaultConfig) Merge(o *VaultConfig) *VaultConfig {
 		r.Enabled = o.Enabled
 	}
 
-	if o.Grace != nil {
-		r.Grace = o.Grace
-	}
-
 	if o.Namespace != nil {
 		r.Namespace = o.Namespace
 	}
@@ -202,10 +187,6 @@ func (c *VaultConfig) Finalize() {
 		c.Address = stringFromEnv([]string{
 			api.EnvVaultAddress,
 		}, "")
-	}
-
-	if c.Grace == nil {
-		c.Grace = TimeDuration(DefaultVaultGrace)
 	}
 
 	if c.Namespace == nil {
@@ -302,7 +283,6 @@ func (c *VaultConfig) GoString() string {
 	return fmt.Sprintf("&VaultConfig{"+
 		"Address:%s, "+
 		"Enabled:%s, "+
-		"Grace:%s, "+
 		"Namespace:%s,"+
 		"RenewToken:%s, "+
 		"Retry:%#v, "+
@@ -314,7 +294,6 @@ func (c *VaultConfig) GoString() string {
 		"}",
 		StringGoString(c.Address),
 		BoolGoString(c.Enabled),
-		TimeDurationGoString(c.Grace),
 		StringGoString(c.Namespace),
 		BoolGoString(c.RenewToken),
 		c.Retry,

--- a/config/vault_test.go
+++ b/config/vault_test.go
@@ -27,7 +27,6 @@ func TestVaultConfig_Copy(t *testing.T) {
 			&VaultConfig{
 				Address:    String("address"),
 				Enabled:    Bool(true),
-				Grace:      TimeDuration(1 * time.Minute),
 				Namespace:  String("foo"),
 				RenewToken: Bool(true),
 				Retry:      &RetryConfig{Enabled: Bool(true)},
@@ -132,30 +131,6 @@ func TestVaultConfig_Merge(t *testing.T) {
 			&VaultConfig{Address: String("address")},
 			&VaultConfig{Address: String("address")},
 			&VaultConfig{Address: String("address")},
-		},
-		{
-			"grace_overrides",
-			&VaultConfig{Grace: TimeDuration(5 * time.Minute)},
-			&VaultConfig{Grace: TimeDuration(10 * time.Minute)},
-			&VaultConfig{Grace: TimeDuration(10 * time.Minute)},
-		},
-		{
-			"grace_empty_one",
-			&VaultConfig{Grace: TimeDuration(5 * time.Minute)},
-			&VaultConfig{},
-			&VaultConfig{Grace: TimeDuration(5 * time.Minute)},
-		},
-		{
-			"grace_empty_two",
-			&VaultConfig{},
-			&VaultConfig{Grace: TimeDuration(5 * time.Minute)},
-			&VaultConfig{Grace: TimeDuration(5 * time.Minute)},
-		},
-		{
-			"grace_same",
-			&VaultConfig{Grace: TimeDuration(5 * time.Minute)},
-			&VaultConfig{Grace: TimeDuration(5 * time.Minute)},
-			&VaultConfig{Grace: TimeDuration(5 * time.Minute)},
 		},
 		{
 			"namespace_overrides",
@@ -351,7 +326,6 @@ func TestVaultConfig_Finalize(t *testing.T) {
 			&VaultConfig{
 				Address:    String(""),
 				Enabled:    Bool(false),
-				Grace:      TimeDuration(DefaultVaultGrace),
 				Namespace:  String(""),
 				RenewToken: Bool(DefaultVaultRenewToken),
 				Retry: &RetryConfig{
@@ -390,7 +364,6 @@ func TestVaultConfig_Finalize(t *testing.T) {
 			&VaultConfig{
 				Address:    String("address"),
 				Enabled:    Bool(true),
-				Grace:      TimeDuration(DefaultVaultGrace),
 				Namespace:  String(""),
 				RenewToken: Bool(DefaultVaultRenewToken),
 				Retry: &RetryConfig{
@@ -429,7 +402,6 @@ func TestVaultConfig_Finalize(t *testing.T) {
 			&VaultConfig{
 				Address:    String("address"),
 				Enabled:    Bool(true),
-				Grace:      TimeDuration(DefaultVaultGrace),
 				Namespace:  String(""),
 				RenewToken: Bool(DefaultVaultRenewToken),
 				Retry: &RetryConfig{

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -1295,7 +1295,6 @@ func newWatcher(c *config.Config, clients *dep.ClientSet, once bool) (*watch.Wat
 		// dependencies like reading a file from disk.
 		RetryFuncDefault: nil,
 		RetryFuncVault:   watch.RetryFunc(c.Vault.Retry.RetryFunc()),
-		VaultGrace:       config.TimeDurationVal(c.Vault.Grace),
 		VaultToken:       clients.Vault().Token(),
 	})
 	if err != nil {

--- a/watch/view.go
+++ b/watch/view.go
@@ -45,11 +45,6 @@ type View struct {
 
 	// stopCh is used to stop polling on this View
 	stopCh chan struct{}
-
-	// vaultGrace is the grace period between a lease and the max TTL for which
-	// Consul Template will generate a new secret instead of renewing an existing
-	// one.
-	vaultGrace time.Duration
 }
 
 // NewViewInput is used as input to the NewView function.
@@ -71,11 +66,6 @@ type NewViewInput struct {
 	// RetryFunc is a function which dictates how this view should retry on
 	// upstream errors.
 	RetryFunc RetryFunc
-
-	// VaultGrace is the grace period between a lease and the max TTL for which
-	// Consul Template will generate a new secret instead of renewing an existing
-	// one.
-	VaultGrace time.Duration
 }
 
 // NewView constructs a new view with the given inputs.
@@ -87,7 +77,6 @@ func NewView(i *NewViewInput) (*View, error) {
 		once:       i.Once,
 		retryFunc:  i.RetryFunc,
 		stopCh:     make(chan struct{}, 1),
-		vaultGrace: i.VaultGrace,
 	}, nil
 }
 
@@ -214,7 +203,6 @@ func (v *View) fetch(doneCh, successCh chan<- struct{}, errCh chan<- error) {
 			AllowStale: allowStale,
 			WaitTime:   defaultWaitTime,
 			WaitIndex:  v.lastIndex,
-			VaultGrace: v.vaultGrace,
 		})
 		if err != nil {
 			if err == dep.ErrStopped {

--- a/watch/watcher.go
+++ b/watch/watcher.go
@@ -42,11 +42,6 @@ type Watcher struct {
 	retryFuncConsul  RetryFunc
 	retryFuncDefault RetryFunc
 	retryFuncVault   RetryFunc
-
-	// vaultGrace is the grace period between a lease and the max TTL for which
-	// Consul Template will generate a new secret instead of renewing an existing
-	// one.
-	vaultGrace time.Duration
 }
 
 type NewWatcherInput struct {
@@ -72,11 +67,6 @@ type NewWatcherInput struct {
 	RetryFuncConsul  RetryFunc
 	RetryFuncDefault RetryFunc
 	RetryFuncVault   RetryFunc
-
-	// VaultGrace is the grace period between a lease and the max TTL for which
-	// Consul Template will generate a new secret instead of renewing an existing
-	// one.
-	VaultGrace time.Duration
 }
 
 // NewWatcher creates a new watcher using the given API client.
@@ -91,7 +81,6 @@ func NewWatcher(i *NewWatcherInput) (*Watcher, error) {
 		retryFuncConsul:  i.RetryFuncConsul,
 		retryFuncDefault: i.RetryFuncDefault,
 		retryFuncVault:   i.RetryFuncVault,
-		vaultGrace:       i.VaultGrace,
 	}
 
 	// Start a watcher for the Vault renew if that config was specified
@@ -165,7 +154,6 @@ func (w *Watcher) Add(d dep.Dependency) (bool, error) {
 		MaxStale:   w.maxStale,
 		Once:       w.once,
 		RetryFunc:  retryFunc,
-		VaultGrace: w.vaultGrace,
 	})
 	if err != nil {
 		return false, errors.Wrap(err, "watcher")


### PR DESCRIPTION
Part of https://github.com/hashicorp/consul-template/issues/1266 . Remove all the code for the deprecated Vault grace field. 

Fixes #1268

Tests:

```
[consul-template][remove-vault-grace](4)$ make test  
==> Testing consul-template
ok      github.com/hashicorp/consul-template    2.042s
ok      github.com/hashicorp/consul-template/child      1.695s
ok      github.com/hashicorp/consul-template/config     0.121s
ok      github.com/hashicorp/consul-template/dependency 6.181s
ok      github.com/hashicorp/consul-template/logging    0.048s
ok      github.com/hashicorp/consul-template/manager    3.334s
ok      github.com/hashicorp/consul-template/renderer   0.102s
ok      github.com/hashicorp/consul-template/signals    0.036s
ok      github.com/hashicorp/consul-template/template   0.120s
?       github.com/hashicorp/consul-template/test       [no test files]
?       github.com/hashicorp/consul-template/version    [no test files]
ok      github.com/hashicorp/consul-template/watch      1.058s
```