### PR TITLE
Remove extra whitespace from sockaddr func

### DIFF
--- a/template/funcs.go
+++ b/template/funcs.go
@@ -1372,7 +1372,7 @@ func pathInSandbox(sandbox, path string) error {
 
 // sockaddr wraps go-sockaddr templating
 func sockaddr(args ...string) (string, error) {
-	t := fmt.Sprintf("{{ %s }} ", strings.Join(args, " "))
+	t := fmt.Sprintf("{{ %s }}", strings.Join(args, " "))
 	k, err := socktmpl.Parse(t)
 	if err != nil {
 		return "", err

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1544,12 +1544,12 @@ func TestTemplate_Execute(t *testing.T) {
 		{
 			"helper_sockaddr",
 			&NewTemplateInput{
-				Contents: `{{ sockaddr "GetAllInterfaces | include \"type\" \"IPv4\"" | contains "127.0.0.1" }}`,
+				Contents: `{{ sockaddr "GetAllInterfaces | include \"flag\" \"loopback\" | include \"type\" \"IPv4\" | sort \"address\" | limit 1 | attr \"address\""}}`,
 			},
 			&ExecuteInput{
 				Brain: NewBrain(),
 			},
-			"true",
+			"127.0.0.1",
 			false,
 		},
 		{


### PR DESCRIPTION
Currently `sockaddr` function explicitly leaves extra whitespace for every template it renders. This PR removes that whitespace. It also improves the related tests so that the (first) loopback address of the machine is string-matched to "127.0.0.1". Previously the test only checked whether "127.0.0.1" is in the result set, without checking the rendered output for an exact match.

Fixes issue #1314.