### PR TITLE
don't send runtime signals to child process

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -166,6 +166,8 @@ func (cli *CLI) Run(args []string) int {
 				//
 				// Also, the reason we do a lookup instead of a direct syscall.SIGCHLD
 				// is because that isn't defined on Windows.
+			case signals.RuntimeSig:
+				// ignore these as the runtime uses them with the scheduler
 			default:
 				// Propagate the signal to the child process
 				runner.Signal(s)

--- a/signals/signals_unix.go
+++ b/signals/signals_unix.go
@@ -7,6 +7,10 @@ import (
 	"syscall"
 )
 
+// RuntimeSig is set to SIGURG, a signal used by the runtime on *nix systems to
+// manage pre-emptive scheduling.
+const RuntimeSig = syscall.SIGURG
+
 var SignalLookup = map[string]os.Signal{
 	"SIGABRT":  syscall.SIGABRT,
 	"SIGALRM":  syscall.SIGALRM,

--- a/signals/signals_windows.go
+++ b/signals/signals_windows.go
@@ -7,6 +7,9 @@ import (
 	"syscall"
 )
 
+// RuntimeSig is set to nil on windows as it doesn't support the signal (SIGURG)
+const RuntimeSig = nil
+
 var SignalLookup = map[string]os.Signal{
 	"SIGABRT": syscall.SIGABRT,
 	"SIGALRM": syscall.SIGALRM,


### PR DESCRIPTION
Go started using SIGURG as a signal used by the runtime to trigger pre-emptive interruptions for parallel execution. This filters them out from being forwarded to the child process (quieting the logging and a bit of overhead).

Fixes #1486