### PR TITLE
fixes #1462, 'secrets' template function issue on Vault kv-v2 secrets engines

### DIFF
--- a/dependency/vault_write.go
+++ b/dependency/vault_write.go
@@ -157,14 +157,15 @@ func (d *VaultWriteQuery) writeSecret(clients *ClientSet, opts *QueryOptions) (*
 		RawQuery: opts.String(),
 	})
 
+	path := d.path
 	data := d.data
-
-	_, isv2, _ := isKVv2(clients.Vault(), d.path)
+	mountPath, isv2, _ := isKVv2(clients.Vault(), path)
 	if isv2 {
+		path = shimKVv2Path(path, mountPath)
 		data = map[string]interface{}{"data": d.data}
 	}
 
-	vaultSecret, err := clients.Vault().Logical().Write(d.path, data)
+	vaultSecret, err := clients.Vault().Logical().Write(path, data)
 	if err != nil {
 		return nil, errors.Wrap(err, d.String())
 	}

--- a/dependency/vault_write_test.go
+++ b/dependency/vault_write_test.go
@@ -141,6 +141,38 @@ func TestVaultWriteSecretKV_Fetch(t *testing.T) {
 		}
 		assert.Equal(t, exp, act.Data["data"])
 	})
+
+	// VaultWriteQuery should work properly on kv-v2 secrets engines if /data/
+	// is not present on secret path
+	t.Run("write_secret_v2_without_data_in_path", func(t *testing.T) {
+		clients, vault := testVaultServer(t, "write_secret_v2_without_data_in_path", "2")
+		secretsPath := vault.secretsPath
+
+		path := secretsPath + "/foo"
+		exp := map[string]interface{}{
+			"bar": "zed",
+		}
+
+		wq, err := NewVaultWriteQuery(path, exp)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, _, err = wq.Fetch(clients, &QueryOptions{})
+		if err != nil {
+			fmt.Println(err)
+		}
+
+		rq, err := NewVaultReadQuery(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		act, err := rq.readSecret(clients, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, exp, act.Data["data"])
+	})
 }
 
 func TestVaultWriteQuery_Fetch(t *testing.T) {

--- a/docs/templating-language.md
+++ b/docs/templating-language.md
@@ -559,7 +559,9 @@ To iterate and list over every secret in the generic secret backend in Vault:
 {{ with secret (printf "secret/%s" .) }}{{ range $k, $v := .Data }}
 {{ $k }}: {{ $v }}
 {{ end }}{{ end }}{{ end }}
-```
+``` 
+
+`.Data` should be replaced with `.Data.data` for KV-V2 secrets engines.
 
 You should probably never do this.
 


### PR DESCRIPTION
Changed `secrets` template function behavior for Vault kv-v2 secrets engines. Added behavior similar to [vault cli kv list command](https://github.com/hashicorp/vault/blob/master/command/kv_list.go#L86), which adds `/metadata/` to secret path if secrets engine version is 2. 

Fixes #1275 
Fixes #1274