### PR TITLE
Allow setting user/group ownership of template output

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1026,6 +1026,48 @@ func TestParse(t *testing.T) {
 			false,
 		},
 		{
+			"template_uid",
+			`template {
+				uid = 1000
+			}`,
+			&Config{
+				Templates: &TemplateConfigs{
+					&TemplateConfig{
+						Uid: Int(1000),
+					},
+				},
+			},
+			false,
+		},
+		{
+			"template_gid",
+			`template {
+				gid = 1000
+			}`,
+			&Config{
+				Templates: &TemplateConfigs{
+					&TemplateConfig{
+						Gid: Int(1000),
+					},
+				},
+			},
+			false,
+		},
+		{
+			"template_uid_gid_default",
+			`template {
+			}`,
+			&Config{
+				Templates: &TemplateConfigs{
+					&TemplateConfig{
+						Uid: nil,
+						Gid: nil,
+					},
+				},
+			},
+			false,
+		},
+		{
 			"template_source",
 			`template {
 				source = "source"

--- a/config/template.go
+++ b/config/template.go
@@ -64,6 +64,20 @@ type TemplateConfig struct {
 	// secrets from Vault.
 	Perms *os.FileMode `mapstructure:"perms"`
 
+	// Uid is the numeric uid that will be set when creating the file on disk.
+	// Useful when simply setting Perms is not enough.
+	//
+	// Platform dependent: this doesn't work on Windows but it fails gracefully
+	// with a warning
+	Uid *int `mapstructure:"uid"`
+
+	// Gid is the numeric gid that will be set when creating the file on disk.
+	// Useful when simply setting Perms is not enough.
+	//
+	// Platform dependent: this doesn't work on Windows but it fails gracefully
+	// with a warning
+	Gid *int `mapstructure:"gid"`
+
 	// Source is the path on disk to the template contents to evaluate. Either
 	// this or Contents should be specified, but not both.
 	Source *string `mapstructure:"source"`

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -780,6 +780,8 @@ func (r *Runner) runTemplate(tmpl *template.Template, runCtx *templateRunCtx) (*
 			DryStream:      r.outStream,
 			Path:           config.StringVal(templateConfig.Destination),
 			Perms:          config.FileModeVal(templateConfig.Perms),
+			Uid:            templateConfig.Uid,
+			Gid:            templateConfig.Gid,
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "error rendering "+templateConfig.Display())

--- a/renderer/file_ownership.go
+++ b/renderer/file_ownership.go
@@ -1,0 +1,49 @@
+//go:build !windows
+// +build !windows
+
+package renderer
+
+import (
+	"os"
+	"syscall"
+)
+
+func getFileOwnership(path string) (*int, *int) {
+	file_info, err := os.Stat(path)
+
+	if err != nil {
+		return nil, nil
+	}
+
+	file_sys := file_info.Sys()
+	st := file_sys.(*syscall.Stat_t)
+	return intPtr(int(st.Uid)), intPtr(int(st.Gid))
+}
+
+func setFileOwnership(path string, uid, gid *int) error {
+	wantedUid := sanitizeUidGid(uid)
+	wantedGid := sanitizeUidGid(gid)
+	if wantedUid == -1 && wantedGid == -1 {
+		return nil //noop
+	}
+	return os.Chown(path, wantedUid, wantedGid)
+}
+
+func isChownNeeded(path string, uid, gid *int) bool {
+	wantedUid := sanitizeUidGid(uid)
+	wantedGid := sanitizeUidGid(gid)
+	if wantedUid == -1 && wantedGid == -1 {
+		return false
+	}
+
+	currUid, currGid := getFileOwnership(path)
+	return wantedUid != *currUid || wantedGid != *currGid
+}
+
+// sanitizeUidGid sanitizes the uid/gid so that can be an input for os.Chown
+func sanitizeUidGid(id *int) int {
+	if id == nil {
+		return -1
+	}
+	return *id
+}

--- a/renderer/file_ownership_windows.go
+++ b/renderer/file_ownership_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+// +build windows
+
+package renderer
+
+import (
+	"log"
+	"os"
+)
+
+func setFileOwnership(path string, uid, gid *int) error {
+	if uid != nil || gid != nil {
+		log.Printf("[WARN] (runner) cannot set uid/gid for rendered files on Windows")
+	}
+	return nil
+}
+
+func isChownNeeded(path string, wantedUid, wantedGid *int) bool {
+	return false
+}

--- a/renderer/file_ownership_windows.go
+++ b/renderer/file_ownership_windows.go
@@ -5,7 +5,6 @@ package renderer
 
 import (
 	"log"
-	"os"
 )
 
 func setFileOwnership(path string, uid, gid *int) error {

--- a/renderer/renderer_test.go
+++ b/renderer/renderer_test.go
@@ -315,3 +315,214 @@ func TestRender(t *testing.T) {
 		}
 	})
 }
+
+func TestRender_Chown(t *testing.T) {
+
+	// Can't change uid unless root, but can try
+	// changing the group id.
+	// setting Uid to -1 means no change
+	wantedUid := -1
+
+	//we enumerate the groups the current user (running the tests) belongs to
+	groups, err := os.Getgroups()
+	if err != nil {
+		t.Fatalf("getgroups: %s", err)
+	}
+	t.Log("groups: ", groups)
+
+	// we'll use the last group because we can assume it's not the default one
+	// for the current user (thinking about CI/CD).
+	// In order to make sure that this is tested properly we would have to
+	// preconfigure the environment and specify the gid here or (better) add
+	// the user to a group and leave this dynamic avoiding hardcoded values,
+	// worst case scenario, if the user belongs to a single group, these tests
+	// would not be testing the cange of ownership but only the fact that it doesn't
+	// fail unexpectedly
+	wantedGid := groups[0]
+
+	t.Run("sets-file-ownership-when-file-exists-same-content", func(t *testing.T) {
+
+		outDir, err := ioutil.TempDir("", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(outDir)
+		outFile, err := ioutil.TempFile(outDir, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		contents := []byte("first")
+		if _, err := outFile.Write(contents); err != nil {
+			t.Fatal(err)
+		}
+		path := outFile.Name()
+		if err = outFile.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		rr, err := Render(&RenderInput{
+			Path:     path,
+			Contents: contents,
+			Uid:      intPtr(wantedUid),
+			Gid:      intPtr(wantedGid),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		switch {
+		case rr.WouldRender && rr.DidRender: //we expect rerendering to disk here
+		default:
+			t.Fatalf("Bad render results; would: %v, did: %v",
+				rr.WouldRender, rr.DidRender)
+		}
+
+		gotUid, gotGid := getFileOwnership(path)
+		if *gotGid != wantedGid {
+			t.Fatalf("Bad render results; gotUid: %v, wantedGid: %v, gotGid: %v",
+				*gotUid, wantedGid, *gotGid)
+		}
+
+	})
+
+	t.Run("sets-file-ownership-when-file-exists-diff-content", func(t *testing.T) {
+
+		outDir, err := ioutil.TempDir("", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(outDir)
+		outFile, err := ioutil.TempFile(outDir, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		contents := []byte("first")
+		if _, err := outFile.Write(contents); err != nil {
+			t.Fatal(err)
+		}
+		path := outFile.Name()
+		if err = outFile.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		diff_contents := []byte("not-first")
+		rr, err := Render(&RenderInput{
+			Path:     path,
+			Contents: diff_contents,
+			Uid:      intPtr(wantedUid),
+			Gid:      intPtr(wantedGid),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		switch {
+		case rr.WouldRender && rr.DidRender:
+		default:
+			t.Fatalf("Bad render results; would: %v, did: %v",
+				rr.WouldRender, rr.DidRender)
+		}
+
+		gotUid, gotGid := getFileOwnership(path)
+		if *gotGid != wantedGid {
+			t.Fatalf("Bad render results; gotUid: %v, wantedGid: %v, gotGid: %v",
+				*gotUid, wantedGid, *gotGid)
+		}
+
+	})
+	t.Run("sets-file-ownership-when-file-no-exists", func(t *testing.T) {
+
+		outDir, err := ioutil.TempDir("", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(outDir)
+		path := path.Join(outDir, "no-exists")
+		contents := []byte("first")
+
+		rr, err := Render(&RenderInput{
+			Path:     path,
+			Contents: contents,
+			Uid:      intPtr(wantedUid),
+			Gid:      intPtr(wantedGid),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		switch {
+		case rr.WouldRender && rr.DidRender:
+		default:
+			t.Fatalf("Bad render results; would: %v, did: %v",
+				rr.WouldRender, rr.DidRender)
+		}
+
+		gotUid, gotGid := getFileOwnership(path)
+		if *gotGid != wantedGid {
+			t.Fatalf("Bad render results; gotUid: %v, wantedGid: %v, gotGid: %v",
+				*gotUid, wantedGid, *gotGid)
+		}
+
+	})
+	t.Run("sets-file-ownership-when-empty-file-no-exists", func(t *testing.T) {
+
+		outDir, err := ioutil.TempDir("", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(outDir)
+		path := path.Join(outDir, "no-exists")
+		contents := []byte{}
+
+		rr, err := Render(&RenderInput{
+			Path:     path,
+			Contents: contents,
+			Uid:      intPtr(wantedUid),
+			Gid:      intPtr(wantedGid),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		switch {
+		case rr.WouldRender && rr.DidRender:
+		default:
+			t.Fatalf("Bad render results; would: %v, did: %v",
+				rr.WouldRender, rr.DidRender)
+		}
+
+		gotUid, gotGid := getFileOwnership(path)
+		if *gotGid != wantedGid {
+			t.Fatalf("Bad render results; gotUid: %v, wantedGid: %v, gotGid: %v",
+				*gotUid, wantedGid, *gotGid)
+		}
+	})
+
+	t.Run("should-be-noop-when-missing-gid", func(t *testing.T) {
+
+		outDir, err := ioutil.TempDir("", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(outDir)
+		path := path.Join(outDir, "no-exists")
+		contents := []byte{}
+
+		rr, err := Render(&RenderInput{
+			Path:     path,
+			Contents: contents,
+			Uid:      intPtr(1000),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		switch {
+		case rr.WouldRender && rr.DidRender:
+		default:
+			t.Fatalf("Bad render results; would: %v, did: %v",
+				rr.WouldRender, rr.DidRender)
+		}
+
+		gotUid, gotGid := getFileOwnership(path)
+		if *gotGid == wantedGid {
+			t.Fatalf("Bad render results; we shouldn't have altered uid/gid. gotUid: %v, gotGid: %v",
+				*gotUid, *gotGid)
+		}
+	})
+}

--- a/renderer/renderer_test.go
+++ b/renderer/renderer_test.go
@@ -338,6 +338,9 @@ func TestRender_Chown(t *testing.T) {
 	// worst case scenario, if the user belongs to a single group, these tests
 	// would not be testing the cange of ownership but only the fact that it doesn't
 	// fail unexpectedly
+	if len(groups) == 0 {
+		t.Skip("The current user is not member of any group, cannot Chown, skipping...")
+	}
 	wantedGid := groups[0]
 
 	t.Run("sets-file-ownership-when-file-exists-same-content", func(t *testing.T) {

--- a/renderer/renderer_test.go
+++ b/renderer/renderer_test.go
@@ -323,12 +323,11 @@ func TestRender_Chown(t *testing.T) {
 	// setting Uid to -1 means no change
 	wantedUid := -1
 
-	//we enumerate the groups the current user (running the tests) belongs to
-	groups, err := os.Getgroups()
+	// we enumerate the groups the current user (running the tests) belongs to
+	callerGroups, err := os.Getgroups()
 	if err != nil {
 		t.Fatalf("getgroups: %s", err)
 	}
-	t.Log("groups: ", groups)
 
 	// we'll use the last group because we can assume it's not the default one
 	// for the current user (thinking about CI/CD).
@@ -338,10 +337,10 @@ func TestRender_Chown(t *testing.T) {
 	// worst case scenario, if the user belongs to a single group, these tests
 	// would not be testing the cange of ownership but only the fact that it doesn't
 	// fail unexpectedly
-	if len(groups) == 0 {
+	if len(callerGroups) == 0 {
 		t.Skip("The current user is not member of any group, cannot Chown, skipping...")
 	}
-	wantedGid := groups[0]
+	wantedGid := callerGroups[0]
 
 	t.Run("sets-file-ownership-when-file-exists-same-content", func(t *testing.T) {
 
@@ -497,20 +496,34 @@ func TestRender_Chown(t *testing.T) {
 		}
 	})
 
-	t.Run("should-be-noop-when-missing-gid", func(t *testing.T) {
+	t.Run("should-be-noop-when-missing-uid", func(t *testing.T) {
 
 		outDir, err := ioutil.TempDir("", "")
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer os.RemoveAll(outDir)
-		path := path.Join(outDir, "no-exists")
-		contents := []byte{}
+		outFile, err := ioutil.TempFile(outDir, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		contents := []byte("first")
+		if _, err := outFile.Write(contents); err != nil {
+			t.Fatal(err)
+		}
+		path := outFile.Name()
+		if err = outFile.Close(); err != nil {
+			t.Fatal(err)
+		}
 
+		// getting file uid:gid for the default behaviour
+		wantUid, wantGid := getFileOwnership(path)
+
+		diff_contents := []byte("not-first")
 		rr, err := Render(&RenderInput{
 			Path:     path,
-			Contents: contents,
-			Uid:      intPtr(1000),
+			Contents: diff_contents,
+			Gid:      intPtr(-1),
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -523,9 +536,102 @@ func TestRender_Chown(t *testing.T) {
 		}
 
 		gotUid, gotGid := getFileOwnership(path)
-		if *gotGid == wantedGid {
-			t.Fatalf("Bad render results; we shouldn't have altered uid/gid. gotUid: %v, gotGid: %v",
-				*gotUid, *gotGid)
+		if *gotUid != *wantUid || *gotGid != *wantGid {
+			t.Fatalf("Bad render results; we shouldn't have altered uid/gid. wantUid: %v, wantGid: %v, gotUid: %v, gotGid: %v ",
+				*wantUid, *wantGid, *gotUid, *gotGid)
+		}
+	})
+
+	t.Run("should-be-noop-when-missing-gid", func(t *testing.T) {
+
+		outDir, err := ioutil.TempDir("", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(outDir)
+		outFile, err := ioutil.TempFile(outDir, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		contents := []byte("first")
+		if _, err := outFile.Write(contents); err != nil {
+			t.Fatal(err)
+		}
+		path := outFile.Name()
+		if err = outFile.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		// getting file uid:gid for the default behaviour
+		wantUid, wantGid := getFileOwnership(path)
+
+		diff_contents := []byte("not-first")
+		rr, err := Render(&RenderInput{
+			Path:     path,
+			Contents: diff_contents,
+			Uid:      intPtr(-1),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		switch {
+		case rr.WouldRender && rr.DidRender:
+		default:
+			t.Fatalf("Bad render results; would: %v, did: %v",
+				rr.WouldRender, rr.DidRender)
+		}
+
+		gotUid, gotGid := getFileOwnership(path)
+		if *gotUid != *wantUid || *gotGid != *wantGid {
+			t.Fatalf("Bad render results; we shouldn't have altered uid/gid. wantUid: %v, wantGid: %v, gotUid: %v, gotGid: %v ",
+				*wantUid, *wantGid, *gotUid, *gotGid)
+		}
+	})
+
+	t.Run("should-be-noop-when-uid-and-gid-are-both-set-to-minus1", func(t *testing.T) {
+
+		outDir, err := ioutil.TempDir("", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(outDir)
+		outFile, err := ioutil.TempFile(outDir, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		contents := []byte("first")
+		if _, err := outFile.Write(contents); err != nil {
+			t.Fatal(err)
+		}
+		path := outFile.Name()
+		if err = outFile.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		// getting file uid:gid for the default behaviour
+		wantUid, wantGid := getFileOwnership(path)
+
+		diff_contents := []byte("not-first")
+		rr, err := Render(&RenderInput{
+			Path:     path,
+			Contents: diff_contents,
+			Uid:      intPtr(-1),
+			Gid:      intPtr(-1),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		switch {
+		case rr.WouldRender && rr.DidRender:
+		default:
+			t.Fatalf("Bad render results; would: %v, did: %v",
+				rr.WouldRender, rr.DidRender)
+		}
+
+		gotUid, gotGid := getFileOwnership(path)
+		if *gotUid != *wantUid || *gotGid != *wantGid {
+			t.Fatalf("Bad render results; we shouldn't have altered uid/gid. wantUid: %v, wantGid: %v, gotUid: %v, gotGid: %v ",
+				*wantUid, *wantGid, *gotUid, *gotGid)
 		}
 	})
 }


### PR DESCRIPTION
Adds support for the `uid` and `gid` entries in the `template` stanza that would ultimately be passed to a `os.Chown` command.

It obviously works only on POSIX and Windows is handled with graceful noop with a warning if the user set `uid` or `gid`


Related issues #639, #1497, #1185 and also nomad/5020

Signed-off-by: Alessandro De Blasis <alex@deblasis.net>