### PR TITLE
dependency: fix kv2 data path prefix checking

### DIFF
--- a/dependency/vault_common.go
+++ b/dependency/vault_common.go
@@ -339,8 +339,12 @@ func addPrefixToVKVPath(p, mountPath, apiPrefix string) string {
 		return path.Join(mountPath, apiPrefix)
 	default:
 		p = strings.TrimPrefix(p, mountPath)
-		// Don't add /data to the path if it's been added manually.
-		if strings.HasPrefix(p, apiPrefix) {
+		// Don't add /data/ to the path if it's been added manually.
+		apiPathPrefix := apiPrefix
+		if !strings.HasSuffix(apiPrefix, "/") {
+			apiPathPrefix += "/"
+		}
+		if strings.HasPrefix(p, apiPathPrefix) {
 			return path.Join(mountPath, p)
 		}
 		return path.Join(mountPath, apiPrefix, p)

--- a/dependency/vault_read_test.go
+++ b/dependency/vault_read_test.go
@@ -286,6 +286,15 @@ func TestVaultReadQuery_Fetch_KVv2(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Write a different secret with the path containing "data/data*/" prefix
+	err = vault.CreateSecret("data/datafoo/bar", map[string]interface{}{
+		"ttl": "100ms", // explicitly make this a short duration for testing
+		"zip": "zop",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	cases := []struct {
 		name string
 		i    string
@@ -326,6 +335,32 @@ func TestVaultReadQuery_Fetch_KVv2(t *testing.T) {
 					"data": map[string]interface{}{
 						"ttl": "100ms", // explicitly make this a short duration for testing
 						"zip": "zap",
+					},
+				},
+			},
+			false,
+		},
+		{
+			"/data in path and in prefix",
+			secretsPath + "/data/datafoo/bar",
+			&Secret{
+				Data: map[string]interface{}{
+					"data": map[string]interface{}{
+						"ttl": "100ms",
+						"zip": "zop",
+					},
+				},
+			},
+			false,
+		},
+		{
+			"without /data/ in path, but contains data prefix",
+			secretsPath + "/datafoo/bar",
+			&Secret{
+				Data: map[string]interface{}{
+					"data": map[string]interface{}{
+						"ttl": "100ms",
+						"zip": "zop",
 					},
 				},
 			},


### PR DESCRIPTION
The implicit `/data/` path prefix for kv2 secrets were not properly prepended for secret paths matching `/data*`.

Fixes #1340