### PR TITLE
Add transport section to configuration file

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -265,6 +265,25 @@ consul {
     # would be: 1s, 2s, 4s, 8s, 10s, 10s, ...
     max_backoff = "1m"
   }
+  
+  # This block configures tcp connection options
+  transport {
+    # This controls duration between two keepalive transmissions in idle condition.
+    dial_keep_alive = "10s"
+    
+    # This controls tcp timeout between retiries. If consul is down and retires
+    # are enabled consul-template will retry after dial_timeout.
+    dial_timeout = "10s"
+    
+    # This allows you to disable keep alive connections
+    disable_keep_alives = true
+    
+    # This controls amount of maximum idle connections. 
+    max_idle_conns_per_host = 100
+    
+    # This controls timeout for tls handshakes with consul.
+    tls_handshake_timeout = "30s"
+  }
 
   # This block configures the SSL options for connecting to the Consul server.
   ssl {


### PR DESCRIPTION
Add transport section to configuration file documentation.
This is not the best version of docs on transport section so I am open for any advices. But I personally do really want to see transport section documentation at least for dial_timeout, which is really important in some situations.