### PR TITLE
simplified the code in a couple places

### DIFF
--- a/template/funcs.go
+++ b/template/funcs.go
@@ -388,10 +388,8 @@ func byMeta(meta string, services []*dep.HealthService) (groups map[string][]*de
 	}
 	getOrDefault := func(m map[string]string, key string) string {
 		realKey := strings.TrimSuffix(key, "|int")
-		if val, ok := m[realKey]; ok {
-			if val != "" {
-				return val
-			}
+		if val := m[realKey]; val != "" {
+			return val
 		}
 		if strings.HasSuffix(key, "|int") {
 			return "0"

--- a/template/funcs_test.go
+++ b/template/funcs_test.go
@@ -88,66 +88,33 @@ func TestFileSandbox(t *testing.T) {
 func Test_byMeta(t *testing.T) {
 	t.Parallel()
 	svcA := &dep.HealthService{
-		Node:                "",
-		NodeID:              "",
-		NodeAddress:         "",
-		NodeTaggedAddresses: nil,
-		NodeMeta:            nil,
 		ServiceMeta: map[string]string{
 			"version":         "v2",
 			"version_num":     "2",
 			"bad_version_num": "1zz",
 			"env":             "dev",
 		},
-		Address: "",
-		ID:      "svcA",
-		Name:    "",
-		Tags:    nil,
-		Checks:  nil,
-		Status:  "",
-		Port:    0,
+		ID: "svcA",
 	}
 
 	svcB := &dep.HealthService{
-		Node:                "",
-		NodeID:              "",
-		NodeAddress:         "",
-		NodeTaggedAddresses: nil,
-		NodeMeta:            nil,
 		ServiceMeta: map[string]string{
 			"version":         "v11",
 			"version_num":     "11",
 			"bad_version_num": "1zz",
 			"env":             "prod",
 		},
-		Address: "",
-		ID:      "svcB",
-		Name:    "",
-		Tags:    nil,
-		Checks:  nil,
-		Status:  "",
-		Port:    0,
+		ID: "svcB",
 	}
 
 	svcC := &dep.HealthService{
-		Node:                "",
-		NodeID:              "",
-		NodeAddress:         "",
-		NodeTaggedAddresses: nil,
-		NodeMeta:            nil,
 		ServiceMeta: map[string]string{
 			"version":         "v11",
 			"version_num":     "11",
 			"bad_version_num": "1zz",
 			"env":             "prod",
 		},
-		Address: "",
-		ID:      "svcC",
-		Name:    "",
-		Tags:    nil,
-		Checks:  nil,
-		Status:  "",
-		Port:    0,
+		ID: "svcC",
 	}
 
 	type args struct {


### PR DESCRIPTION
While looking into an issue I saw these and went ahead and fixed them.
One is taking advantage of map defaults.
The other eliminates struct elements set to their default values.


Almost skipped the PR/review, but decided I should have these sorts of things reviewed as standard practice in case I overlook something.