### PR TITLE
support secret write queries w/ an empty write

### DIFF
--- a/template/funcs.go
+++ b/template/funcs.go
@@ -342,10 +342,12 @@ func secretFunc(b *Brain, used, missing *dep.Set) func(...string) (*dep.Secret, 
 			return result, nil
 		}
 
-		// TODO: Refactor into separate template functions
 		path, rest := s[0], s[1:]
 		data := make(map[string]interface{})
 		for _, str := range rest {
+			if len(str) == 0 {
+				continue
+			}
 			parts := strings.SplitN(str, "=", 2)
 			if len(parts) != 2 {
 				return result, fmt.Errorf("not k=v pair %q", str)
@@ -358,7 +360,8 @@ func secretFunc(b *Brain, used, missing *dep.Set) func(...string) (*dep.Secret, 
 		var d dep.Dependency
 		var err error
 
-		if len(rest) == 0 {
+		isReadQuery := len(rest) == 0
+		if isReadQuery {
 			d, err = dep.NewVaultReadQuery(path)
 		} else {
 			d, err = dep.NewVaultWriteQuery(path, data)

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -556,6 +556,27 @@ func TestTemplate_Execute(t *testing.T) {
 			false,
 		},
 		{
+			"func_secret_write_empty",
+			&NewTemplateInput{
+				Contents: `{{ with secret "transit/encrypt/foo" "" }}{{ .Data.ciphertext }}{{ end }}`,
+			},
+			&ExecuteInput{
+				Brain: func() *Brain {
+					b := NewBrain()
+					d, err := dep.NewVaultWriteQuery("transit/encrypt/foo", nil)
+					if err != nil {
+						t.Fatal(err)
+					}
+					b.Remember(d, &dep.Secret{
+						Data: map[string]interface{}{"ciphertext": "encrypted"},
+					})
+					return b
+				}(),
+			},
+			"encrypted",
+			false,
+		},
+		{
 			"func_secret_write_no_exist",
 			&NewTemplateInput{
 				Contents: `{{ with secret "secret/nope" "a=b" }}{{ .Data.zip }}{{ end }}`,


### PR DESCRIPTION
Vault uses the write API for create+read and the create call doesn't
always take write key/value pairs (requires no fields to be provided)
but these cases would error out on absense of k/v pair. This change
simply skips the k/v check if the parameter string field is empty.

Fixes  #1453