### PR TITLE
fix data race issue setting vault's default lease

### DIFF
--- a/dependency/vault_common.go
+++ b/dependency/vault_common.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/vault/api"
@@ -12,7 +13,8 @@ import (
 
 var (
 	// VaultDefaultLeaseDuration is the default lease duration in seconds.
-	VaultDefaultLeaseDuration time.Duration
+	VaultDefaultLeaseDuration     time.Duration
+	onceVaultDefaultLeaseDuration sync.Once
 )
 
 // Secret is the structure returned for every secret within Vault.
@@ -340,4 +342,12 @@ func isKVv2(client *api.Client, path string) (string, bool, error) {
 	}
 
 	return mountPath, false, nil
+}
+
+// Make sure to only set VaultDefaultLeaseDuration once
+func SetVaultDefaultLeaseDuration(t time.Duration) {
+	set := func() {
+		VaultDefaultLeaseDuration = t
+	}
+	onceVaultDefaultLeaseDuration.Do(set)
 }

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -852,8 +852,7 @@ func (r *Runner) init() error {
 	}
 	log.Printf("[DEBUG] (runner) final config: %s", result)
 
-	//Set VaultDefaultLeaseDuration
-	dep.VaultDefaultLeaseDuration = config.TimeDurationVal(r.config.Vault.DefaultLeaseDuration)
+	dep.SetVaultDefaultLeaseDuration(config.TimeDurationVal(r.config.Vault.DefaultLeaseDuration))
 
 	// Create the clientset
 	clients, err := newClientSet(r.config)


### PR DESCRIPTION
It is using a module/global variable at the moment and race tests are
normally run, so it was missed during review. This is the common
sync.Once pattern for this sort of thing that fixes the race.