### PR TITLE
Logging to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ this functionality might prove useful.
 - [Math Functions](docs/templating-language.md#math-functions)
 - [Observability](docs/observability.md)
 - [Logging](docs/observability.md#logging)
+  - [Logging to file](docs/observability.md#logging-to-file)
 - [Modes](docs/modes.md)
 - [Once Mode](docs/modes.md#once-mode)
 - [De-Duplication Mode](docs/modes.md#de-duplication-mode)
@@ -44,7 +45,7 @@ this functionality might prove useful.
 - [Plugins](docs/plugins.md)
 - [Caveats](#caveats)
 - [Docker Image Use](#docker-image-use)
-- [Dots in Service Names](#dots-in-service-names)  
+- [Dots in Service Names](#dots-in-service-names)
 - [Termination on Error](#termination-on-error)
 - [Commands](#commands)
   - [Environment](#environment)
@@ -235,7 +236,7 @@ users the ability to further customize their command script.
 #### Multiple Commands
 
 The command configured for running on template rendering must take one of two
-forms. 
+forms.
 
 The first is as a single command without spaces in its name and no arguments.
 This form of command will be called directly by consul-template and is good for

--- a/cli.go
+++ b/cli.go
@@ -387,6 +387,26 @@ func (cli *CLI) ParseFlags(args []string) (
 		return nil
 	}), "log-level", "")
 
+	flags.Var((funcVar)(func(s string) error {
+		c.FileLog.LogFilePath = config.String(s)
+		return nil
+	}), "log-file", "")
+
+	flags.Var((funcIntVar)(func(i int) error {
+		c.FileLog.LogRotateBytes = config.Int(i)
+		return nil
+	}), "log-rotate-bytes", "")
+
+	flags.Var((funcDurationVar)(func(d time.Duration) error {
+		c.FileLog.LogRotateDuration = config.TimeDuration(d)
+		return nil
+	}), "log-rotate-duration", "")
+
+	flags.Var((funcIntVar)(func(i int) error {
+		c.FileLog.LogRotateMaxFiles = config.Int(i)
+		return nil
+	}), "log-rotate-max-files", "")
+
 	flags.Var((funcDurationVar)(func(d time.Duration) error {
 		c.MaxStale = config.TimeDuration(d)
 		return nil
@@ -605,11 +625,15 @@ func logError(err error, status int) int {
 
 func (cli *CLI) setup(conf *config.Config) (*config.Config, error) {
 	if err := logging.Setup(&logging.Config{
-		Level:          config.StringVal(conf.LogLevel),
-		Syslog:         config.BoolVal(conf.Syslog.Enabled),
-		SyslogFacility: config.StringVal(conf.Syslog.Facility),
-		SyslogName:     config.StringVal(conf.Syslog.Name),
-		Writer:         cli.errStream,
+		Level:             config.StringVal(conf.LogLevel),
+		LogFilePath:       config.StringVal(conf.FileLog.LogFilePath),
+		LogRotateBytes:    config.IntVal(conf.FileLog.LogRotateBytes),
+		LogRotateDuration: config.TimeDurationVal(conf.FileLog.LogRotateDuration),
+		LogRotateMaxFiles: config.IntVal(conf.FileLog.LogRotateMaxFiles),
+		Syslog:            config.BoolVal(conf.Syslog.Enabled),
+		SyslogFacility:    config.StringVal(conf.Syslog.Facility),
+		SyslogName:        config.StringVal(conf.Syslog.Name),
+		Writer:            cli.errStream,
 	}); err != nil {
 		return nil, err
 	}

--- a/cli_test.go
+++ b/cli_test.go
@@ -356,6 +356,46 @@ func TestCLI_ParseFlags(t *testing.T) {
 			false,
 		},
 		{
+			"log-file",
+			[]string{"-log-file", "something.log"},
+			&config.Config{
+				FileLog: &config.LogFileConfig{
+					LogFilePath: config.String("something.log"),
+				},
+			},
+			false,
+		},
+		{
+			"log-rotate-bytes",
+			[]string{"-log-rotate-bytes", "102400"},
+			&config.Config{
+				FileLog: &config.LogFileConfig{
+					LogRotateBytes: config.Int(102400),
+				},
+			},
+			false,
+		},
+		{
+			"log-rotate-duration",
+			[]string{"-log-rotate-duration", "24h"},
+			&config.Config{
+				FileLog: &config.LogFileConfig{
+					LogRotateDuration: config.TimeDuration(24 * time.Hour),
+				},
+			},
+			false,
+		},
+		{
+			"log-rotate-max-files",
+			[]string{"-log-rotate-max-files", "10"},
+			&config.Config{
+				FileLog: &config.LogFileConfig{
+					LogRotateMaxFiles: config.Int(10),
+				},
+			},
+			false,
+		},
+		{
 			"max-stale",
 			[]string{"-max-stale", "10s"},
 			&config.Config{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -539,6 +539,74 @@ func TestParse(t *testing.T) {
 			false,
 		},
 		{
+			"log_file",
+			`log_file {}`,
+			&Config{
+				FileLog: &LogFileConfig{},
+			},
+			false,
+		},
+		{
+			"log_file_path",
+			`log_file {
+				path = "something.log"
+			}`,
+			&Config{
+				FileLog: &LogFileConfig{
+					LogFilePath: String("something.log"),
+				},
+			},
+			false,
+		},
+		{
+			"log_file_path_no_filename",
+			`log_file {
+				path = "./logs"
+			}`,
+			&Config{
+				FileLog: &LogFileConfig{
+					LogFilePath: String("./logs"),
+				},
+			},
+			false,
+		},
+		{
+			"log_file_log_rotate_bytes",
+			`log_file {
+				log_rotate_bytes = 102400
+			}`,
+			&Config{
+				FileLog: &LogFileConfig{
+					LogRotateBytes: Int(102400),
+				},
+			},
+			false,
+		},
+		{
+			"log_file_log_rotate_duration",
+			`log_file {
+				log_rotate_duration = "24h"
+			}`,
+			&Config{
+				FileLog: &LogFileConfig{
+					LogRotateDuration: TimeDuration(24 * time.Hour),
+				},
+			},
+			false,
+		},
+		{
+			"log_file_log_rotate_max_files",
+			`log_file {
+				log_rotate_max_files = 10
+			}`,
+			&Config{
+				FileLog: &LogFileConfig{
+					LogRotateMaxFiles: Int(10),
+				},
+			},
+			false,
+		},
+		{
 			"max_stale",
 			`max_stale = "10s"`,
 			&Config{
@@ -1781,6 +1849,24 @@ func TestConfig_Merge(t *testing.T) {
 			},
 			&Config{
 				LogLevel: String("log_level-diff"),
+			},
+		},
+		{
+			"file_log",
+			&Config{
+				FileLog: &LogFileConfig{
+					LogFilePath: String("something.log"),
+				},
+			},
+			&Config{
+				FileLog: &LogFileConfig{
+					LogFilePath: String("somethingelse.log"),
+				},
+			},
+			&Config{
+				FileLog: &LogFileConfig{
+					LogFilePath: String("somethingelse.log"),
+				},
 			},
 		},
 		{

--- a/config/logfile.go
+++ b/config/logfile.go
@@ -1,0 +1,129 @@
+package config
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/consul-template/version"
+)
+
+var (
+	// DefaultLogFileName is the default filename if the user didn't specify one
+	// which means that the user specified a directory to log to
+	DefaultLogFileName = fmt.Sprintf("%s.log", version.Name)
+
+	// DefaultLogRotateDuration is the default time taken by the agent to rotate logs
+	DefaultLogRotateDuration = 24 * time.Hour
+)
+
+type LogFileConfig struct {
+	// LogFilePath is the path to the file the logs get written to
+	LogFilePath *string `mapstructure:"path"`
+
+	// LogRotateBytes is the maximum number of bytes that should be written to a log
+	// file
+	LogRotateBytes *int `mapstructure:"log_rotate_bytes"`
+
+	// LogRotateDuration is the time after which log rotation needs to be performed
+	LogRotateDuration *time.Duration `mapstructure:"log_rotate_duration"`
+
+	// LogRotateMaxFiles is the maximum number of log file archives to keep
+	LogRotateMaxFiles *int `mapstructure:"log_rotate_max_files"`
+}
+
+// DefaultLogFileConfig returns a configuration that is populated with the
+// default values.
+func DefaultLogFileConfig() *LogFileConfig {
+	return &LogFileConfig{}
+}
+
+// Copy returns a deep copy of this configuration.
+func (c *LogFileConfig) Copy() *LogFileConfig {
+	if c == nil {
+		return nil
+	}
+
+	var o LogFileConfig
+	o.LogFilePath = c.LogFilePath
+	o.LogRotateBytes = c.LogRotateBytes
+	o.LogRotateDuration = c.LogRotateDuration
+	o.LogRotateMaxFiles = c.LogRotateMaxFiles
+	return &o
+}
+
+// Merge combines all values in this configuration with the values in the other
+// configuration, with values in the other configuration taking precedence.
+// Maps and slices are merged, most other values are overwritten. Complex
+// structs define their own merge functionality.
+func (c *LogFileConfig) Merge(o *LogFileConfig) *LogFileConfig {
+	if c == nil {
+		if o == nil {
+			return nil
+		}
+		return o.Copy()
+	}
+
+	if o == nil {
+		return c.Copy()
+	}
+
+	r := c.Copy()
+
+	if o.LogFilePath != nil {
+		r.LogFilePath = o.LogFilePath
+	}
+
+	if o.LogRotateBytes != nil {
+		r.LogRotateBytes = o.LogRotateBytes
+	}
+
+	if o.LogRotateDuration != nil {
+		r.LogRotateDuration = o.LogRotateDuration
+	}
+
+	if o.LogRotateMaxFiles != nil {
+		r.LogRotateMaxFiles = o.LogRotateMaxFiles
+	}
+
+	return r
+}
+
+// Finalize ensures there no nil pointers.
+func (c *LogFileConfig) Finalize() {
+
+	if c.LogFilePath == nil {
+		c.LogFilePath = String("")
+	}
+
+	if c.LogRotateBytes == nil {
+		c.LogRotateBytes = Int(0)
+	}
+
+	if c.LogRotateDuration == nil {
+		c.LogRotateDuration = TimeDuration(DefaultLogRotateDuration)
+	}
+
+	if c.LogRotateMaxFiles == nil {
+		c.LogRotateMaxFiles = Int(0)
+	}
+
+}
+
+// GoString defines the printable version of this struct.
+func (c *LogFileConfig) GoString() string {
+	if c == nil {
+		return "(*LogFileConfig)(nil)"
+	}
+
+	return fmt.Sprintf("&LogFileConfig{"+
+		"LogFilePath:%s, "+
+		"LogRotateBytes:%s, "+
+		"LogRotateDuration:%s, "+
+		"LogRotateMaxFiles:%s, "+
+		"}",
+		StringGoString(c.LogFilePath),
+		IntGoString(c.LogRotateBytes),
+		TimeDurationGoString(c.LogRotateDuration),
+		IntGoString(c.LogRotateMaxFiles),
+	)
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -194,6 +194,31 @@ syslog {
   # This is the name of the syslog facility to log to.
   facility = "LOCAL5"
 }
+
+# This block defines the configuration for logging to file
+log_file {
+  # If a path is specified, the feature is enabled
+  # Please refer to the documentation for the -log-file
+  # CLI flag for more information about its behaviour
+  path = "/var/log/something.log"
+
+  # This allow you to control the number of bytes that
+  # should be written to a log before it needs to be
+  # rotated. Unless specified, there is no limit to the
+  # number of bytes that can be written to a log file
+  log_rotate_bytes = 1024000
+
+  # This lets you control time based rotation, by default
+  # logs are rotated every 24h
+  log_rotate_duration = "3h"
+
+  # This lets you control the maximum number of older log
+  # file archives to keep. Defaults to 0 (no files are ever
+  # deleted).
+  # Set to -1 to discard old log files when a new one is
+  # created
+  log_rotate_max_files = 10
+}
 ```
 
 ## Consul
@@ -347,7 +372,7 @@ vault {
   # documentation for more information.
   unwrap_token = true
 
-  # The default lease duration Consul Template will use on a Vault secret that 
+  # The default lease duration Consul Template will use on a Vault secret that
   # does not have a lease duration. This is used to calculate the sleep duration
   # for rechecking a Vault secret value. This field is optional and will default to
   # 5 minutes.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -41,3 +41,31 @@ $ consul-template -log-level debug ...
 # ...
 ```
 
+## Logging to file
+
+Consul Template can log to file as well.
+Particularly useful in use cases where it's not trivial to capture *stdout* and/or *stderr*
+like for example when Consul Template is deployed as a Windows Service.
+
+These are the relevant CLI flags:
+
+- `-log-file` - writes all the Consul Template log messages
+  to a file. This value is used as a prefix for the log file name. The current timestamp
+  is appended to the file name. If the value ends in a path separator, `consul-template-`
+  will be appended to the value. If the file name is missing an extension, `.log`
+  is appended. For example, setting `log-file` to `/var/log/` would result in a log
+  file path of `/var/log/consul-template-{timestamp}.log`. `log-file` can be combined with
+  `-log-rotate-bytes` and `-log-rotate-duration`
+  for a fine-grained log rotation experience.
+
+- `-log-rotate-bytes` - to specify the number of
+  bytes that should be written to a log before it needs to be rotated. Unless specified,
+  there is no limit to the number of bytes that can be written to a log file.
+
+- `-log-rotate-duration` - to specify the maximum
+  duration a log should be written to before it needs to be rotated. Must be a duration
+  value such as 30s. Defaults to 24h.
+
+- `-log-rotate-max-files` - to specify the maximum
+  number of older log file archives to keep. Defaults to 0 (no files are ever deleted).
+  Set to -1 to discard old log files when a new one is created.

--- a/logging/logfile.go
+++ b/logging/logfile.go
@@ -1,0 +1,147 @@
+package logging
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/logutils"
+)
+
+type LogFile struct {
+	//Name of the log file
+	fileName string
+
+	//Path to the log file
+	logPath string
+
+	//Duration between each file rotation operation
+	duration time.Duration
+
+	//LastCreated represents the creation time of the latest log
+	LastCreated time.Time
+
+	//FileInfo is the pointer to the current file being written to
+	FileInfo *os.File
+
+	//MaxBytes is the maximum number of desired bytes for a log file
+	MaxBytes int
+
+	//BytesWritten is the number of bytes written in the current log file
+	BytesWritten int64
+
+	// Max rotated files to keep before removing them.
+	MaxFiles int
+
+	//filt is used to filter log messages depending on their level
+	filt *logutils.LevelFilter
+
+	//acquire is the mutex utilized to ensure we have no concurrency issues
+	acquire sync.Mutex
+}
+
+func (l *LogFile) fileNamePattern() string {
+	// Extract the file extension
+	fileExt := filepath.Ext(l.fileName)
+	// If we have no file extension we append .log
+	if fileExt == "" {
+		fileExt = ".log"
+	}
+	// Remove the file extension from the filename
+	return strings.TrimSuffix(l.fileName, fileExt) + "-%s" + fileExt
+}
+
+func (l *LogFile) openNew() error {
+	fileNamePattern := l.fileNamePattern()
+
+	createTime := time.Now()
+	newfileName := fmt.Sprintf(fileNamePattern, strconv.FormatInt(createTime.UnixNano(), 10))
+	newfilePath := filepath.Join(l.logPath, newfileName)
+
+	// Try creating a file. We truncate the file because we are the only authority to write the logs
+	filePointer, err := os.OpenFile(newfilePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0640)
+	if err != nil {
+		return err
+	}
+
+	l.FileInfo = filePointer
+	// New file, new bytes tracker, new creation time :)
+	l.LastCreated = createTime
+	l.BytesWritten = 0
+	return nil
+}
+
+func (l *LogFile) rotate() error {
+	// Get the time from the last point of contact
+	timeElapsed := time.Since(l.LastCreated)
+	// Rotate if we hit the byte file limit or the time limit
+	if (l.BytesWritten >= int64(l.MaxBytes) && (l.MaxBytes > 0)) || timeElapsed >= l.duration {
+		l.FileInfo.Close()
+		if err := l.pruneFiles(); err != nil {
+			return err
+		}
+		return l.openNew()
+	}
+	return nil
+}
+
+func (l *LogFile) pruneFiles() error {
+	if l.MaxFiles == 0 {
+		return nil
+	}
+
+	pattern := filepath.Join(l.logPath, fmt.Sprintf(l.fileNamePattern(), "*"))
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case l.MaxFiles < 0:
+		return removeFiles(matches)
+	case len(matches) < l.MaxFiles:
+		return nil
+	}
+
+	sort.Strings(matches)
+	last := len(matches) - l.MaxFiles
+	return removeFiles(matches[:last])
+}
+
+func removeFiles(files []string) error {
+	for _, file := range files {
+		if err := os.Remove(file); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Write is used to implement io.Writer.
+func (l *LogFile) Write(b []byte) (int, error) {
+	l.acquire.Lock()
+	defer l.acquire.Unlock()
+
+	// Skip if the log level doesn't apply
+	if l.filt != nil && !l.filt.Check(b) {
+		return 0, nil
+	}
+
+	// Create a new file if we have no file to write to
+	if l.FileInfo == nil {
+		if err := l.openNew(); err != nil {
+			return 0, err
+		}
+	}
+	// Check for the last contact and rotate if necessary
+	if err := l.rotate(); err != nil {
+		return 0, err
+	}
+	l.BytesWritten += int64(len(b))
+	return l.FileInfo.Write(b)
+}

--- a/logging/logfile_test.go
+++ b/logging/logfile_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul-template/config"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/logutils"
 	"github.com/stretchr/testify/require"
 )
@@ -21,7 +20,11 @@ func TestLogFileFilter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tempDir := testutil.TempDir(t, "")
+	tempDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
 	logFile := LogFile{
 		fileName: "something.log",
 		logPath:  tempDir,
@@ -57,8 +60,11 @@ func TestLogFileFilter(t *testing.T) {
 }
 
 func TestLogFileNoFilter(t *testing.T) {
-
-	tempDir := testutil.TempDir(t, "")
+	tempDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
 	logFile := LogFile{
 		fileName: "something.log",
 		logPath:  tempDir,
@@ -97,7 +103,11 @@ func TestLogFile_Rotation_MaxDuration(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	tempDir := testutil.TempDir(t, "")
+	tempDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
 	logFile := LogFile{
 		fileName: "something.log",
 		logPath:  tempDir,
@@ -111,12 +121,17 @@ func TestLogFile_Rotation_MaxDuration(t *testing.T) {
 }
 
 func TestLogFile_openNew(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
 	logFile := LogFile{
 		fileName: "something.log",
-		logPath:  testutil.TempDir(t, ""),
+		logPath:  tempDir,
 		duration: config.DefaultLogRotateDuration,
 	}
-	err := logFile.openNew()
+	err = logFile.openNew()
 	require.NoError(t, err)
 
 	msg := "[INFO] Something"
@@ -129,7 +144,11 @@ func TestLogFile_openNew(t *testing.T) {
 }
 
 func TestLogFile_Rotation_MaxBytes(t *testing.T) {
-	tempDir := testutil.TempDir(t, "LogWriterBytes")
+	tempDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
 	logFile := LogFile{
 		fileName: "somefile.log",
 		logPath:  tempDir,
@@ -142,7 +161,11 @@ func TestLogFile_Rotation_MaxBytes(t *testing.T) {
 }
 
 func TestLogFile_PruneFiles(t *testing.T) {
-	tempDir := testutil.TempDir(t, t.Name())
+	tempDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
 	logFile := LogFile{
 		fileName: "something.log",
 		logPath:  tempDir,
@@ -168,7 +191,11 @@ func TestLogFile_PruneFiles(t *testing.T) {
 }
 
 func TestLogFile_PruneFiles_Disabled(t *testing.T) {
-	tempDir := testutil.TempDir(t, t.Name())
+	tempDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
 	logFile := LogFile{
 		fileName: "somename.log",
 		logPath:  tempDir,
@@ -183,7 +210,11 @@ func TestLogFile_PruneFiles_Disabled(t *testing.T) {
 }
 
 func TestLogFile_FileRotation_Disabled(t *testing.T) {
-	tempDir := testutil.TempDir(t, t.Name())
+	tempDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
 	logFile := LogFile{
 		fileName: "something.log",
 		logPath:  tempDir,

--- a/logging/logfile_test.go
+++ b/logging/logfile_test.go
@@ -1,0 +1,206 @@
+package logging
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul-template/config"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/logutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogFileFilter(t *testing.T) {
+
+	filt, err := newLogFilter(ioutil.Discard, logutils.LogLevel("INFO"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tempDir := testutil.TempDir(t, "")
+	logFile := LogFile{
+		fileName: "something.log",
+		logPath:  tempDir,
+		duration: 50 * time.Millisecond,
+		filt:     filt,
+	}
+
+	logFile.Write([]byte("Hello World"))
+	time.Sleep(3 * logFile.duration)
+	logFile.Write([]byte("Second File"))
+	require.Len(t, listDir(t, tempDir), 2)
+
+	infotest := []byte("[INFO] test")
+	n, err := logFile.Write(infotest)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if n == 0 {
+		t.Fatalf("should have logged")
+	}
+	if n != len(infotest) {
+		t.Fatalf("byte count (%d) doesn't match output len (%d).",
+			n, len(infotest))
+	}
+
+	n, err = logFile.Write([]byte("[DEBUG] test"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if n != 0 {
+		t.Fatalf("should not have logged")
+	}
+}
+
+func TestLogFileNoFilter(t *testing.T) {
+
+	tempDir := testutil.TempDir(t, "")
+	logFile := LogFile{
+		fileName: "something.log",
+		logPath:  tempDir,
+		duration: 50 * time.Millisecond,
+	}
+
+	logFile.Write([]byte("Hello World"))
+	time.Sleep(3 * logFile.duration)
+	logFile.Write([]byte("Second File"))
+	require.Len(t, listDir(t, tempDir), 2)
+
+	infotest := []byte("[INFO] test")
+	n, err := logFile.Write(infotest)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if n == 0 {
+		t.Fatalf("should have logged")
+	}
+	if n != len(infotest) {
+		t.Fatalf("byte count (%d) doesn't match output len (%d).",
+			n, len(infotest))
+	}
+
+	n, err = logFile.Write([]byte("[DEBUG] test"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if n == 0 {
+		t.Fatalf("should have logged")
+	}
+}
+
+func TestLogFile_Rotation_MaxDuration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	tempDir := testutil.TempDir(t, "")
+	logFile := LogFile{
+		fileName: "something.log",
+		logPath:  tempDir,
+		duration: 50 * time.Millisecond,
+	}
+
+	logFile.Write([]byte("Hello World"))
+	time.Sleep(3 * logFile.duration)
+	logFile.Write([]byte("Second File"))
+	require.Len(t, listDir(t, tempDir), 2)
+}
+
+func TestLogFile_openNew(t *testing.T) {
+	logFile := LogFile{
+		fileName: "something.log",
+		logPath:  testutil.TempDir(t, ""),
+		duration: config.DefaultLogRotateDuration,
+	}
+	err := logFile.openNew()
+	require.NoError(t, err)
+
+	msg := "[INFO] Something"
+	_, err = logFile.Write([]byte(msg))
+	require.NoError(t, err)
+
+	content, err := ioutil.ReadFile(logFile.FileInfo.Name())
+	require.NoError(t, err)
+	require.Contains(t, string(content), msg)
+}
+
+func TestLogFile_Rotation_MaxBytes(t *testing.T) {
+	tempDir := testutil.TempDir(t, "LogWriterBytes")
+	logFile := LogFile{
+		fileName: "somefile.log",
+		logPath:  tempDir,
+		MaxBytes: 10,
+		duration: config.DefaultLogRotateDuration,
+	}
+	logFile.Write([]byte("Hello World"))
+	logFile.Write([]byte("Second File"))
+	require.Len(t, listDir(t, tempDir), 2)
+}
+
+func TestLogFile_PruneFiles(t *testing.T) {
+	tempDir := testutil.TempDir(t, t.Name())
+	logFile := LogFile{
+		fileName: "something.log",
+		logPath:  tempDir,
+		MaxBytes: 10,
+		duration: config.DefaultLogRotateDuration,
+		MaxFiles: 1,
+	}
+	logFile.Write([]byte("[INFO] Hello World"))
+	logFile.Write([]byte("[INFO] Second File"))
+	logFile.Write([]byte("[INFO] Third File"))
+
+	logFiles := listDir(t, tempDir)
+	sort.Strings(logFiles)
+	require.Len(t, logFiles, 2)
+
+	content, err := ioutil.ReadFile(filepath.Join(tempDir, logFiles[0]))
+	require.NoError(t, err)
+	require.Contains(t, string(content), "Second File")
+
+	content, err = ioutil.ReadFile(filepath.Join(tempDir, logFiles[1]))
+	require.NoError(t, err)
+	require.Contains(t, string(content), "Third File")
+}
+
+func TestLogFile_PruneFiles_Disabled(t *testing.T) {
+	tempDir := testutil.TempDir(t, t.Name())
+	logFile := LogFile{
+		fileName: "somename.log",
+		logPath:  tempDir,
+		MaxBytes: 10,
+		duration: config.DefaultLogRotateDuration,
+		MaxFiles: 0,
+	}
+	logFile.Write([]byte("[INFO] Hello World"))
+	logFile.Write([]byte("[INFO] Second File"))
+	logFile.Write([]byte("[INFO] Third File"))
+	require.Len(t, listDir(t, tempDir), 3)
+}
+
+func TestLogFile_FileRotation_Disabled(t *testing.T) {
+	tempDir := testutil.TempDir(t, t.Name())
+	logFile := LogFile{
+		fileName: "something.log",
+		logPath:  tempDir,
+		MaxBytes: 10,
+		MaxFiles: -1,
+	}
+	logFile.Write([]byte("[INFO] Hello World"))
+	logFile.Write([]byte("[INFO] Second File"))
+	logFile.Write([]byte("[INFO] Third File"))
+	require.Len(t, listDir(t, tempDir), 1)
+}
+
+func listDir(t *testing.T, name string) []string {
+	t.Helper()
+	fh, err := os.Open(name)
+	require.NoError(t, err)
+	files, err := fh.Readdirnames(100)
+	require.NoError(t, err)
+	return files
+}


### PR DESCRIPTION
Hi, I spotted this issue and it sounded like an easy one.
Most of the credits go to the Consul folks because while copying the semantics I ended up taking most of the logic too. 
I just added a few tweaks to match consul-template semantics and structure.

This PR adds:
- Consul-like CLI flags used to control the behaviour of the feature
- `log_file` configuration stanza
- updated docs for CLI and config

Fixes #1416
