### PR TITLE
move render events to after template command

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,7 +555,9 @@ template {
   command = "restart service foo"
 
   # This is the maximum amount of time to wait for the optional command to
-  # return. Default is 30s.
+  # return. If you set the timeout to 0s the command is run in the background
+  # without monitoring it for errors. If also using Once, consul-template can
+  # exit before the command is finished. Default is 30s.
   command_timeout = "60s"
 
   # Exit with an error when accessing a struct or map field/key that does not

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -556,23 +556,6 @@ func (r *Runner) Run() error {
 		}
 	}
 
-	// Check if we need to deliver any rendered signals
-	if wouldRenderAny || renderedAny {
-		// Send the signal that a template got rendered
-		select {
-		case r.renderedCh <- struct{}{}:
-		default:
-		}
-	}
-
-	// Check if we need to deliver any event signals
-	if newRenderEvent {
-		select {
-		case r.renderEventCh <- struct{}{}:
-		default:
-		}
-	}
-
 	// Perform the diff and update the known dependencies.
 	r.diffAndUpdateDeps(runCtx.depsMap)
 
@@ -598,6 +581,23 @@ func (r *Runner) Run() error {
 		}); err != nil {
 			s := fmt.Sprintf("failed to execute command %q from %s", command, t.Display())
 			errs = append(errs, errors.Wrap(err, s))
+		}
+	}
+
+	// Check if we need to deliver any rendered signals
+	if wouldRenderAny || renderedAny {
+		// Send the signal that a template got rendered
+		select {
+		case r.renderedCh <- struct{}{}:
+		default:
+		}
+	}
+
+	// Check if we need to deliver any event signals
+	if newRenderEvent {
+		select {
+		case r.renderEventCh <- struct{}{}:
+		default:
 		}
 	}
 


### PR DESCRIPTION
When using CT as a library, the "standard" way to monitor and know when
to exit is to watch for messages on the TemplateRenderedCh(). The
problem is that the message is sent down that channel before the
commands are run, so the program could exit before the command has run.

The problem is more obvious when CT is run in a transient container,
where even if the commands are run the container might exit before they
finish and they get killed.

Moving the render events to after the command avoids these issues (the
container exit issue also requires a command_timeout > 0s).

Fixes #1369