### PR TITLE
use gnueabihf for 32-bit arm build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ define make-xc-target
 		@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT}"
 		case "$2" in \
 			arm) export CGO_ENABLED="1" ; \
-				  export GOARM=5 \
-				  export CC="arm-linux-gnueabi-gcc" ;; \
+				  export GOARM=6 \
+				  export CC="arm-linux-gnueabihf-gcc" ;; \
 			arm64) export CGO_ENABLED="1" ; \
 				  export CC="aarch64-linux-gnu-gcc" ;; \
 			*) export CGO_ENABLED="0" ;; \


### PR DESCRIPTION
The 32 bit arm build that was supposed to work on both arm5 and arm6
won't run on systems without moving files around due to linking/naming
clashes. So we're changing the arm6 build to use
arm-linux-gnueabihf-gcc, which links against the expected libraries.

At this point we're just going to drop support for arm5 as I don't think
anyone is using it and it's starting to become obsolete.

Fixes #1317