### PR TITLE
Allow additional time for PKI certificates to valid

### DIFF
--- a/dependency/vault_common.go
+++ b/dependency/vault_common.go
@@ -7,10 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"crypto/x509"
 	"encoding/json"
-	"encoding/pem"
-
 	"github.com/hashicorp/vault/api"
 )
 
@@ -115,22 +112,6 @@ func renewSecret(clients *ClientSet, d renewer) error {
 	}
 }
 
-// durationFrom cert gets the duration of validity from cert data and
-// returns that value as an integer number of seconds
-func durationFromCert(certData string) int {
-	block, _ := pem.Decode([]byte(certData))
-	if block == nil {
-		return -1
-	}
-	cert, err := x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		log.Printf("[WARN] Unable to parse certificate data: %s", err)
-		return -1
-	}
-
-	return int(cert.NotAfter.Sub(cert.NotBefore).Seconds())
-}
-
 // leaseCheckWait accepts a secret and returns the recommended amount of
 // time to sleep.
 func leaseCheckWait(s *Secret) time.Duration {
@@ -141,16 +122,11 @@ func leaseCheckWait(s *Secret) time.Duration {
 	}
 
 	// Handle if this is a certificate with no lease
-	if certInterface, ok := s.Data["certificate"]; ok && s.LeaseID == "" {
-		if certData, ok := certInterface.(string); ok {
-			// Vault adds a 30 second pad to NotAfter to account for clockskew.
-			// We're removing the pad here to give additional time for rendering
-			// before cert expiration when TTL is set to a low value.
-			newDuration := durationFromCert(certData) - 30
-
-			if newDuration > 0 {
-				log.Printf("[DEBUG] Found certificate and set lease duration to %d seconds", newDuration)
-				base = newDuration
+	if _, ok := s.Data["certificate"]; ok && s.LeaseID == "" {
+		if expInterface, ok := s.Data["expiration"]; ok {
+			if expData, err := expInterface.(json.Number).Int64(); err == nil {
+				base = int(expData - time.Now().Unix())
+				log.Printf("[DEBUG] Found certificate and set lease duration to %d seconds", base)
 			}
 		}
 	}

--- a/dependency/vault_common.go
+++ b/dependency/vault_common.go
@@ -128,7 +128,7 @@ func durationFromCert(certData string) int {
 		return -1
 	}
 
-	return int(cert.NotAfter.Sub(cert.NotBefore).Seconds())
+   return int(cert.NotAfter.Sub(cert.NotBefore).Seconds())
 }
 
 // leaseCheckWait accepts a secret and returns the recommended amount of
@@ -143,7 +143,11 @@ func leaseCheckWait(s *Secret) time.Duration {
 	// Handle if this is a certificate with no lease
 	if certInterface, ok := s.Data["certificate"]; ok && s.LeaseID == "" {
 		if certData, ok := certInterface.(string); ok {
-			newDuration := durationFromCert(certData)
+		   // Vault adds a 30 second pad to NotAfter to account for clockskew.
+		   // We're removing the pad here to give additional time for rendering 
+           // before cert expiration when TTL is set to a low value.
+			newDuration := durationFromCert(certData) - 30
+
 			if newDuration > 0 {
 				log.Printf("[DEBUG] Found certificate and set lease duration to %d seconds", newDuration)
 				base = newDuration

--- a/dependency/vault_common.go
+++ b/dependency/vault_common.go
@@ -128,7 +128,7 @@ func durationFromCert(certData string) int {
 		return -1
 	}
 
-   return int(cert.NotAfter.Sub(cert.NotBefore).Seconds())
+	return int(cert.NotAfter.Sub(cert.NotBefore).Seconds())
 }
 
 // leaseCheckWait accepts a secret and returns the recommended amount of
@@ -143,9 +143,9 @@ func leaseCheckWait(s *Secret) time.Duration {
 	// Handle if this is a certificate with no lease
 	if certInterface, ok := s.Data["certificate"]; ok && s.LeaseID == "" {
 		if certData, ok := certInterface.(string); ok {
-		   // Vault adds a 30 second pad to NotAfter to account for clockskew.
-		   // We're removing the pad here to give additional time for rendering 
-           // before cert expiration when TTL is set to a low value.
+			// Vault adds a 30 second pad to NotAfter to account for clockskew.
+			// We're removing the pad here to give additional time for rendering
+			// before cert expiration when TTL is set to a low value.
 			newDuration := durationFromCert(certData) - 30
 
 			if newDuration > 0 {

--- a/dependency/vault_common_test.go
+++ b/dependency/vault_common_test.go
@@ -26,7 +26,7 @@ func TestVaultRenewDuration(t *testing.T) {
 
 	var data = map[string]interface{}{
 		"rotation_period": json.Number("60"),
-		"ttl": json.Number("30"),
+		"ttl":             json.Number("30"),
 	}
 
 	nonRenewableRotated := Secret{LeaseDuration: 100, Data: data}
@@ -39,7 +39,7 @@ func TestVaultRenewDuration(t *testing.T) {
 
 	data = map[string]interface{}{
 		"rotation_period": json.Number("30"),
-		"ttl": json.Number("5"),
+		"ttl":             json.Number("5"),
 	}
 
 	nonRenewableRotated = Secret{LeaseDuration: 100, Data: data}
@@ -54,7 +54,7 @@ func TestVaultRenewDuration(t *testing.T) {
 	expiration := strconv.FormatInt(rawExpiration, 10)
 
 	data = map[string]interface{}{
-		"expiration": json.Number(expiration),
+		"expiration":  json.Number(expiration),
 		"certificate": "foobar",
 	}
 

--- a/dependency/vault_common_test.go
+++ b/dependency/vault_common_test.go
@@ -2,9 +2,9 @@ package dependency
 
 import (
 	"encoding/json"
+	"strconv"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
+	"time"
 )
 
 func init() {
@@ -49,36 +49,18 @@ func TestVaultRenewDuration(t *testing.T) {
 	if nonRenewableRotatedDur != 6 {
 		t.Fatalf("renewable duration is not 6: %f", nonRenewableRotatedDur)
 	}
-}
 
-const testGoodCert = `-----BEGIN CERTIFICATE-----
-MIICAjCCAWugAwIBAgIJALDrJbXZKXXnMA0GCSqGSIb3DQEBCwUAMBoxGDAWBgNV
-BAMMD2NvbnN1bC10ZW1wbGF0ZTAeFw0xODA1MjUxNTAzNDdaFw0xODA2MDQxNTAz
-NDdaMBoxGDAWBgNVBAMMD2NvbnN1bC10ZW1wbGF0ZTCBnzANBgkqhkiG9w0BAQEF
-AAOBjQAwgYkCgYEAuT1yS2FvX2bpNvEkrapt4wC68NIfTU9Xx55DC4/Pq1ZkuI8b
-tC64x1oiJdM7ABEmT58rofTXoEpeHxcLTpXtJcrfLdgHUkPxNdrBgLWJi0BGI3m6
-zLF9KLTwEpFfBBTLgM6HIvTqqBD4itFtI0BDS/mqQKqa33Ai6hX0zPAH6AECAwEA
-AaNQME4wHQYDVR0OBBYEFLldqcFQ+RF40xBNgSjdNGBN78yHMB8GA1UdIwQYMBaA
-FLldqcFQ+RF40xBNgSjdNGBN78yHMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEL
-BQADgYEAUXeDp5pyGhH3RCxdJgjbQ67D5nqTVbTJnetEw1UdMEDQGrgCIUrbsJWm
-G4SbKUjKP+4wVUJLZpmv9PwJcN0ZxntNkJBDzTk+KULu4+8cCj6A27bBhmzeOu1y
-zZlyse1m1NECY3ryPtkst4U/0wCiKcI4ZW58RrhXgKucB3Y0C0w=
------END CERTIFICATE-----`
+	rawExpiration := time.Now().Unix() + 100
+	expiration := strconv.FormatInt(rawExpiration, 10)
 
-const testBadCert = `-----BEGIN CERTIFICATE-----
-THIS IS NOT A VALID CERT
------END CERTIFICATE-----`
+	data = map[string]interface{}{
+		"expiration": json.Number(expiration),
+		"certificate": "foobar",
+	}
 
-func TestDurationFromCert(t *testing.T) {
-	t.Parallel()
-
-	dur := durationFromCert(testGoodCert)
-
-	// 10 days in seconds
-	assert.Equal(t, 864000, dur)
-
-	dur = durationFromCert(testBadCert)
-
-	// Negative duration means an invalid cert
-	assert.Equal(t, -1, dur)
+	nonRenewableCert := Secret{LeaseDuration: 100, Data: data}
+	nonRenewableCertDur := leaseCheckWait(&nonRenewableCert).Seconds()
+	if nonRenewableCertDur < 85 || nonRenewableCertDur > 95 {
+		t.Fatalf("non renewable certificate duration is not within 85%% to 95%%: %f", nonRenewableCertDur)
+	}
 }


### PR DESCRIPTION
Vault adds 30 seconds to pad `NotBefore` (configurable) field for certificates issued by the PKI secret engine.  This pad compensates for clockskew.  

An issue I'm seeing with rendering certificates is Consul Template calculates the sleep time using  `cert.NotAfter - cert.NotBefore` of the certificate and configures the read loop for 85-95% of that value, which has the padding included.  In some situations, specifically when TTL is low,  the certificate expires before the application serving it has time to react.

This PR changes Consul Template to instead use the `expiration` value sent along with the certificates.  This means no cert inspection is required and we can do our calculations based on `expiration - time.Now`.  This will give us a better duration to wait.

If the client has significant clockskew and requested certificates have a low TTL (maybe ~1m), this could still result in rendering new certs after the cert has already expired.  As TTL grows, though, this issue quickly goes away.

This logic only applies to certificates that do not have a lease (`generate_lease=false` is the default).  Leased certs use a different code path and renew instead of updating.