### PR TITLE
Fix reading Vault KVv2 secrets metadata

### DIFF
--- a/dependency/vault_common.go
+++ b/dependency/vault_common.go
@@ -336,12 +336,15 @@ func addPrefixToVKVPath(p, mountPath, apiPrefix string) string {
 		return path.Join(mountPath, apiPrefix)
 	default:
 		p = strings.TrimPrefix(p, mountPath)
-		// Don't add /data/ to the path if it's been added manually.
+
+		// Add trailing slash if doesn't already exist to prefix
 		apiPathPrefix := apiPrefix
 		if !strings.HasSuffix(apiPrefix, "/") {
 			apiPathPrefix += "/"
 		}
-		if strings.HasPrefix(p, apiPathPrefix) {
+
+		// Only add prefix to the path if neither /<prefix>/ or /metadata/ are present.
+		if strings.HasPrefix(p, apiPathPrefix) || strings.HasPrefix(p, "metadata/") {
 			return path.Join(mountPath, p)
 		}
 		return path.Join(mountPath, apiPrefix, p)

--- a/dependency/vault_common.go
+++ b/dependency/vault_common.go
@@ -3,8 +3,6 @@ package dependency
 import (
 	"log"
 	"math/rand"
-	"path"
-	"strings"
 	"time"
 
 	"encoding/json"
@@ -328,25 +326,4 @@ func isKVv2(client *api.Client, path string) (string, bool, error) {
 	}
 
 	return mountPath, false, nil
-}
-
-func addPrefixToVKVPath(p, mountPath, apiPrefix string) string {
-	switch {
-	case p == mountPath, p == strings.TrimSuffix(mountPath, "/"):
-		return path.Join(mountPath, apiPrefix)
-	default:
-		p = strings.TrimPrefix(p, mountPath)
-
-		// Add trailing slash if doesn't already exist to prefix
-		apiPathPrefix := apiPrefix
-		if !strings.HasSuffix(apiPrefix, "/") {
-			apiPathPrefix += "/"
-		}
-
-		// Only add prefix to the path if neither /<prefix>/ or /metadata/ are present.
-		if strings.HasPrefix(p, apiPathPrefix) || strings.HasPrefix(p, "metadata/") {
-			return path.Join(mountPath, p)
-		}
-		return path.Join(mountPath, apiPrefix, p)
-	}
 }

--- a/dependency/vault_common_test.go
+++ b/dependency/vault_common_test.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func init() {
@@ -62,5 +64,72 @@ func TestVaultRenewDuration(t *testing.T) {
 	nonRenewableCertDur := leaseCheckWait(&nonRenewableCert).Seconds()
 	if nonRenewableCertDur < 85 || nonRenewableCertDur > 95 {
 		t.Fatalf("non renewable certificate duration is not within 85%% to 95%%: %f", nonRenewableCertDur)
+	}
+}
+
+func TestAddPrefixToVKVPath(t *testing.T) {
+	cases := []struct {
+		name      string
+		path      string
+		mountPath string
+		expected  string
+	}{
+		{
+			"full path",
+			"secret/data/foo/bar",
+			"secret/",
+			"secret/data/foo/bar",
+		}, {
+			"data prefix added",
+			"secret/foo/bar",
+			"secret/",
+			"secret/data/foo/bar",
+		}, {
+			"full path with data* in subpath",
+			"secret/data/datafoo/bar",
+			"secret/",
+			"secret/data/datafoo/bar",
+		}, {
+			"prefix added with data* in subpath",
+			"secret/datafoo/bar",
+			"secret/",
+			"secret/data/datafoo/bar",
+		}, {
+			"prefix added with *data in subpath",
+			"secret/foodata/foo/bar",
+			"secret/",
+			"secret/data/foodata/foo/bar",
+		}, {
+			"prefix not added to metadata",
+			"secret/metadata/foo/bar",
+			"secret/",
+			"secret/metadata/foo/bar",
+		}, {
+			"prefix added with metadata* in subpath",
+			"secret/metadatafoo/foo/bar",
+			"secret/",
+			"secret/data/metadatafoo/foo/bar",
+		}, {
+			"prefix added with *metadata in subpath",
+			"secret/foometadata/foo/bar",
+			"secret/",
+			"secret/data/foometadata/foo/bar",
+		}, {
+			"prefix added to mount path",
+			"secret/",
+			"secret/",
+			"secret/data",
+		}, {
+			"prefix added to mount path not exact match",
+			"secret",
+			"secret/",
+			"secret/data",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := addPrefixToVKVPath(tc.path, tc.mountPath, "data")
+			assert.Equal(t, tc.expected, actual)
+		})
 	}
 }

--- a/dependency/vault_common_test.go
+++ b/dependency/vault_common_test.go
@@ -5,8 +5,6 @@ import (
 	"strconv"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func init() {
@@ -64,72 +62,5 @@ func TestVaultRenewDuration(t *testing.T) {
 	nonRenewableCertDur := leaseCheckWait(&nonRenewableCert).Seconds()
 	if nonRenewableCertDur < 85 || nonRenewableCertDur > 95 {
 		t.Fatalf("non renewable certificate duration is not within 85%% to 95%%: %f", nonRenewableCertDur)
-	}
-}
-
-func TestAddPrefixToVKVPath(t *testing.T) {
-	cases := []struct {
-		name      string
-		path      string
-		mountPath string
-		expected  string
-	}{
-		{
-			"full path",
-			"secret/data/foo/bar",
-			"secret/",
-			"secret/data/foo/bar",
-		}, {
-			"data prefix added",
-			"secret/foo/bar",
-			"secret/",
-			"secret/data/foo/bar",
-		}, {
-			"full path with data* in subpath",
-			"secret/data/datafoo/bar",
-			"secret/",
-			"secret/data/datafoo/bar",
-		}, {
-			"prefix added with data* in subpath",
-			"secret/datafoo/bar",
-			"secret/",
-			"secret/data/datafoo/bar",
-		}, {
-			"prefix added with *data in subpath",
-			"secret/foodata/foo/bar",
-			"secret/",
-			"secret/data/foodata/foo/bar",
-		}, {
-			"prefix not added to metadata",
-			"secret/metadata/foo/bar",
-			"secret/",
-			"secret/metadata/foo/bar",
-		}, {
-			"prefix added with metadata* in subpath",
-			"secret/metadatafoo/foo/bar",
-			"secret/",
-			"secret/data/metadatafoo/foo/bar",
-		}, {
-			"prefix added with *metadata in subpath",
-			"secret/foometadata/foo/bar",
-			"secret/",
-			"secret/data/foometadata/foo/bar",
-		}, {
-			"prefix added to mount path",
-			"secret/",
-			"secret/",
-			"secret/data",
-		}, {
-			"prefix added to mount path not exact match",
-			"secret",
-			"secret/",
-			"secret/data",
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			actual := addPrefixToVKVPath(tc.path, tc.mountPath, "data")
-			assert.Equal(t, tc.expected, actual)
-		})
 	}
 }

--- a/dependency/vault_read.go
+++ b/dependency/vault_read.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 
@@ -145,7 +146,7 @@ func (d *VaultReadQuery) readSecret(clients *ClientSet, opts *QueryOptions) (*ap
 			isKVv2 = false
 			d.secretPath = d.rawPath
 		} else if isKVv2 {
-			d.secretPath = addPrefixToVKVPath(d.rawPath, mountPath, "data")
+			d.secretPath = shimKVv2Path(d.rawPath, mountPath)
 		} else {
 			d.secretPath = d.rawPath
 		}
@@ -175,4 +176,22 @@ func deletedKVv2(s *api.Secret) bool {
 		return md["deletion_time"] != ""
 	}
 	return false
+}
+
+// shimKVv2Path aligns the supported legacy path to KV v2 specs by inserting
+// /data/ into the path for reading secrets. Paths for metadata are not modified.
+func shimKVv2Path(rawPath, mountPath string) string {
+	switch {
+	case rawPath == mountPath, rawPath == strings.TrimSuffix(mountPath, "/"):
+		return path.Join(mountPath, "data")
+	default:
+		p := strings.TrimPrefix(rawPath, mountPath)
+
+		// Only add /data/ prefix to the path if neither /data/ or /metadata/ are
+		// present.
+		if strings.HasPrefix(p, "data/") || strings.HasPrefix(p, "metadata/") {
+			return rawPath
+		}
+		return path.Join(mountPath, "data", p)
+	}
 }

--- a/dependency/vault_read_test.go
+++ b/dependency/vault_read_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/vault/api"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewVaultReadQuery(t *testing.T) {
@@ -397,6 +398,18 @@ func TestVaultReadQuery_Fetch_KVv2(t *testing.T) {
 			assert.Equal(t, tc.exp, act)
 		})
 	}
+
+	t.Run("read_metadata", func(t *testing.T) {
+		d, err := NewVaultReadQuery(secretsPath + "/metadata/foo/bar")
+		require.NoError(t, err)
+
+		act, _, err := d.Fetch(clients, nil)
+		require.NoError(t, err)
+		require.NotNil(t, act)
+
+		versions := act.(*Secret).Data["versions"]
+		assert.Len(t, versions, 2)
+	})
 
 	t.Run("read_deleted", func(t *testing.T) {
 		// only needed for KVv2 as KVv1 doesn't have metadata

--- a/dependency/vault_read_test.go
+++ b/dependency/vault_read_test.go
@@ -664,3 +664,70 @@ func TestVaultReadQuery_String(t *testing.T) {
 		})
 	}
 }
+
+func TestShimKVv2Path(t *testing.T) {
+	cases := []struct {
+		name      string
+		path      string
+		mountPath string
+		expected  string
+	}{
+		{
+			"full path",
+			"secret/data/foo/bar",
+			"secret/",
+			"secret/data/foo/bar",
+		}, {
+			"data prefix added",
+			"secret/foo/bar",
+			"secret/",
+			"secret/data/foo/bar",
+		}, {
+			"full path with data* in subpath",
+			"secret/data/datafoo/bar",
+			"secret/",
+			"secret/data/datafoo/bar",
+		}, {
+			"prefix added with data* in subpath",
+			"secret/datafoo/bar",
+			"secret/",
+			"secret/data/datafoo/bar",
+		}, {
+			"prefix added with *data in subpath",
+			"secret/foodata/foo/bar",
+			"secret/",
+			"secret/data/foodata/foo/bar",
+		}, {
+			"prefix not added to metadata",
+			"secret/metadata/foo/bar",
+			"secret/",
+			"secret/metadata/foo/bar",
+		}, {
+			"prefix added with metadata* in subpath",
+			"secret/metadatafoo/foo/bar",
+			"secret/",
+			"secret/data/metadatafoo/foo/bar",
+		}, {
+			"prefix added with *metadata in subpath",
+			"secret/foometadata/foo/bar",
+			"secret/",
+			"secret/data/foometadata/foo/bar",
+		}, {
+			"prefix added to mount path",
+			"secret/",
+			"secret/",
+			"secret/data",
+		}, {
+			"prefix added to mount path not exact match",
+			"secret",
+			"secret/",
+			"secret/data",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := shimKVv2Path(tc.path, tc.mountPath)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
Fixes reading Vault KVv2 secrets metadata by not prepending `/data/` path.

<details>
  <summary>Test results before change</summary>

```
=== RUN   TestVaultReadQuery_Fetch_KVv2/read_metadata
    vault_read_test.go:407: 
        	Error Trace:	vault_read_test.go:407
        	Error:      	Received unexpected error:
        	            	no secret exists at read_fetch_v2/data/metadata/foo/bar
        	            	vault.read(read_fetch_v2/metadata/foo/bar)
        	            	github.com/hashicorp/consul-template/dependency.(*VaultReadQuery).Fetch
        	            		/Users/kngo/dev/hashicorp/consul-template/dependency/vault_read.go:80
        	            	github.com/hashicorp/consul-template/dependency.TestVaultReadQuery_Fetch_KVv2.func2
        	            		/Users/kngo/dev/hashicorp/consul-template/dependency/vault_read_test.go:406
        	            	testing.tRunner
        	            		/usr/local/go/src/testing/testing.go:1039
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1373
        	Test:       	TestVaultReadQuery_Fetch_KVv2/read_metadata
```

</details>

Resolves #1396 