### PR TITLE
Fix - tests support consul 1.7 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     environment:
       GO111MODULE: "on"
-      CONSUL_VERSION: 1.6.4
+      CONSUL_VERSION: 1.7.2
       VAULT_VERSION: 1.3.2
     docker:
       - image: circleci/golang:latest

--- a/dependency/catalog_node_test.go
+++ b/dependency/catalog_node_test.go
@@ -95,8 +95,10 @@ func TestCatalogNodeQuery_Fetch(t *testing.T) {
 					Address:    testConsul.Config.Bind,
 					Datacenter: "dc1",
 					TaggedAddresses: map[string]string{
-						"lan": "127.0.0.1",
-						"wan": "127.0.0.1",
+						"lan":      "127.0.0.1",
+						"wan":      "127.0.0.1",
+						"lan_ipv4": "127.0.0.1",
+						"wan_ipv4": "127.0.0.1",
 					},
 					Meta: map[string]string{
 						"consul-network-segment": "",

--- a/dependency/catalog_nodes_test.go
+++ b/dependency/catalog_nodes_test.go
@@ -88,8 +88,10 @@ func TestCatalogNodesQuery_Fetch(t *testing.T) {
 					Address:    testConsul.Config.Bind,
 					Datacenter: "dc1",
 					TaggedAddresses: map[string]string{
-						"lan": "127.0.0.1",
-						"wan": "127.0.0.1",
+						"lan":      "127.0.0.1",
+						"wan":      "127.0.0.1",
+						"lan_ipv4": "127.0.0.1",
+						"wan_ipv4": "127.0.0.1",
 					},
 					Meta: map[string]string{
 						"consul-network-segment": "",

--- a/dependency/catalog_service_test.go
+++ b/dependency/catalog_service_test.go
@@ -160,8 +160,10 @@ func TestCatalogServiceQuery_Fetch(t *testing.T) {
 					Address:    testConsul.Config.Bind,
 					Datacenter: "dc1",
 					TaggedAddresses: map[string]string{
-						"lan": "127.0.0.1",
-						"wan": "127.0.0.1",
+						"lan":      "127.0.0.1",
+						"wan":      "127.0.0.1",
+						"lan_ipv4": "127.0.0.1",
+						"wan_ipv4": "127.0.0.1",
 					},
 					NodeMeta: map[string]string{
 						"consul-network-segment": "",
@@ -184,8 +186,10 @@ func TestCatalogServiceQuery_Fetch(t *testing.T) {
 					Address:    testConsul.Config.Bind,
 					Datacenter: "dc1",
 					TaggedAddresses: map[string]string{
-						"lan": "127.0.0.1",
-						"wan": "127.0.0.1",
+						"lan":      "127.0.0.1",
+						"wan":      "127.0.0.1",
+						"lan_ipv4": "127.0.0.1",
+						"wan_ipv4": "127.0.0.1",
 					},
 					NodeMeta: map[string]string{
 						"consul-network-segment": "",

--- a/dependency/health_service_test.go
+++ b/dependency/health_service_test.go
@@ -229,8 +229,10 @@ func TestHealthServiceQuery_Fetch(t *testing.T) {
 					Node:        testConsul.Config.NodeName,
 					NodeAddress: testConsul.Config.Bind,
 					NodeTaggedAddresses: map[string]string{
-						"lan": "127.0.0.1",
-						"wan": "127.0.0.1",
+						"lan":      "127.0.0.1",
+						"wan":      "127.0.0.1",
+						"lan_ipv4": "127.0.0.1",
+						"wan_ipv4": "127.0.0.1",
 					},
 					NodeMeta: map[string]string{
 						"consul-network-segment": "",
@@ -258,8 +260,10 @@ func TestHealthServiceQuery_Fetch(t *testing.T) {
 					Node:        testConsul.Config.NodeName,
 					NodeAddress: testConsul.Config.Bind,
 					NodeTaggedAddresses: map[string]string{
-						"lan": "127.0.0.1",
-						"wan": "127.0.0.1",
+						"lan":      "127.0.0.1",
+						"wan":      "127.0.0.1",
+						"lan_ipv4": "127.0.0.1",
+						"wan_ipv4": "127.0.0.1",
 					},
 					NodeMeta: map[string]string{
 						"consul-network-segment": "",
@@ -282,8 +286,10 @@ func TestHealthServiceQuery_Fetch(t *testing.T) {
 					Node:        testConsul.Config.NodeName,
 					NodeAddress: testConsul.Config.Bind,
 					NodeTaggedAddresses: map[string]string{
-						"lan": "127.0.0.1",
-						"wan": "127.0.0.1",
+						"lan":      "127.0.0.1",
+						"wan":      "127.0.0.1",
+						"lan_ipv4": "127.0.0.1",
+						"wan_ipv4": "127.0.0.1",
 					},
 					NodeMeta: map[string]string{
 						"consul-network-segment": "",


### PR DESCRIPTION
Since consul 1.7 the response for tagged addresses have changed.: https://github.com/hashicorp/consul/issues/6531

This patch update tests to new 1.7 response syntax.