### PR TITLE
fix bug looking up versioned vault secrets

### DIFF
--- a/dependency/vault_read.go
+++ b/dependency/vault_read.go
@@ -122,6 +122,9 @@ func (d *VaultReadQuery) Stop() {
 
 // String returns the human-friendly version of this dependency.
 func (d *VaultReadQuery) String() string {
+	if v := d.queryValues["version"]; len(v) > 0 {
+		return fmt.Sprintf("vault.read(%s.v%s)", d.rawPath, v[0])
+	}
 	return fmt.Sprintf("vault.read(%s)", d.rawPath)
 }
 

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -459,6 +459,34 @@ func TestTemplate_Execute(t *testing.T) {
 			false,
 		},
 		{
+			"func_secret_read_versions",
+			&NewTemplateInput{
+				Contents: `{{with secret "secret/foo"}}{{.Data.zip}}{{end}}:{{with secret "secret/foo?version=1"}}{{.Data.zip}}{{end}}`,
+			},
+			&ExecuteInput{
+				Brain: func() *Brain {
+					b := NewBrain()
+					d, err := dep.NewVaultReadQuery("secret/foo")
+					if err != nil {
+						t.Fatal(err)
+					}
+					b.Remember(d, &dep.Secret{
+						Data: map[string]interface{}{"zip": "zap"},
+					})
+					d1, err := dep.NewVaultReadQuery("secret/foo?version=1")
+					if err != nil {
+						t.Fatal(err)
+					}
+					b.Remember(d1, &dep.Secret{
+						Data: map[string]interface{}{"zip": "zed"},
+					})
+					return b
+				}(),
+			},
+			"zap:zed",
+			false,
+		},
+		{
 			"func_secret_read_no_exist",
 			&NewTemplateInput{
 				Contents: `{{ with secret "secret/nope" }}{{ .Data.zip }}{{ end }}`,


### PR DESCRIPTION
The brains/cache is keyed off String() output of a dependency. In this
case the dependency is a versioned vault secret. The problem is that the
vault secret's String() output doesn't contain the version. So the first
version retrieved seeds the cache and all subsequent references use that
version even if they specify a different (or no) version.

Including the version in vault secret String() output fixes this.

Fixes #1350