### PR TITLE
version (-v) output should go to stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Upcoming
 
+## v0.25.2 (Feb ??, 2021)
+
+BREAKING CHANGES:
+
+* version output from -v/-version should go to STDOUT (not STDERR)[[GH-1452](https://github.com/hashicorp/consul-template/issues/1452)]
+
+
 ## v0.25.1 (Jul 27, 2020)
 
 IMPROVEMENTS:

--- a/cli.go
+++ b/cli.go
@@ -98,7 +98,7 @@ func (cli *CLI) Run(args []string) int {
 	// print their version on stderr anyway.
 	if isVersion {
 		log.Printf("[DEBUG] (cli) version flag was given, exiting now")
-		fmt.Fprintf(cli.errStream, "%s\n", version.HumanVersion)
+		fmt.Fprintf(cli.outStream, "%s\n", version.HumanVersion)
 		return ExitCodeOK
 	}
 


### PR DESCRIPTION
Fixes #1452

