### PR TITLE
Simplify log level environment variable usage

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -517,6 +517,7 @@ func (c *Config) Finalize() {
 		c.LogLevel = stringFromEnv([]string{
 			"CT_LOG",
 			"CONSUL_TEMPLATE_LOG",
+			"CONSUL_TEMPLATE_LOG_LEVEL",
 		}, DefaultLogLevel)
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2056,7 +2056,7 @@ func TestDefaultConfig(t *testing.T) {
 			false,
 		},
 		{
-			"CONSUL_TEMPLATE_LOG",
+			"CONSUL_TEMPLATE_LOG_LEVEL",
 			"DEBUG",
 			&Config{
 				LogLevel: String("DEBUG"),

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -9,6 +9,8 @@ Consul Template, use the `-log-level` flag:
 $ consul-template -log-level info ...
 ```
 
+Or set it via the `CONSUL_TEMPLATE_LOG_LEVEL` environment variable.
+
 ```text
 <timestamp> [INFO] (cli) received redis from Watcher
 <timestamp> [INFO] (cli) invoking Runner


### PR DESCRIPTION
- Add _LEVEL as suffix to CONSUL_TEMPLATE_LOG
- Remove CT_LOG
- Add reference to the environment variable on the readme file

ref #1328
