### PR TITLE
Allow to set application name in syslog

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -420,6 +420,11 @@ func (cli *CLI) ParseFlags(args []string) (
 	}), "syslog-facility", "")
 
 	flags.Var((funcVar)(func(s string) error {
+		c.Syslog.Name = config.String(s)
+	return nil
+	}), "syslog-name", "")
+
+	flags.Var((funcVar)(func(s string) error {
 		t, err := config.ParseTemplateConfig(s)
 		if err != nil {
 			return err
@@ -588,10 +593,10 @@ func logError(err error, status int) int {
 
 func (cli *CLI) setup(conf *config.Config) (*config.Config, error) {
 	if err := logging.Setup(&logging.Config{
-		Name:           version.Name,
 		Level:          config.StringVal(conf.LogLevel),
 		Syslog:         config.BoolVal(conf.Syslog.Enabled),
 		SyslogFacility: config.StringVal(conf.Syslog.Facility),
+		SyslogName:	config.StringVal(conf.Syslog.Name),
 		Writer:         cli.errStream,
 	}); err != nil {
 		return nil, err
@@ -735,6 +740,10 @@ Options:
   -syslog-facility=<facility>
       Set the facility where syslog should log - if this attribute is supplied,
       the -syslog flag must also be supplied
+
+  -syslog-name=<name>
+      Set the name of the application which will appear in syslog, if this
+      attribute is supplied, the -syslog flag must also be supplied
 
   -template=<template>
        Adds a new template to watch on disk in the format 'in:out(:command)'

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -578,6 +578,18 @@ func TestParse(t *testing.T) {
 			false,
 		},
 		{
+			"syslog_name",
+			`syslog {
+				name = "name"
+			}`,
+			&Config{
+				Syslog: &SyslogConfig{
+					Name: String("name"),
+				},
+			},
+			false,
+		},
+		{
 			"template",
 			`template {}`,
 			&Config{

--- a/config/syslog.go
+++ b/config/syslog.go
@@ -1,16 +1,26 @@
 package config
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/hashicorp/consul-template/version"
+)
 
 const (
 	// DefaultSyslogFacility is the default facility to log to.
 	DefaultSyslogFacility = "LOCAL0"
 )
 
+var (
+	// DefaultSyslogName is the default app name in syslog.
+	DefaultSyslogName = version.Name
+)
+
 // SyslogConfig is the configuration for syslog.
 type SyslogConfig struct {
 	Enabled  *bool   `mapstructure:"enabled"`
 	Facility *string `mapstructure:"facility"`
+	Name	 *string `mapstructure:"name"`
 }
 
 // DefaultSyslogConfig returns a configuration that is populated with the
@@ -28,6 +38,7 @@ func (c *SyslogConfig) Copy() *SyslogConfig {
 	var o SyslogConfig
 	o.Enabled = c.Enabled
 	o.Facility = c.Facility
+	o.Name = c.Name
 	return &o
 }
 
@@ -57,17 +68,25 @@ func (c *SyslogConfig) Merge(o *SyslogConfig) *SyslogConfig {
 		r.Facility = o.Facility
 	}
 
+	if o.Name != nil {
+		r.Name = o.Name
+	}
+
 	return r
 }
 
 // Finalize ensures there no nil pointers.
 func (c *SyslogConfig) Finalize() {
 	if c.Enabled == nil {
-		c.Enabled = Bool(StringPresent(c.Facility))
+		c.Enabled = Bool(StringPresent(c.Facility) || StringPresent(c.Name))
 	}
 
 	if c.Facility == nil {
 		c.Facility = String(DefaultSyslogFacility)
+	}
+
+	if c.Name == nil {
+		c.Name = String(DefaultSyslogName)
 	}
 }
 
@@ -80,8 +99,10 @@ func (c *SyslogConfig) GoString() string {
 	return fmt.Sprintf("&SyslogConfig{"+
 		"Enabled:%s, "+
 		"Facility:%s"+
+		"Name:%s"+
 		"}",
 		BoolGoString(c.Enabled),
 		StringGoString(c.Facility),
+		StringGoString(c.Name),
 	)
 }

--- a/config/syslog_test.go
+++ b/config/syslog_test.go
@@ -26,6 +26,7 @@ func TestSyslogConfig_Copy(t *testing.T) {
 			&SyslogConfig{
 				Enabled:  Bool(true),
 				Facility: String("facility"),
+				Name:	  String("name"),
 			},
 		},
 	}
@@ -121,6 +122,30 @@ func TestSyslogConfig_Merge(t *testing.T) {
 			&SyslogConfig{Facility: String("facility")},
 			&SyslogConfig{Facility: String("facility")},
 		},
+		{
+			"name_overrides",
+			&SyslogConfig{Name: String("name")},
+			&SyslogConfig{Name: String("")},
+			&SyslogConfig{Name: String("")},
+		},
+		{
+			"name_empty_one",
+			&SyslogConfig{Name: String("name")},
+			&SyslogConfig{},
+			&SyslogConfig{Name: String("name")},
+		},
+		{
+			"name_empty_two",
+			&SyslogConfig{},
+			&SyslogConfig{Name: String("name")},
+			&SyslogConfig{Name: String("name")},
+		},
+		{
+			"name_same",
+			&SyslogConfig{Name: String("name")},
+			&SyslogConfig{Name: String("name")},
+			&SyslogConfig{Name: String("name")},
+		},
 	}
 
 	for i, tc := range cases {
@@ -147,6 +172,7 @@ func TestSyslogConfig_Finalize(t *testing.T) {
 			&SyslogConfig{
 				Enabled:  Bool(false),
 				Facility: String(DefaultSyslogFacility),
+				Name:	  String(DefaultSyslogName),
 			},
 		},
 		{
@@ -157,6 +183,18 @@ func TestSyslogConfig_Finalize(t *testing.T) {
 			&SyslogConfig{
 				Enabled:  Bool(true),
 				Facility: String("facility"),
+				Name:	  String(DefaultSyslogName),
+			},
+		},
+		{
+			"with_name",
+			&SyslogConfig{
+				Name: String("name"),
+			},
+			&SyslogConfig{
+				Enabled:  Bool(true),
+				Facility: String(DefaultSyslogFacility),
+				Name:     String("name"),
 			},
 		},
 	}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -22,7 +22,7 @@ type Config struct {
 	// Syslog and SyslogFacility are the syslog configuration options.
 	Syslog         bool   `json:"syslog"`
 	SyslogFacility string `json:"syslog_facility"`
-	// Name is the progname as it will appear in syslog output (if enabled).
+	// SyslogName is the progname as it will appear in syslog output (if enabled).
 	SyslogName     string `json:"name"`
 
 	// Writer is the output where logs should go. If syslog is enabled, data will

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -16,15 +16,14 @@ var Levels = []logutils.LogLevel{"TRACE", "DEBUG", "INFO", "WARN", "ERR"}
 
 // Config is the configuration for this log setup.
 type Config struct {
-	// Name is the progname as it will appear in syslog output (if enabled).
-	Name string `json:"name"`
-
 	// Level is the log level to use.
 	Level string `json:"level"`
 
 	// Syslog and SyslogFacility are the syslog configuration options.
 	Syslog         bool   `json:"syslog"`
 	SyslogFacility string `json:"syslog_facility"`
+	// Name is the progname as it will appear in syslog output (if enabled).
+	SyslogName     string `json:"name"`
 
 	// Writer is the output where logs should go. If syslog is enabled, data will
 	// be written to writer in addition to syslog.
@@ -51,7 +50,7 @@ func Setup(config *Config) error {
 	if config.Syslog {
 		log.Printf("[DEBUG] (logging) enabling syslog on %s", config.SyslogFacility)
 
-		l, err := gsyslog.NewLogger(gsyslog.LOG_NOTICE, config.SyslogFacility, config.Name)
+		l, err := gsyslog.NewLogger(gsyslog.LOG_NOTICE, config.SyslogFacility, config.SyslogName)
 		if err != nil {
 			return fmt.Errorf("error setting up syslog logger: %s", err)
 		}


### PR DESCRIPTION
Currently "consul-template" appear as progname in syslog,
which is quite annoying when you run multiple programs.

Signed-off-by: Jean-Philippe Menil <jpmenil@gmail.com>