### PR TITLE
Removed special cases for ARM build in Makefile fixes #1404

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,15 +53,8 @@ define make-xc-target
 		@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT} (excluded)"
   else
 		@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT}"
-		case "$2" in \
-			arm) export CGO_ENABLED="1" ; \
-				  export GOARM=6 \
-				  export CC="arm-linux-gnueabihf-gcc" ;; \
-			arm64) export CGO_ENABLED="1" ; \
-				  export CC="aarch64-linux-gnu-gcc" ;; \
-			*) export CGO_ENABLED="0" ;; \
-		esac ; \
 		env \
+			CGO_ENABLED="0" \
 			GOOS="${1}" \
 			GOARCH="${2}" \
 			go build \


### PR DESCRIPTION
Removes workaround with using CGO_ENABLED for ARM builds 
Fixes #1404 