### PR TITLE
Issue 1262 consul connect

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     environment:
       GO111MODULE: "on"
-      CONSUL_VERSION: 1.5.1
+      CONSUL_VERSION: 1.6.1
       VAULT_VERSION: 1.1.3
     docker:
       - image: circleci/golang:latest

--- a/README.md
+++ b/README.md
@@ -639,6 +639,87 @@ provides the following functions:
 API functions interact with remote API calls, communicating with external
 services like [Consul][consul] and [Vault][vault].
 
+##### `caLeaf`
+
+Query [Consul][consul] for the leaf certificate representing a single service.
+
+```liquid
+{{ caLeaf "<NAME>" }}
+```
+
+For example:
+```liquid
+{{ with caLeaf "proxy" }}{{ .CertPEM }}{{ end }}
+```
+
+renders
+```text
+-----BEGIN CERTIFICATE-----
+MIICizCCAjGgAwIBAgIBCDAKBggqhkjOPQQDAjAWMRQwEgYDVQQDEwtDb25zdWwg
+...
+lXcQzfKlIYeFWvcAv4cA4W258gTtqaFRDRJ2i720eQ==
+-----END CERTIFICATE-----
+```
+
+The two most useful fields are `.CertPEM` and `.PrivateKeyPEM`. For a complete
+list of available fields, see consul's documentation on
+[LeafCert](https://godoc.org/github.com/hashicorp/consul/api#LeafCert).
+
+##### `caRoot`
+
+Query [Consul][consul] for all [connect][connect] trusted certificate authority
+(CA) root certificates.
+
+```liquid
+{{ caRoots }}
+```
+
+For example:
+```liquid
+{{ range caRoots }}{{ .RootCertPEM }}{{ end }}
+```
+
+renders
+```text
+-----BEGIN CERTIFICATE-----
+MIICWDCCAf+gAwIBAgIBBzAKBggqhkjOPQQDAjAWMRQwEgYDVQQDEwtDb25zdWwg
+...
+bcA+Su3r8qSRppTlc6D0UOYOWc1ykQKQOK7mIg==
+-----END CERTIFICATE-----
+
+```
+
+The most useful field is `.RootCertPEM`. For a complete list of available
+fields, see consul's documentation on
+[CARootList](https://godoc.org/github.com/hashicorp/consul/api#CARootList).
+
+
+##### `connect`
+
+Query [Consul][consul] for [connect][connect]-capable services based on their
+health.
+
+```liquid
+{{ connect "<TAG>.<NAME>@<DATACENTER>~<NEAR>|<FILTER>" }}
+```
+
+Syntax is exactly the same as for the [service](#service) function below.
+
+
+```liquid
+{{ range connect "web" }}
+server {{ .Name }} {{ .Address }}:{{ .Port }}{{ end }}
+```
+
+renders the IP addresses of all _healthy_ nodes with a logical
+[connect][connect]-capable service named "web":
+
+```text
+server web01 10.5.2.45:21000
+server web02 10.2.6.61:21000
+```
+
+
 ##### `datacenters`
 
 Query [Consul][consul] for all datacenters in its catalog.
@@ -2459,6 +2540,7 @@ go test ./... -run SomeTestFunction_name
 ```
 
 [consul]: https://www.consul.io "Consul by HashiCorp"
+[connect]: https://www.consul.io/docs/connect/ "Connect"
 [examples]: (https://github.com/hashicorp/consul-template/tree/master/examples) "Consul Template Examples"
 [hcl]: https://github.com/hashicorp/hcl "HashiCorp Configuration Language (hcl)"
 [releases]: https://releases.hashicorp.com/consul-template "Consul Template Releases"

--- a/dependency/catalog_node_test.go
+++ b/dependency/catalog_node_test.go
@@ -111,6 +111,13 @@ func TestCatalogNodeQuery_Fetch(t *testing.T) {
 						Meta:    map[string]string{},
 					},
 					&CatalogNodeService{
+						ID:      "foo",
+						Service: "foo-sidecar-proxy",
+						Tags:    ServiceTags([]string{}),
+						Meta:    map[string]string{},
+						Port:    21999,
+					},
+					&CatalogNodeService{
 						ID:      "service-meta",
 						Service: "service-meta",
 						Tags:    ServiceTags([]string{"tag1"}),

--- a/dependency/catalog_services_test.go
+++ b/dependency/catalog_services_test.go
@@ -71,6 +71,10 @@ func TestCatalogServicesQuery_Fetch(t *testing.T) {
 					Tags: ServiceTags([]string{}),
 				},
 				&CatalogSnippet{
+					Name: "foo-sidecar-proxy",
+					Tags: ServiceTags([]string{}),
+				},
+				&CatalogSnippet{
 					Name: "service-meta",
 					Tags: ServiceTags([]string{"tag1"}),
 				},

--- a/dependency/connect_ca.go
+++ b/dependency/connect_ca.go
@@ -1,0 +1,72 @@
+package dependency
+
+import (
+	"log"
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	// Ensure implements
+	_ Dependency = (*ConnectCAQuery)(nil)
+)
+
+type ConnectCAQuery struct {
+	stopCh chan struct{}
+}
+
+func NewConnectCAQuery() *ConnectCAQuery {
+	return &ConnectCAQuery{
+		stopCh: make(chan struct{}, 1),
+	}
+}
+
+func (d *ConnectCAQuery) Fetch(clients *ClientSet, opts *QueryOptions) (
+	interface{}, *ResponseMetadata, error,
+) {
+	select {
+	case <-d.stopCh:
+		return nil, nil, ErrStopped
+	default:
+	}
+
+	opts = opts.Merge(nil)
+	log.Printf("[TRACE] %s: GET %s", d, &url.URL{
+		Path:     "/v1/agent/connect/ca/roots",
+		RawQuery: opts.String(),
+	})
+
+	certs, md, err := clients.Consul().Agent().ConnectCARoots(
+		opts.ToConsulOpts())
+	if err != nil {
+		return nil, nil, errors.Wrap(err, d.String())
+	}
+
+	log.Printf("[TRACE] %s: returned %d results", d, len(certs.Roots))
+	log.Printf("[TRACE] %s: %#v ", d, md)
+
+	rm := &ResponseMetadata{
+		LastIndex:   md.LastIndex,
+		LastContact: md.LastContact,
+		Block:       true,
+	}
+
+	return certs.Roots, rm, nil
+}
+
+func (d *ConnectCAQuery) Stop() {
+	close(d.stopCh)
+}
+
+func (d *ConnectCAQuery) CanShare() bool {
+	return false
+}
+
+func (d *ConnectCAQuery) Type() Type {
+	return TypeConsul
+}
+
+func (d *ConnectCAQuery) String() string {
+	return "connect.caroots"
+}

--- a/dependency/connect_ca_test.go
+++ b/dependency/connect_ca_test.go
@@ -1,0 +1,23 @@
+package dependency
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConnectCAQuery_Fetch(t *testing.T) {
+	t.Parallel()
+
+	d := NewConnectCAQuery()
+	raw, _, err := d.Fetch(testClients, nil)
+	assert.NoError(t, err)
+	act := raw.([]*api.CARoot)
+	if assert.Len(t, act, 1) {
+		root := act[0]
+		assert.Equal(t, root.Name, "Consul CA Root Cert")
+		assert.True(t, root.Active)
+		assert.NotEmpty(t, root.RootCertPEM)
+	}
+}

--- a/dependency/connect_leaf.go
+++ b/dependency/connect_leaf.go
@@ -1,0 +1,77 @@
+package dependency
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	// Ensure implements
+	_ Dependency = (*ConnectLeafQuery)(nil)
+)
+
+type ConnectLeafQuery struct {
+	stopCh chan struct{}
+
+	service string
+}
+
+func NewConnectLeafQuery(service string) *ConnectLeafQuery {
+	return &ConnectLeafQuery{
+		stopCh:  make(chan struct{}, 1),
+		service: service,
+	}
+}
+
+func (d *ConnectLeafQuery) Fetch(clients *ClientSet, opts *QueryOptions) (
+	interface{}, *ResponseMetadata, error,
+) {
+	select {
+	case <-d.stopCh:
+		return nil, nil, ErrStopped
+	default:
+	}
+	opts = opts.Merge(nil)
+	log.Printf("[TRACE] %s: GET %s", d, &url.URL{
+		Path:     "/v1/agent/connect/ca/leaf/" + d.service,
+		RawQuery: opts.String(),
+	})
+
+	cert, md, err := clients.Consul().Agent().ConnectCALeaf(d.service,
+		opts.ToConsulOpts())
+	if err != nil {
+		return nil, nil, errors.Wrap(err, d.String())
+	}
+
+	log.Printf("[TRACE] %s: returned response", d)
+
+	rm := &ResponseMetadata{
+		LastIndex:   md.LastIndex,
+		LastContact: md.LastContact,
+		Block:       true,
+	}
+
+	return cert, rm, nil
+}
+
+func (d *ConnectLeafQuery) Stop() {
+	close(d.stopCh)
+}
+
+func (d *ConnectLeafQuery) CanShare() bool {
+	return false
+}
+
+func (d *ConnectLeafQuery) Type() Type {
+	return TypeConsul
+}
+
+func (d *ConnectLeafQuery) String() string {
+	if d.service != "" {
+		return fmt.Sprintf("connect.caleaf(%s)", d.service)
+	}
+	return "connect.caleaf"
+}

--- a/dependency/connect_leaf_test.go
+++ b/dependency/connect_leaf_test.go
@@ -1,0 +1,102 @@
+package dependency
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/api"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewConnectLeafQuery(t *testing.T) {
+	t.Parallel()
+
+	act := NewConnectLeafQuery("foo")
+	act.stopCh = nil
+	exp := &ConnectLeafQuery{service: "foo"}
+	assert.Equal(t, exp, act)
+}
+
+func TestConnectLeafQuery_Fetch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty-service", func(t *testing.T) {
+		d := NewConnectLeafQuery("")
+
+		_, _, err := d.Fetch(testClients, nil)
+		exp := "Unexpected response code: 500 (" +
+			"URI must be either service or agent)"
+		if errors.Cause(err).Error() != exp {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+	})
+	t.Run("with-service", func(t *testing.T) {
+		d := NewConnectLeafQuery("foo")
+		raw, _, err := d.Fetch(testClients, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cert := raw.(*api.LeafCert)
+		if cert.Service != "foo" {
+			t.Fatalf("Unexpected service: %v", cert.Service)
+		}
+		if cert.CertPEM == "" {
+			t.Fatal("Empty cert PEM")
+		}
+		if cert.ValidAfter.After(time.Now()) {
+			t.Fatalf("Bad cert: (bad ValidAfter: %v)", cert.ValidAfter)
+		}
+		if cert.ValidBefore.Before(time.Now()) {
+			t.Fatalf("Bad cert: (bad ValidBefore: %v)", cert.ValidBefore)
+		}
+	})
+	t.Run("double-check", func(t *testing.T) {
+		d1 := NewConnectLeafQuery("foo")
+		raw1, _, err := d1.Fetch(testClients, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cert1 := raw1.(*api.LeafCert)
+		d2 := NewConnectLeafQuery("foo")
+		raw2, _, err := d2.Fetch(testClients, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cert2 := raw2.(*api.LeafCert)
+		if cert1.CertPEM != cert2.CertPEM {
+			t.Fatalf("Certs should match:\n%v\n%v",
+				cert1.CertPEM, cert2.CertPEM)
+		}
+	})
+}
+
+func TestConnectLeafQuery_String(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		service string
+		exp     string
+	}{
+		{
+			"empty",
+			"",
+			"connect.caleaf",
+		},
+		{
+			"service",
+			"foo",
+			"connect.caleaf(foo)",
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			d := NewConnectLeafQuery(tc.service)
+			assert.Equal(t, tc.exp, d.String())
+		})
+	}
+}

--- a/dependency/health_service.go
+++ b/dependency/health_service.go
@@ -62,10 +62,20 @@ type HealthServiceQuery struct {
 	name    string
 	near    string
 	tag     string
+	connect bool
 }
 
 // NewHealthServiceQuery processes the strings to build a service dependency.
 func NewHealthServiceQuery(s string) (*HealthServiceQuery, error) {
+	return healthServiceQuery(s, false)
+}
+
+// NewHealthConnect Query processes the strings to build a connect dependency.
+func NewHealthConnectQuery(s string) (*HealthServiceQuery, error) {
+	return healthServiceQuery(s, true)
+}
+
+func healthServiceQuery(s string, connect bool) (*HealthServiceQuery, error) {
 	if !HealthServiceQueryRe.MatchString(s) {
 		return nil, fmt.Errorf("health.service: invalid format: %q", s)
 	}
@@ -86,7 +96,8 @@ func NewHealthServiceQuery(s string) (*HealthServiceQuery, error) {
 				filters = append(filters, f)
 			case "":
 			default:
-				return nil, fmt.Errorf("health.service: invalid filter: %q in %q", f, s)
+				return nil, fmt.Errorf(
+					"health.service: invalid filter: %q in %q", f, s)
 			}
 		}
 		sort.Strings(filters)
@@ -101,6 +112,7 @@ func NewHealthServiceQuery(s string) (*HealthServiceQuery, error) {
 		name:    m["name"],
 		near:    m["near"],
 		tag:     m["tag"],
+		connect: connect,
 	}, nil
 }
 
@@ -130,10 +142,15 @@ func (d *HealthServiceQuery) Fetch(clients *ClientSet, opts *QueryOptions) (inte
 	log.Printf("[TRACE] %s: GET %s", d, u)
 
 	// Check if a user-supplied filter was given. If so, we may be querying for
-	// more than healthy services, so we need to implement client-side filtering.
+	// more than healthy services, so we need to implement client-side
+	// filtering.
 	passingOnly := len(d.filters) == 1 && d.filters[0] == HealthPassing
 
-	entries, qm, err := clients.Consul().Health().Service(d.name, d.tag, passingOnly, opts.ToConsulOpts())
+	nodes := clients.Consul().Health().Service
+	if d.connect {
+		nodes = clients.Consul().Health().Connect
+	}
+	entries, qm, err := nodes(d.name, d.tag, passingOnly, opts.ToConsulOpts())
 	if err != nil {
 		return nil, nil, errors.Wrap(err, d.String())
 	}
@@ -145,13 +162,14 @@ func (d *HealthServiceQuery) Fetch(clients *ClientSet, opts *QueryOptions) (inte
 		// Get the status of this service from its checks.
 		status := entry.Checks.AggregatedStatus()
 
-		// If we are not checking only healthy services, filter out services that do
-		// not match the given filter.
+		// If we are not checking only healthy services, filter out services
+		// that do not match the given filter.
 		if !acceptStatus(d.filters, status) {
 			continue
 		}
 
-		// Get the address of the service, falling back to the address of the node.
+		// Get the address of the service, falling back to the address of the
+		// node.
 		address := entry.Service.Address
 		if address == "" {
 			address = entry.Node.Address
@@ -167,10 +185,11 @@ func (d *HealthServiceQuery) Fetch(clients *ClientSet, opts *QueryOptions) (inte
 			Address:             address,
 			ID:                  entry.Service.ID,
 			Name:                entry.Service.Service,
-			Tags:                ServiceTags(deepCopyAndSortTags(entry.Service.Tags)),
-			Status:              status,
-			Checks:              entry.Checks,
-			Port:                entry.Service.Port,
+			Tags: ServiceTags(
+				deepCopyAndSortTags(entry.Service.Tags)),
+			Status: status,
+			Checks: entry.Checks,
+			Port:   entry.Service.Port,
 		})
 	}
 

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -473,6 +473,32 @@ func servicesFunc(b *Brain, used, missing *dep.Set) func(...string) ([]*dep.Cata
 	}
 }
 
+// connectFunc returns or accumulates health connect dependencies.
+func connectFunc(b *Brain, used, missing *dep.Set) func(...string) ([]*dep.HealthService, error) {
+	return func(s ...string) ([]*dep.HealthService, error) {
+		result := []*dep.HealthService{}
+
+		if len(s) == 0 || s[0] == "" {
+			return result, nil
+		}
+
+		d, err := dep.NewHealthConnectQuery(strings.Join(s, "|"))
+		if err != nil {
+			return nil, err
+		}
+
+		used.Add(d)
+
+		if value, ok := b.Recall(d); ok {
+			return value.([]*dep.HealthService), nil
+		}
+
+		missing.Add(d)
+
+		return result, nil
+	}
+}
+
 func connectCARootsFunc(b *Brain, used, missing *dep.Set,
 ) func(...string) ([]*api.CARoot, error) {
 	return func(...string) ([]*api.CARoot, error) {

--- a/template/funcs_test.go
+++ b/template/funcs_test.go
@@ -10,6 +10,9 @@ import (
 	dep "github.com/hashicorp/consul-template/dependency"
 )
 
+// NOTE: the template functions are all tested in ./template_test.go and
+// the tests here are for ancillary code only.
+
 func TestFileSandbox(t *testing.T) {
 	t.Parallel()
 	// while most of the function can be tested lexigraphically,

--- a/template/template.go
+++ b/template/template.go
@@ -237,6 +237,7 @@ func funcMap(i *funcMapInput) template.FuncMap {
 		"secret":       secretFunc(i.brain, i.used, i.missing),
 		"secrets":      secretsFunc(i.brain, i.used, i.missing),
 		"service":      serviceFunc(i.brain, i.used, i.missing),
+		"connect":      connectFunc(i.brain, i.used, i.missing),
 		"services":     servicesFunc(i.brain, i.used, i.missing),
 		"tree":         treeFunc(i.brain, i.used, i.missing, true),
 		"safeTree":     safeTreeFunc(i.brain, i.used, i.missing),

--- a/template/template.go
+++ b/template/template.go
@@ -240,6 +240,8 @@ func funcMap(i *funcMapInput) template.FuncMap {
 		"services":     servicesFunc(i.brain, i.used, i.missing),
 		"tree":         treeFunc(i.brain, i.used, i.missing, true),
 		"safeTree":     safeTreeFunc(i.brain, i.used, i.missing),
+		"caRoots":      connectCARootsFunc(i.brain, i.used, i.missing),
+		"caLeaf":       connectLeafFunc(i.brain, i.used, i.missing),
 
 		// Scratch
 		"scratch": func() *Scratch { return &scratch },

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1650,7 +1650,43 @@ func TestTemplate_Execute(t *testing.T) {
 			"PEM",
 			false,
 		},
+		{
+			"func_connect",
+			&NewTemplateInput{
+				Contents: `{{ range connect "webapp" }}{{ .Address }}{{ end }}`,
+			},
+			&ExecuteInput{
+				Brain: func() *Brain {
+					b := NewBrain()
+					d, err := dep.NewHealthConnectQuery("webapp")
+					if err != nil {
+						t.Fatal(err)
+					}
+					b.Remember(d, []*dep.HealthService{
+						&dep.HealthService{
+							Node:    "node1",
+							Address: "1.2.3.4",
+						},
+						&dep.HealthService{
+							Node:    "node2",
+							Address: "5.6.7.8",
+						},
+					})
+					return b
+				}(),
+			},
+			"1.2.3.45.6.7.8",
+			false,
+		},
 	}
+
+	//	struct {
+	//		name string
+	//		ti   *NewTemplateInput
+	//		i    *ExecuteInput
+	//		e    string
+	//		err  bool
+	//	}
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {


### PR DESCRIPTION
Initial Consul Connect support. Target is to allow proxies (nginx, haproxy) to route directly to services inside the mesh network. This is the basic support and reference docs. I'm still working on some examples/intros for each.