### PR TITLE
Fixed broken link in docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,7 +62,7 @@ $ consul-template \
 ```
 
 For more information on supervising, please see the
-[Consul Template Exec Mode documentation](caveats.md#exec-mode).
+[Consul Template Exec Mode documentation](modes.md#exec-mode).
 
 ## Configuration File
 


### PR DESCRIPTION
Fix broken link in `docs/configuration.md` for consul-template exec mode documentation.
