### PR TITLE
replace shell parsing w/ direct shell call

### DIFF
--- a/manager/command-prep.go
+++ b/manager/command-prep.go
@@ -1,0 +1,12 @@
+package manager
+
+const whitespace = " \t\n\v\f\r"
+
+func prepCommand(command string) ([]string, error) {
+	if len(command) == 0 {
+		return []string{}, nil
+	}
+
+	cmd := []string{"sh", "-c", command}
+	return cmd, nil
+}

--- a/manager/command-prep_windows.go
+++ b/manager/command-prep_windows.go
@@ -1,0 +1,13 @@
+// +build windows
+
+package manager
+
+func prepCommand(command string) ([]string, error) {
+	switch {
+	case len(command) == 0:
+		return []string{}, nil
+	case len(strings.Fields(command)) > 1:
+		return cmd, fmt.Errorf("only single commands supported on windows")
+	}
+	return []string{command}, nil
+}

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -10,15 +10,16 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/hashicorp/consul-template/child"
 	"github.com/hashicorp/consul-template/config"
 	dep "github.com/hashicorp/consul-template/dependency"
 	"github.com/hashicorp/consul-template/renderer"
 	"github.com/hashicorp/consul-template/template"
 	"github.com/hashicorp/consul-template/watch"
+
 	multierror "github.com/hashicorp/go-multierror"
-	shellwords "github.com/mattn/go-shellwords"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -1151,7 +1152,7 @@ type spawnChildInput struct {
 // spawnChild spawns a child process with the given inputs and returns the
 // resulting child.
 func spawnChild(i *spawnChildInput) (*child.Child, error) {
-	args, err := parseCommand(i.Command)
+	args, err := prepCommand(i.Command)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed parsing command")
 	}
@@ -1176,14 +1177,6 @@ func spawnChild(i *spawnChildInput) (*child.Child, error) {
 		return nil, errors.Wrap(err, "child")
 	}
 	return child, nil
-}
-
-// parseCommand parses the shell command line into usable format
-func parseCommand(command string) ([]string, error) {
-	p := shellwords.NewParser()
-	p.ParseEnv = true
-	p.ParseBacktick = true
-	return p.Parse(command)
 }
 
 // quiescence is an internal representation of a single template's quiescence


### PR DESCRIPTION
Instead of trying to parse the shell command line into arguments for input to exec.Command this replaces that all with passing it to an 'sh -c' call. This will "fix" the wack-o-mole game of spot fixing issues that keep coming up with the shell parsing package.

Windows is handled separately (no 'sh') and is setup to only accept/run a single command.

The code changes are pretty small, bulked out a bit by the need to handle windows separately. Most of the code here are tests I added to try to exercise different cases mentioned in previously submitted issues.

Fixes #1482