### PR TITLE
don't renew vault token when no token is set

### DIFF
--- a/config/vault.go
+++ b/config/vault.go
@@ -193,16 +193,6 @@ func (c *VaultConfig) Finalize() {
 		c.Namespace = stringFromEnv([]string{"VAULT_NAMESPACE"}, "")
 	}
 
-	if c.RenewToken == nil {
-		default_renew := DefaultVaultRenewToken
-		if c.VaultAgentTokenFile != nil {
-			default_renew = false
-		}
-		c.RenewToken = boolFromEnv([]string{
-			"VAULT_RENEW_TOKEN",
-		}, default_renew)
-	}
-
 	if c.Retry == nil {
 		c.Retry = DefaultRetryConfig()
 	}
@@ -256,6 +246,19 @@ func (c *VaultConfig) Finalize() {
 		}
 	} else {
 		c.Token = stringFromFile([]string{*c.VaultAgentTokenFile}, "")
+	}
+
+	// must be after c.Token setting, as default depends on that.
+	if c.RenewToken == nil {
+		default_renew := DefaultVaultRenewToken
+		if c.VaultAgentTokenFile != nil {
+			default_renew = false
+		} else if StringVal(c.Token) == "" {
+			default_renew = false
+		}
+		c.RenewToken = boolFromEnv([]string{
+			"VAULT_RENEW_TOKEN",
+		}, default_renew)
 	}
 
 	if c.Transport == nil {

--- a/config/vault_test.go
+++ b/config/vault_test.go
@@ -327,7 +327,7 @@ func TestVaultConfig_Finalize(t *testing.T) {
 				Address:    String(""),
 				Enabled:    Bool(false),
 				Namespace:  String(""),
-				RenewToken: Bool(DefaultVaultRenewToken),
+				RenewToken: Bool(false),
 				Retry: &RetryConfig{
 					Backoff:    TimeDuration(DefaultRetryBackoff),
 					MaxBackoff: TimeDuration(DefaultRetryMaxBackoff),
@@ -365,7 +365,7 @@ func TestVaultConfig_Finalize(t *testing.T) {
 				Address:    String("address"),
 				Enabled:    Bool(true),
 				Namespace:  String(""),
-				RenewToken: Bool(DefaultVaultRenewToken),
+				RenewToken: Bool(false),
 				Retry: &RetryConfig{
 					Backoff:    TimeDuration(DefaultRetryBackoff),
 					MaxBackoff: TimeDuration(DefaultRetryMaxBackoff),
@@ -403,7 +403,7 @@ func TestVaultConfig_Finalize(t *testing.T) {
 				Address:    String("address"),
 				Enabled:    Bool(true),
 				Namespace:  String(""),
-				RenewToken: Bool(DefaultVaultRenewToken),
+				RenewToken: Bool(false),
 				Retry: &RetryConfig{
 					Backoff:    TimeDuration(DefaultRetryBackoff),
 					MaxBackoff: TimeDuration(DefaultRetryMaxBackoff),
@@ -444,7 +444,7 @@ func TestVaultConfig_Finalize(t *testing.T) {
 	}
 }
 
-func TestVaultConfig_TokenFileRenew(t *testing.T) {
+func TestVaultConfig_TokenRenew(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -456,6 +456,16 @@ func TestVaultConfig_TokenFileRenew(t *testing.T) {
 		{
 			"base_renew",
 			&VaultConfig{},
+			&VaultConfig{
+				RenewToken: Bool(false),
+			},
+			[]string{"RenewToken"},
+		},
+		{
+			"base_renew_w_token",
+			&VaultConfig{
+				Token: String("a-token"),
+			},
 			&VaultConfig{
 				RenewToken: Bool(true),
 			},


### PR DESCRIPTION
Adds check in config to change the vault token renew check to not fire
if there is no vault token to renew. Avoids warning spams in the logs.