### PR TITLE
make connect and health service ids different

### DIFF
--- a/dependency/health_service.go
+++ b/dependency/health_service.go
@@ -237,6 +237,9 @@ func (d *HealthServiceQuery) String() string {
 	if len(d.filters) > 0 {
 		name = name + "|" + strings.Join(d.filters, ",")
 	}
+	if d.connect {
+		return fmt.Sprintf("health.connect(%s)", name)
+	}
 	return fmt.Sprintf("health.service(%s)", name)
 }
 

--- a/dependency/health_service_test.go
+++ b/dependency/health_service_test.go
@@ -463,3 +463,37 @@ func TestHealthServiceQuery_String(t *testing.T) {
 		})
 	}
 }
+
+func TestHealthServiceQueryConnect_String(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		fact func(string) (*HealthServiceQuery, error)
+		in   string
+		exp  string
+	}{
+		{
+			"name",
+			NewHealthServiceQuery,
+			"name",
+			"health.service(name|passing)",
+		},
+		{
+			"name",
+			NewHealthConnectQuery,
+			"name",
+			"health.connect(name|passing)",
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			d, err := tc.fact(tc.in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, tc.exp, d.String())
+		})
+	}
+}


### PR DESCRIPTION
The IDs need to be different as they are used as the cache keys and
using the same ID means `connect` and `service` would overwrite each
other if both used. (this is bad)

The `connect` function re-uses the health `service` code as it is
identical except for an additional option. When adding connect the ID
was unintentially left the same, it should be different.

Fixes #1458