### PR TITLE
fix: clarify kvv2 .data value is not a key reference, but a kvv2 syntax change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1040,7 +1040,7 @@ To access a versioned secret value (for the K/V version 2 backend):
 ```
 
 When omitting the `?version` parameter, the latest version of the secret will be
-fetched. Note the nested `.Data.data` syntax when referencing the secret value.
+fetched. Note the nested `.Data.data` syntax when referencing the secret value, the second `.data` value is not specific to a key, it is necessary syntax to reference a K/V version 2 value.
 For more information about using the K/V v2 backend, see the
 [Vault Documentation](https://www.vaultproject.io/docs/secrets/kv/kv-v2.html).
 

--- a/README.md
+++ b/README.md
@@ -1041,6 +1041,7 @@ To access a versioned secret value (for the K/V version 2 backend):
 
 When omitting the `?version` parameter, the latest version of the secret will be
 fetched. Note the nested `.Data.data` syntax when referencing the secret value, the second `.data` value is not specific to a key, it is necessary syntax to reference a K/V version 2 value.
+
 For more information about using the K/V v2 backend, see the
 [Vault Documentation](https://www.vaultproject.io/docs/secrets/kv/kv-v2.html).
 


### PR DESCRIPTION
Putting this readme change in, the current note wasn't explicit enough for me to realize that the extra `.data` value was syntax and not referencing something key related while reading through the docs.