### PR TITLE
Fix incorrect code example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1413,7 +1413,7 @@ If we have the following services registered in Consul:
 ```
 
 ```liquid
-{{ service "redis|any" | byMeta "environment,shard_number|int" | toJson }}
+{{ service "redis|any" | byMeta "environment,shard_number|int" | toJSON }}
 ```
 
 The code above will produce a map of services grouped by meta:


### PR DESCRIPTION
Replace `toJson` with `toJSON` in one of the README.md code examples, as the function name is case sensitive and throws errors otherwise.