### PR TITLE
alpine docker image doesn't run entrypoint as root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.24.0 (Dec NN, 2019)
+
+BREAKING CHANGES:
+
+* Alpine Docker image no longer runs as root and so doesn't change ownership of the /consul-template/data and /consul-template/config directories to the consul-template user. See the [Docker Image Use](https://github.com/hashicorp/consul-template#docker-image-use) topic in the documentation for more.
+
+
 ## v0.23.0 (Nov 13, 2019)
 
 IMPROVEMENTS:

--- a/README.md
+++ b/README.md
@@ -2174,6 +2174,26 @@ func main() {
 
 ## Caveats
 
+### Docker Image Use
+
+The Alpine Docker image is configured to support an external volume to render
+shared templates to. If mounted you will need to make sure that the
+consul-template user in the docker image has write permissions to the
+directory. Also if you build your own image using these you need to be sure you
+have the permissions correct.
+
+**The consul-template user in docker has a UID of 100 and a GID of 1000.**
+
+This effects the in image directories /consul-template/config, used to add
+configuration when using this as a parent image, and /consul-template/data,
+exported as a VOLUME as a location to render shared results.
+
+Previously the image initially ran as root in order to ensure the permissions
+allowed it. But this ran against docker best practices and security policies.
+
+If you build your own image based on ours you can override these values with
+`--build-arg` parameters.
+
 ### Dots in Service Names
 
 Using dots `.` in service names will conflict with the use of dots for [TAG

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -22,17 +22,22 @@ RUN \
 FROM alpine:latest
 LABEL maintainer "John Eikenberry <jae@zhar.net>"
 
-# This is the release of https://github.com/hashicorp/docker-base to pull in order
-# to provide HashiCorp-built versions of basic utilities like dumb-init and gosu.
+# This is the release of https://github.com/hashicorp/docker-base to pull in
+# order to provide HashiCorp-built versions of basic utilities like dumb-init.
 ARG DOCKER_BASE_VERSION="0.0.4"
 
 # This is the location of the releases.
 ARG HASHICORP_RELEASES="https://releases.hashicorp.com"
 
+# UID and GID of consul-template user and group.
+# These are the defaults, this makes them explicit and overridable.
+ARG UID=100
+ARG GID=1000
+
 # Create a consul-template user and group first so the IDs get set the same way,
 # even as the rest of this may change over time.
-RUN addgroup consul-template && \
-    adduser -S -G consul-template consul-template
+RUN addgroup -g ${GID} consul-template && \
+    adduser -u ${UID} -S -G consul-template consul-template
 
 # Set up certificates, our base tools, and Consul Template (CT).
 RUN apk add --no-cache ca-certificates curl gnupg libcap openssl && \
@@ -46,7 +51,7 @@ RUN apk add --no-cache ca-certificates curl gnupg libcap openssl && \
     gpg --batch --verify docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS.sig docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS && \
     grep ${DOCKER_BASE_VERSION}_linux_amd64.zip docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS | sha256sum -c && \
     unzip docker-base_${DOCKER_BASE_VERSION}_linux_amd64.zip && \
-    cp bin/gosu bin/dumb-init /bin && \
+    cp bin/dumb-init /bin && \
     cd /tmp && \
     rm -rf /tmp/build && \
     apk del gnupg openssl && \
@@ -55,8 +60,8 @@ RUN apk add --no-cache ca-certificates curl gnupg libcap openssl && \
 # Install consul-template
 COPY --from=builder "/consul-template" "/bin/consul-template"
 
-# The agent will be started with /consul-template/config as the configuration directory
-# so you can add additional config files in that location.
+# The agent will be started with /consul-template/config as the configuration
+# directory so you can add additional config files in that location.
 RUN mkdir -p /consul-template/data && \
     mkdir -p /consul-template/config && \
     chown -R consul-template:consul-template /consul-template
@@ -70,6 +75,7 @@ VOLUME /consul-template/data
 COPY "docker/alpine/docker-entrypoint.sh" "/bin/docker-entrypoint.sh"
 RUN chmod +x "/bin/docker-entrypoint.sh"
 ENTRYPOINT ["/bin/docker-entrypoint.sh"]
+USER consul-template:consul-template
 
 # Run consul-template by default
 CMD ["/bin/consul-template"]


### PR DESCRIPTION
Set USER directrive in the Dockerfile to the consul-template user
created to run consul-template.

Made this change as some organizations security policies require it. The
only reason it wasn't done this way before was to run a chown on the
(possibly) bind mounted directories and this is a bad practice anyways
(who knows who the user matches on the external system).

Only change the alpine image this way as the other 2 (scratch and light)
purposely do as little as possible so they don't even create the user.

Fixes #1321