### PR TITLE
Add setpgid for all called commands

### DIFF
--- a/child/child.go
+++ b/child/child.go
@@ -65,6 +65,9 @@ type Child struct {
 	stopLock sync.RWMutex
 	stopCh   chan struct{}
 	stopped  bool
+
+	// whether to set process group id or not (default on)
+	setpgid bool
 }
 
 // NewInput is input to the NewChild function.
@@ -135,6 +138,7 @@ func New(i *NewInput) (*Child, error) {
 		killTimeout:  i.KillTimeout,
 		splay:        i.Splay,
 		stopCh:       make(chan struct{}, 1),
+		setpgid:      true,
 	}
 
 	return child, nil
@@ -264,6 +268,7 @@ func (c *Child) start() error {
 	cmd.Stdout = c.stdout
 	cmd.Stderr = c.stderr
 	cmd.Env = c.env
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: c.setpgid}
 	if err := cmd.Start(); err != nil {
 		return err
 	}
@@ -353,7 +358,18 @@ func (c *Child) signal(s os.Signal) error {
 	if !c.running() {
 		return nil
 	}
-	return c.cmd.Process.Signal(s)
+
+	sig, ok := s.(syscall.Signal)
+	if !ok {
+		return fmt.Errorf("bad signal: %s", s)
+	}
+	pid := c.cmd.Process.Pid
+	if c.setpgid {
+		// kill takes negative pid to indicate that you want to use gpid
+		pid = -(pid)
+	}
+	// kill is syscall's only signal API
+	return syscall.Kill(pid, sig)
 }
 
 func (c *Child) reload() error {
@@ -381,32 +397,38 @@ func (c *Child) kill(immediately bool) {
 		}
 	}
 
-	exited := false
-	process := c.cmd.Process
-
-	if c.killSignal != nil {
-		if err := process.Signal(c.killSignal); err == nil {
-			// Wait a few seconds for it to exit
-			killCh := make(chan struct{}, 1)
-			go func() {
-				defer close(killCh)
-				process.Wait()
-			}()
-
-			select {
-			case <-c.stopCh:
-			case <-killCh:
-				exited = true
-			case <-time.After(c.killTimeout):
-			}
+	var exited bool
+	defer func() {
+		if !exited {
+			c.cmd.Process.Kill()
 		}
+		c.cmd = nil
+	}()
+
+	if c.killSignal == nil {
+		return
 	}
 
-	if !exited {
-		process.Kill()
+	if err := c.signal(c.killSignal); err != nil {
+		log.Printf("[ERR] (child) Kill failed: %s", err)
+		if err == syscall.ESRCH {
+			exited = true // ESRCH == no such process, ie. already exited
+		}
+		return
 	}
 
-	c.cmd = nil
+	killCh := make(chan struct{}, 1)
+	go func() {
+		defer close(killCh)
+		c.cmd.Process.Wait()
+	}()
+
+	select {
+	case <-c.stopCh:
+	case <-killCh:
+		exited = true
+	case <-time.After(c.killTimeout):
+	}
 }
 
 func (c *Child) running() bool {

--- a/child/child_test.go
+++ b/child/child_test.go
@@ -455,3 +455,49 @@ func TestStop_childAlreadyDead(t *testing.T) {
 		t.Error("expected not to wait for splay")
 	}
 }
+
+func TestSetpgid(t *testing.T) {
+	t.Run("true", func(t *testing.T) {
+		c := testChild(t)
+		c.command = "sh"
+		c.args = []string{"-c", "while true; do sleep 0.2; done"}
+		// default, but to be explicit for the test
+		c.setpgid = true
+
+		if err := c.Start(); err != nil {
+			t.Fatal(err)
+		}
+		defer c.Stop()
+
+		// when setpgid is true, the pid and gpid should be the same
+		gpid, err := syscall.Getpgid(c.Pid())
+		if err != nil {
+			t.Fatal("Getpgid error:", err)
+		}
+
+		if c.Pid() != gpid {
+			t.Fatal("pid and gpid should match")
+		}
+	})
+	t.Run("false", func(t *testing.T) {
+		c := testChild(t)
+		c.command = "sh"
+		c.args = []string{"-c", "while true; do sleep 0.2; done"}
+		c.setpgid = false
+
+		if err := c.Start(); err != nil {
+			t.Fatal(err)
+		}
+		defer c.Stop()
+
+		// when setpgid is true, the pid and gpid should be the same
+		gpid, err := syscall.Getpgid(c.Pid())
+		if err != nil {
+			t.Fatal("Getpgid error:", err)
+		}
+
+		if c.Pid() == gpid {
+			t.Fatal("pid and gpid should NOT match")
+		}
+	})
+}


### PR DESCRIPTION
Need to make sure signals are sent to all processes as sub-shells interfere with signal propagation. Using Setpgid to create a process group for the command and all it's subprocesses fixes this by allowing child to send the signals to the pgid, which thus gets sent to all processes in that group.

This is required for upcoming change to use sub-shells for all executed commands to eliminate need for shell parsing.

With this change it is always set to true and the pgid is always used to send signals to the process(es).

In the future it could be made configurable if needed.

Might be easier to review using the commits. The second commit is test cleanups and fixes where the first one contains the new code and tests.