### PR TITLE
Allow external FuncMaps

### DIFF
--- a/config/template.go
+++ b/config/template.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"text/template"
 	"time"
 )
 
@@ -76,6 +77,12 @@ type TemplateConfig struct {
 	LeftDelim  *string `mapstructure:"left_delimiter"`
 	RightDelim *string `mapstructure:"right_delimiter"`
 
+	// FuncMap is a map of external functions that this template is
+	// permitted to run. Allows users to add functions to the library
+	// and selectively opaque existing ones. Omitted from json output
+	// to prevent errors when the configuration is marshalled for printing.
+	FuncMap template.FuncMap `json:"-"`
+
 	// FunctionDenylist is a list of functions that this template is not
 	// permitted to run.
 	FunctionDenylist []string `mapstructure:"function_denylist"`
@@ -96,8 +103,9 @@ type TemplateConfig struct {
 // default values.
 func DefaultTemplateConfig() *TemplateConfig {
 	return &TemplateConfig{
-		Exec: DefaultExecConfig(),
-		Wait: DefaultWaitConfig(),
+		Exec:    DefaultExecConfig(),
+		Wait:    DefaultWaitConfig(),
+		FuncMap: template.FuncMap{},
 	}
 }
 
@@ -137,6 +145,10 @@ func (c *TemplateConfig) Copy() *TemplateConfig {
 
 	o.LeftDelim = c.LeftDelim
 	o.RightDelim = c.RightDelim
+
+	for key, fun := range c.FuncMap {
+		o.FuncMap[key] = fun
+	}
 
 	for _, fun := range c.FunctionDenylist {
 		o.FunctionDenylist = append(o.FunctionDenylist, fun)
@@ -221,6 +233,10 @@ func (c *TemplateConfig) Merge(o *TemplateConfig) *TemplateConfig {
 		r.RightDelim = o.RightDelim
 	}
 
+	for key, fun := range o.FuncMap {
+		r.FuncMap[key] = fun
+	}
+
 	for _, fun := range o.FunctionDenylist {
 		r.FunctionDenylist = append(r.FunctionDenylist, fun)
 	}
@@ -303,6 +319,10 @@ func (c *TemplateConfig) Finalize() {
 
 	if c.SandboxPath == nil {
 		c.SandboxPath = String("")
+	}
+
+	if c.FuncMap == nil {
+		c.FuncMap = template.FuncMap{}
 	}
 
 	if c.FunctionDenylist == nil && c.FunctionDenylistDeprecated == nil {

--- a/config/template_test.go
+++ b/config/template_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"text/template"
 	"time"
 )
 
@@ -453,6 +454,7 @@ func TestTemplateConfig_Finalize(t *testing.T) {
 				},
 				LeftDelim:                  String(""),
 				RightDelim:                 String(""),
+				FuncMap:                    template.FuncMap{},
 				FunctionDenylist:           []string{},
 				FunctionDenylistDeprecated: []string{},
 				SandboxPath:                String(""),

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -889,6 +889,7 @@ func (r *Runner) init() error {
 			ErrMissingKey:    config.BoolVal(ctmpl.ErrMissingKey),
 			LeftDelim:        leftDelim,
 			RightDelim:       rightDelim,
+			FuncMap:          ctmpl.FuncMap,
 			FunctionDenylist: ctmpl.FunctionDenylist,
 			SandboxPath:      config.StringVal(ctmpl.SandboxPath),
 		})

--- a/template/template.go
+++ b/template/template.go
@@ -46,6 +46,11 @@ type Template struct {
 	// is indexed with a key that does not exist.
 	errMissingKey bool
 
+	// FuncMap is a map of external functions that this template is
+	// permitted to run. Allows users to add functions to the library
+	// and selectively opaque existing ones.
+	funcMap template.FuncMap
+
 	// functionDenylist are functions not permitted to be executed
 	// when we render this template
 	functionDenylist []string
@@ -71,6 +76,11 @@ type NewTemplateInput struct {
 	// LeftDelim and RightDelim are the template delimiters.
 	LeftDelim  string
 	RightDelim string
+
+	// FuncMap is a map of external functions that this template is
+	// permitted to run. Allows users to add functions to the library
+	// and selectively opaque existing ones.
+	FuncMap template.FuncMap
 
 	// FunctionDenylist are functions not permitted to be executed
 	// when we render this template
@@ -104,6 +114,7 @@ func NewTemplate(i *NewTemplateInput) (*Template, error) {
 	t.leftDelim = i.LeftDelim
 	t.rightDelim = i.RightDelim
 	t.errMissingKey = i.ErrMissingKey
+	t.funcMap = i.FuncMap
 	t.functionDenylist = i.FunctionDenylist
 	t.sandboxPath = i.SandboxPath
 
@@ -183,6 +194,8 @@ func (t *Template) Execute(i *ExecuteInput) (*ExecuteResult, error) {
 		functionDenylist: t.functionDenylist,
 		sandboxPath:      t.sandboxPath,
 	}))
+
+	tmpl.Funcs(t.funcMap)
 
 	if t.errMissingKey {
 		tmpl.Option("missingkey=error")

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -1770,6 +1771,22 @@ func TestTemplate_Execute(t *testing.T) {
 				}(),
 			},
 			"1.2.3.45.6.7.8",
+			false,
+		},
+		{
+			"external_func",
+			&NewTemplateInput{
+				Contents: `{{ toUpTest "abCba" }}`,
+				FuncMap: map[string]interface{}{
+					"toUpTest": func(inString string) string {
+						return strings.ToUpper(inString)
+					},
+				},
+			},
+			&ExecuteInput{
+				Brain: NewBrain(),
+			},
+			"ABCBA",
 			false,
 		},
 	}


### PR DESCRIPTION
Since Nomad uses CT as its underlying template engine, it would be nice to be able to pass functions from Nomad itself into the template configurations that it generates.  I thought exposing a route to inject functions for applications that use CT internally might be a good middle ground to prevent even more template application sprawl.

This would allow Nomad to inject purpose-built templating functions into the rendering pipeline without having to make additional changes to consul-template.

Custom Functions could also be used to simplify the FunctionBlockList by allowing someone to implement their own no-op function to opaque an implementation provided in CT.

This could let us resolve #1312 and #1406 by allowing them to be passed into CT from Nomad using this scheme.