### PR TITLE
Add parseYAML helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ this functionality might prove useful.
       - [parseInt](#parseint)
       - [parseJSON](#parsejson)
       - [parseUint](#parseuint)
+      - [parseYAML](#parseyaml)
       - [plugin](#plugin)
       - [regexMatch](#regexmatch)
       - [regexReplaceAll](#regexreplaceall)
@@ -1780,6 +1781,17 @@ Takes the given string and parses it as a base-10 int64:
 ```liquid
 {{ "1" | parseUint }}
 ```
+
+##### `parseYAML`
+
+Takes the given input (usually the value from a key) and parses the result as
+YAML:
+
+```liquid
+{{ with $d := key "user/info" | parseYAML }}{{ $d.name }}{{ end }}
+```
+
+Note: The same caveats that apply to `parseJSON` apply to `parseYAML`.
 
 ##### `plugin`
 

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -981,6 +981,19 @@ func parseUint(s string) (uint64, error) {
 	return result, nil
 }
 
+// parseYAML returns a structure for valid YAML
+func parseYAML(s string) (interface{}, error) {
+	if s == "" {
+		return map[string]interface{}{}, nil
+	}
+
+	var data interface{}
+	if err := yaml.Unmarshal([]byte(s), &data); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
 // plugin executes a subprocess as the given command string. It is assumed the
 // resulting command returns JSON which is then parsed and returned as the
 // value for use in the template.

--- a/template/template.go
+++ b/template/template.go
@@ -273,6 +273,7 @@ func funcMap(i *funcMapInput) template.FuncMap {
 		"parseInt":        parseInt,
 		"parseJSON":       parseJSON,
 		"parseUint":       parseUint,
+		"parseYAML":       parseYAML,
 		"plugin":          plugin,
 		"regexReplaceAll": regexReplaceAll,
 		"regexMatch":      regexMatch,

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1376,6 +1376,39 @@ func TestTemplate_Execute(t *testing.T) {
 			false,
 		},
 		{
+			"helper_parseYAML",
+			&NewTemplateInput{
+				Contents: `{{ "foo: bar" | parseYAML }}`,
+			},
+			&ExecuteInput{
+				Brain: NewBrain(),
+			},
+			"map[foo:bar]",
+			false,
+		},
+		{
+			"helper_parseYAMLv2",
+			&NewTemplateInput{
+				Contents: `{{ "foo: bar\nbaz: \"foo\"" | parseYAML }}`,
+			},
+			&ExecuteInput{
+				Brain: NewBrain(),
+			},
+			"map[baz:foo foo:bar]",
+			false,
+		},
+		{
+			"helper_parseYAMLnested",
+			&NewTemplateInput{
+				Contents: `{{ "foo:\n  bar: \"baz\"\n  baz: 7" | parseYAML }}`,
+			},
+			&ExecuteInput{
+				Brain: NewBrain(),
+			},
+			"map[foo:map[bar:baz baz:7]]",
+			false,
+		},
+		{
 			"helper_plugin",
 			&NewTemplateInput{
 				Contents: `{{ "1" | plugin "echo" }}`,


### PR DESCRIPTION
### Why
Consul-template supports parseJSON. The consul ui supports syntax highlighting for both JSON and YAML so it'd be ncie if consul-template had first-class support for both reading and writing yaml.

### What
This adds a new helper `parseYAML` that works identically to `parseJSON` but accepts YAML.

YAML is much nicer to use for config files than JSON mainly because
comments can be used.

It should be noted that `parseYAML | toYAML` will strip comments with
the current yaml library, but I don't want to go about changing
that huge of a dependency at this stage. `yaml.v3` does support comments,
but it's not super easy to use as you can't just unmarshal to a
`map[string]interface{}` and keep comments.

### Other details

To work around this, I'd made a plugin `yaml2json` which was just a tiny go program but then I have to carry that around in my `$PATH` and I have to use the following snippet which feels a bit meh given how nicely the parseJSON parser works.

```liquid
{{ with $d := key "user/info.yaml" | plugin "yaml2json" | parseJSON }}
{{ $d.name }}
{{ end }}
```

This fixes #1343 