### PR TITLE
switch to hashicorp docker mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,13 @@ jobs:
       CONSUL_VERSION: 1.8.0
       VAULT_VERSION: 1.4.2
     docker:
-      - image: circleci/golang:latest
+      - image: docker.mirror.hashicorp.services/circleci/golang:latest
     working_directory: /go/src/github.com/hashicorp/consul-template
     steps:
       - checkout
       - restore_cache:
           keys:
-          - ct-modcache-v1-{{ checksum "go.mod" }}
+            - ct-modcache-v1-{{ checksum "go.mod" }}
       - run: |
           curl -sLo consul.zip https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip
           unzip consul.zip
@@ -26,5 +26,4 @@ jobs:
       - save_cache:
           key: ct-modcache-v1-{{ checksum "go.mod" }}
           paths:
-          - /go/pkg/mod
-
+            - /go/pkg/mod


### PR DESCRIPTION
I only modified the CI config. I didn't modify anything in `docker/*/Dockerfile` since those are usually run locally and you need credentials to push anyway so you will be authenticated to pull from Dockerhub. 