### PR TITLE
fix test compatibility issue with consul 1.7

### DIFF
--- a/dependency/catalog_node_test.go
+++ b/dependency/catalog_node_test.go
@@ -150,6 +150,7 @@ func TestCatalogNodeQuery_Fetch(t *testing.T) {
 			if act != nil {
 				if n := act.(*CatalogNode).Node; n != nil {
 					n.ID = ""
+					n.TaggedAddresses = filterAddresses(n.TaggedAddresses)
 				}
 				// delete any version data from ServiceMeta
 				services := act.(*CatalogNode).Services

--- a/dependency/catalog_nodes_test.go
+++ b/dependency/catalog_nodes_test.go
@@ -114,6 +114,7 @@ func TestCatalogNodesQuery_Fetch(t *testing.T) {
 			if act != nil {
 				for _, n := range act.([]*Node) {
 					n.ID = ""
+					n.TaggedAddresses = filterAddresses(n.TaggedAddresses)
 				}
 			}
 

--- a/dependency/catalog_service_test.go
+++ b/dependency/catalog_service_test.go
@@ -215,6 +215,7 @@ func TestCatalogServiceQuery_Fetch(t *testing.T) {
 			if act != nil {
 				for _, s := range act.([]*CatalogService) {
 					s.ID = ""
+					s.TaggedAddresses = filterAddresses(s.TaggedAddresses)
 				}
 			}
 

--- a/dependency/consul_common_test.go
+++ b/dependency/consul_common_test.go
@@ -1,19 +1,29 @@
 package dependency
 
-var filtered_meta = []string{"raft_version", "serf_protocol_current",
-	"serf_protocol_min", "serf_protocol_max", "version",
+// filter is used as a helper for filtering values out of maps.
+func filter(data map[string]string, remove []string) map[string]string {
+	if data == nil {
+		return make(map[string]string)
+	}
+	for _, k := range remove {
+		delete(data, k)
+	}
+	return data
 }
 
 // filterVersionMeta filters out all version information from the returned
 // metadata. It allocates the meta map if it is nil to make the tests backward
-// compatible with versions < 1.5.2. Once this is no longer needed the returned
-// value can be removed (along with its assignment).
+// compatible with versions < 1.5.2.
 func filterVersionMeta(meta map[string]string) map[string]string {
-	if meta == nil {
-		return make(map[string]string)
+	filteredMeta := []string{"raft_version", "serf_protocol_current",
+		"serf_protocol_min", "serf_protocol_max", "version",
 	}
-	for _, k := range filtered_meta {
-		delete(meta, k)
-	}
-	return meta
+	return filter(meta, filteredMeta)
+}
+
+// filterAddresses filters out consul >1.7 ipv4/ipv6 specific entries
+// from TaggedAddresses entries on nodes, catlog and health services.
+func filterAddresses(addrs map[string]string) map[string]string {
+	ipvKeys := []string{"lan_ipv4", "wan_ipv4", "lan_ipv6", "wan_ipv6"}
+	return filter(addrs, ipvKeys)
 }

--- a/dependency/health_service_test.go
+++ b/dependency/health_service_test.go
@@ -336,6 +336,8 @@ func TestHealthServiceQuery_Fetch(t *testing.T) {
 					v.Checks = nil
 					// delete any version data from ServiceMeta
 					v.ServiceMeta = filterVersionMeta(v.ServiceMeta)
+					v.NodeTaggedAddresses = filterAddresses(
+						v.NodeTaggedAddresses)
 				}
 			}
 


### PR DESCRIPTION
Some data got added to [Node]TaggedAddresses field. This filters them
out so >1.7 look like <=1.6. I like to be able to test older consul
versions if bugs are filed against them and like the tests to play
along.

Resolves #1359