### PR TITLE
Allow setting dedup prefix on cli

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -326,6 +326,11 @@ func (cli *CLI) ParseFlags(args []string) (
 	}), "dedup", "")
 
 	flags.Var((funcVar)(func(s string) error {
+		c.Dedup.Prefix = config.String(s)
+		return nil
+	}), "dedup-prefix", "")
+
+	flags.Var((funcVar)(func(s string) error {
 		c.DefaultDelims.Left = config.String(s)
 		return nil
 	}), "default-left-delimiter", "")
@@ -687,6 +692,10 @@ Options:
   -dedup
       Enable de-duplication mode - reduces load on Consul when many instances of
       Consul Template are rendering a common template
+
+  -dedup-prefix=<string>
+      Set the prefix to the path in Consul's KV store where de-duplication
+      templates will be pre-rendered and stored
 
   -default-left-delimiter
       The default left delimiter for templating

--- a/cli_test.go
+++ b/cli_test.go
@@ -290,6 +290,16 @@ func TestCLI_ParseFlags(t *testing.T) {
 			false,
 		},
 		{
+			"dedup-prefix",
+			[]string{"-dedup-prefix", "test/prefix"},
+			&config.Config{
+				Dedup: &config.DedupConfig{
+					Prefix: config.String("test/prefix"),
+				},
+			},
+			false,
+		},
+		{
 			"exec",
 			[]string{"-exec", "command"},
 			&config.Config{


### PR DESCRIPTION
Allows for setting the dedup prefix on the command line. This can be nice if you want to set different prefixes at runtime without having to template the consul-template config file.