### PR TITLE
consul namespaces support

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,11 @@ consul {
   # clients can connect.
   address = "127.0.0.1:8500"
 
+  # This is a Consul Enterprise namespace to use for reading/writing. This can
+  # also be set via the CONSUL_NAMESPACE environment variable.
+  # BETA: this is to be considered a beta feature as it has had limited testing
+  namespace = "foo"
+
   # This is the ACL token to use when connecting to Consul. If you did not
   # enable ACLs on your Consul cluster, you do not need to set this option.
   #

--- a/config/consul.go
+++ b/config/consul.go
@@ -8,6 +8,10 @@ type ConsulConfig struct {
 	// Address is the address of the Consul server. It may be an IP or FQDN.
 	Address *string
 
+	// Namespace is the Consul namespace to use for reading/writing. This can
+	// also be set via the CONSUL_NAMESPACE environment variable.
+	Namespace *string `mapstructure:"namespace"`
+
 	// Auth is the HTTP basic authentication for communicating with Consul.
 	Auth *AuthConfig `mapstructure:"auth"`
 
@@ -45,6 +49,8 @@ func (c *ConsulConfig) Copy() *ConsulConfig {
 	var o ConsulConfig
 
 	o.Address = c.Address
+
+	o.Namespace = c.Namespace
 
 	if c.Auth != nil {
 		o.Auth = c.Auth.Copy()
@@ -89,6 +95,10 @@ func (c *ConsulConfig) Merge(o *ConsulConfig) *ConsulConfig {
 		r.Address = o.Address
 	}
 
+	if o.Namespace != nil {
+		r.Namespace = o.Namespace
+	}
+
 	if o.Auth != nil {
 		r.Auth = r.Auth.Merge(o.Auth)
 	}
@@ -118,6 +128,10 @@ func (c *ConsulConfig) Finalize() {
 		c.Address = stringFromEnv([]string{
 			"CONSUL_HTTP_ADDR",
 		}, "")
+	}
+
+	if c.Namespace == nil {
+		c.Namespace = stringFromEnv([]string{"CONSUL_NAMESPACE"}, "")
 	}
 
 	if c.Auth == nil {
@@ -156,6 +170,7 @@ func (c *ConsulConfig) GoString() string {
 
 	return fmt.Sprintf("&ConsulConfig{"+
 		"Address:%s, "+
+		"Namespace:%s, "+
 		"Auth:%#v, "+
 		"Retry:%#v, "+
 		"SSL:%#v, "+
@@ -163,6 +178,7 @@ func (c *ConsulConfig) GoString() string {
 		"Transport:%#v"+
 		"}",
 		StringGoString(c.Address),
+		StringGoString(c.Namespace),
 		c.Auth,
 		c.Retry,
 		c.SSL,

--- a/config/consul_test.go
+++ b/config/consul_test.go
@@ -25,11 +25,12 @@ func TestConsulConfig_Copy(t *testing.T) {
 		{
 			"same_enabled",
 			&ConsulConfig{
-				Address: String("1.2.3.4"),
-				Auth:    &AuthConfig{Enabled: Bool(true)},
-				Retry:   &RetryConfig{Enabled: Bool(true)},
-				SSL:     &SSLConfig{Enabled: Bool(true)},
-				Token:   String("abcd1234"),
+				Address:   String("1.2.3.4"),
+				Namespace: String("foo"),
+				Auth:      &AuthConfig{Enabled: Bool(true)},
+				Retry:     &RetryConfig{Enabled: Bool(true)},
+				SSL:       &SSLConfig{Enabled: Bool(true)},
+				Token:     String("abcd1234"),
 				Transport: &TransportConfig{
 					DialKeepAlive: TimeDuration(20 * time.Second),
 				},
@@ -103,6 +104,30 @@ func TestConsulConfig_Merge(t *testing.T) {
 			&ConsulConfig{Address: String("same")},
 			&ConsulConfig{Address: String("same")},
 			&ConsulConfig{Address: String("same")},
+		},
+		{
+			"namespace_overrides",
+			&ConsulConfig{Namespace: String("foo")},
+			&ConsulConfig{Namespace: String("bar")},
+			&ConsulConfig{Namespace: String("bar")},
+		},
+		{
+			"namespace_empty_one",
+			&ConsulConfig{Namespace: String("foo")},
+			&ConsulConfig{},
+			&ConsulConfig{Namespace: String("foo")},
+		},
+		{
+			"namespace_empty_two",
+			&ConsulConfig{},
+			&ConsulConfig{Namespace: String("bar")},
+			&ConsulConfig{Namespace: String("bar")},
+		},
+		{
+			"namespace_same",
+			&ConsulConfig{Namespace: String("foo")},
+			&ConsulConfig{Namespace: String("foo")},
+			&ConsulConfig{Namespace: String("foo")},
 		},
 		{
 			"auth_overrides",
@@ -248,7 +273,8 @@ func TestConsulConfig_Finalize(t *testing.T) {
 			"empty",
 			&ConsulConfig{},
 			&ConsulConfig{
-				Address: String(""),
+				Address:   String(""),
+				Namespace: String(""),
 				Auth: &AuthConfig{
 					Enabled:  Bool(false),
 					Username: String(""),

--- a/dependency/client_set.go
+++ b/dependency/client_set.go
@@ -38,6 +38,7 @@ type vaultClient struct {
 // CreateConsulClientInput is used as input to the CreateConsulClient function.
 type CreateConsulClientInput struct {
 	Address      string
+	Namespace    string
 	Token        string
 	AuthEnabled  bool
 	AuthUsername string
@@ -93,6 +94,10 @@ func (c *ClientSet) CreateConsulClient(i *CreateConsulClientInput) error {
 
 	if i.Address != "" {
 		consulConfig.Address = i.Address
+	}
+
+	if i.Namespace != "" {
+		consulConfig.Namespace = i.Namespace
 	}
 
 	if i.Token != "" {

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -1249,6 +1249,7 @@ func newClientSet(c *config.Config) (*dep.ClientSet, error) {
 
 	if err := clients.CreateConsulClient(&dep.CreateConsulClientInput{
 		Address:                      config.StringVal(c.Consul.Address),
+		Namespace:                    config.StringVal(c.Consul.Namespace),
 		Token:                        config.StringVal(c.Consul.Token),
 		AuthEnabled:                  config.BoolVal(c.Consul.Auth.Enabled),
 		AuthUsername:                 config.StringVal(c.Consul.Auth.Username),


### PR DESCRIPTION
Add support for Consul namespaces following the same pattern as for
Vault namespaces.

Depends on code in consul's master branch (unreleased). So won't build unless you update the modules dependencies to the correct master commit. Once the upstream code is released, the module dependencies will be updated and added to this PR.