### PR TITLE
Make user non-numeric to satisfy PSP

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -75,7 +75,7 @@ VOLUME /consul-template/data
 COPY "docker/alpine/docker-entrypoint.sh" "/bin/docker-entrypoint.sh"
 RUN chmod +x "/bin/docker-entrypoint.sh"
 ENTRYPOINT ["/bin/docker-entrypoint.sh"]
-USER consul-template:consul-template
+USER ${UID}:${GID}
 
 # Run consul-template by default
 CMD ["/bin/consul-template"]


### PR DESCRIPTION
Hey guys,

I appreciate that the container no longer runs as root, but instead runs as the `consul-template` user.

This PR introduces a small change to the Alpine Dockerfile, in that it uses numeric UID/GID values for the `USER` statement. This is required when using PodSecurityPolicies under Kubernetes, to assure the admission controller that the container will not run as root. (Setting a non-numeric value like `USER consul-template:consul-template` is insufficient, since the Dockerfile could simply have renamed the root account, I guess!)

Cheers!
D

