### PR TITLE
Add better sleep configuration for static roles

### DIFF
--- a/dependency/vault_common.go
+++ b/dependency/vault_common.go
@@ -143,13 +143,14 @@ func leaseCheckWait(s *Secret) time.Duration {
 	}
 
 	// Handle if this is a secret with a rotation period.  If this is a rotating secret,
-	// the rotation period will be the duration to sleep before rendering the new secret.
+	// the rotating secret's TTL will be the duration to sleep before rendering the new secret.
 	var rotatingSecret bool
-	if rotationInterface, ok := s.Data["rotation_period"]; ok && s.LeaseID == "" {
-		if rotationData, err := rotationInterface.(json.Number).Int64(); err == nil {
-			if rotationData > 0 {
-				log.Printf("[DEBUG] Found rotation_period and set lease duration to %d seconds", rotationData)
-				base = int(rotationData)
+	if _, ok := s.Data["rotation_period"]; ok && s.LeaseID == "" {
+		if ttlInterface, ok := s.Data["ttl"]; ok {
+			if ttlData, err := ttlInterface.(json.Number).Int64(); err == nil {
+				log.Printf("[DEBUG] Found rotation_period and set lease duration to %d seconds", ttlData)
+				// Add a second for cushion
+				base = int(ttlData) + 1
 				rotatingSecret = true
 			}
 		}

--- a/dependency/vault_common_test.go
+++ b/dependency/vault_common_test.go
@@ -26,12 +26,28 @@ func TestVaultRenewDuration(t *testing.T) {
 
 	var data = map[string]interface{}{
 		"rotation_period": json.Number("60"),
+		"ttl": json.Number("30"),
 	}
 
 	nonRenewableRotated := Secret{LeaseDuration: 100, Data: data}
 	nonRenewableRotatedDur := leaseCheckWait(&nonRenewableRotated).Seconds()
-	if nonRenewableRotatedDur != 60 {
-		t.Fatalf("renewable duration is not 60: %f", nonRenewableRotatedDur)
+
+	// We expect a 1 second cushion
+	if nonRenewableRotatedDur != 31 {
+		t.Fatalf("renewable duration is not 31: %f", nonRenewableRotatedDur)
+	}
+
+	data = map[string]interface{}{
+		"rotation_period": json.Number("30"),
+		"ttl": json.Number("5"),
+	}
+
+	nonRenewableRotated = Secret{LeaseDuration: 100, Data: data}
+	nonRenewableRotatedDur = leaseCheckWait(&nonRenewableRotated).Seconds()
+
+	// We expect a 1 second cushion
+	if nonRenewableRotatedDur != 6 {
+		t.Fatalf("renewable duration is not 6: %f", nonRenewableRotatedDur)
 	}
 }
 


### PR DESCRIPTION
#1358 introduced support for templating Vault static roles that have rotating passwords by looking for `rotation_period`.  This does indeed configure Consul Template to have a better sense of how often it should render secrets, but falls short of rendering stale secrets in a timely fashion.

For example, when a static role is created in Vault, the rotation period automatically starts even if the credentials haven't been read.  The time before the next rotation will be very different than the rotation period, so Consul Template will be very out of sync with Vault.

If a secret has a `rotation_period`, Vault will automatically update its `ttl` with the time left before rotation.  Since Consul Template updates the sleep time every time we fetch the secret from Vault, we can simply use the `ttl` plus a second of cushion as the sleep time.  This ensures no matter when Consul Template starts, it will know exactly when the next password will be available.

It's expected that all static roles with rotating passwords will have both `rotation_period` and `ttl` values as shown in this OpenLDAP example:

```
Key                    Value
---                    -----
dn                     cn=hashicorp,ou=users,dc=hashicorp,dc=com
last_vault_rotation    2020-03-24T13:11:02.441162-04:00
password               f7P6miNI0p32qVucm9fo2Csc15IFJs5D5ZQBleelV7BDJe7wYfvCaW8BLKX4TIQk
rotation_period        30s
ttl                    5s
username               hashicorp

...

Key                    Value
---                    -----
dn                     cn=hashicorp,ou=users,dc=hashicorp,dc=com
last_vault_rotation    2020-03-24T13:11:02.441162-04:00
password               f7P6miNI0p32qVucm9fo2Csc15IFJs5D5ZQBleelV7BDJe7wYfvCaW8BLKX4TIQk
rotation_period        30s
ttl                    3s
username               hashicorp
```