### PR TITLE
fix issue returning typed nil pointers

### DIFF
--- a/template/funcs.go
+++ b/template/funcs.go
@@ -291,8 +291,8 @@ func lsFunc(b *Brain, used, missing *dep.Set, emptyIsSafe bool) func(string) ([]
 }
 
 // nodeFunc returns or accumulates catalog node dependency.
-func nodeFunc(b *Brain, used, missing *dep.Set) func(...string) (*dep.CatalogNode, error) {
-	return func(s ...string) (*dep.CatalogNode, error) {
+func nodeFunc(b *Brain, used, missing *dep.Set) func(...string) (interface{}, error) {
+	return func(s ...string) (interface{}, error) {
 
 		d, err := dep.NewCatalogNodeQuery(strings.Join(s, ""))
 		if err != nil {
@@ -334,12 +334,10 @@ func nodesFunc(b *Brain, used, missing *dep.Set) func(...string) ([]*dep.Node, e
 }
 
 // secretFunc returns or accumulates secret dependencies from Vault.
-func secretFunc(b *Brain, used, missing *dep.Set) func(...string) (*dep.Secret, error) {
-	return func(s ...string) (*dep.Secret, error) {
-		var result *dep.Secret
-
+func secretFunc(b *Brain, used, missing *dep.Set) func(...string) (interface{}, error) {
+	return func(s ...string) (interface{}, error) {
 		if len(s) == 0 {
-			return result, nil
+			return nil, nil
 		}
 
 		path, rest := s[0], s[1:]
@@ -350,7 +348,7 @@ func secretFunc(b *Brain, used, missing *dep.Set) func(...string) (*dep.Secret, 
 			}
 			parts := strings.SplitN(str, "=", 2)
 			if len(parts) != 2 {
-				return result, fmt.Errorf("not k=v pair %q", str)
+				return nil, fmt.Errorf("not k=v pair %q", str)
 			}
 
 			k, v := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
@@ -374,13 +372,12 @@ func secretFunc(b *Brain, used, missing *dep.Set) func(...string) (*dep.Secret, 
 		used.Add(d)
 
 		if value, ok := b.Recall(d); ok {
-			result = value.(*dep.Secret)
-			return result, nil
+			return value.(*dep.Secret), nil
 		}
 
 		missing.Add(d)
 
-		return result, nil
+		return nil, nil
 	}
 }
 
@@ -542,8 +539,8 @@ func connectCARootsFunc(b *Brain, used, missing *dep.Set,
 }
 
 func connectLeafFunc(b *Brain, used, missing *dep.Set,
-) func(...string) (*api.LeafCert, error) {
-	return func(s ...string) (*api.LeafCert, error) {
+) func(...string) (interface{}, error) {
+	return func(s ...string) (interface{}, error) {
 		if len(s) == 0 || s[0] == "" {
 			return nil, nil
 		}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -430,6 +430,17 @@ func TestTemplate_Execute(t *testing.T) {
 			false,
 		},
 		{
+			"func_node_nil_pointer_evaluation",
+			&NewTemplateInput{
+				Contents: `{{ $v := node }}{{ $v.Node }}`,
+			},
+			&ExecuteInput{
+				Brain: NewBrain(),
+			},
+			"<no value>",
+			false,
+		},
+		{
 			"func_nodes",
 			&NewTemplateInput{
 				Contents: `{{ range nodes }}{{ .Node }}{{ end }}`,
@@ -473,6 +484,17 @@ func TestTemplate_Execute(t *testing.T) {
 				}(),
 			},
 			"zap",
+			false,
+		},
+		{
+			"func_secret_nil_pointer_evaluation",
+			&NewTemplateInput{
+				Contents: `{{ $v := secret "secret/foo" }}{{ $v.Data.zip }}`,
+			},
+			&ExecuteInput{
+				Brain: NewBrain(),
+			},
+			"<no value>",
 			false,
 		},
 		{
@@ -1842,6 +1864,17 @@ func TestTemplate_Execute(t *testing.T) {
 				}(),
 			},
 			"PEMKEY",
+			false,
+		},
+		{
+			"leaf_cert_nil_pointer_evaluation",
+			&NewTemplateInput{
+				Contents: `{{ $v := caLeaf "foo" }}{{ $v.CertPEM }}`,
+			},
+			&ExecuteInput{
+				Brain: NewBrain(),
+			},
+			"<no value>",
 			false,
 		},
 		{


### PR DESCRIPTION
Fix 3 template functions; secrets, caLeafe and node

These functions returned typed pointers as their data field. Template
execution didn't like these typed nil pointer values when looking up
data on them. Changing them to return untyped pointers with an function
signature returning interface{} fixes this as the template knows to have
these always return `<no value>`.

Fixes #1418