### PR TITLE
Allow setting ownership by name

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1096,12 +1096,12 @@ func TestParse(t *testing.T) {
 		{
 			"template_uid",
 			`template {
-				uid = 1000
+				user = "1000"
 			}`,
 			&Config{
 				Templates: &TemplateConfigs{
 					&TemplateConfig{
-						Uid: Int(1000),
+						User: String("1000"),
 					},
 				},
 			},
@@ -1110,12 +1110,12 @@ func TestParse(t *testing.T) {
 		{
 			"template_gid",
 			`template {
-				gid = 1000
+				group = "1000"
 			}`,
 			&Config{
 				Templates: &TemplateConfigs{
 					&TemplateConfig{
-						Gid: Int(1000),
+						Group: String("1000"),
 					},
 				},
 			},
@@ -1128,8 +1128,8 @@ func TestParse(t *testing.T) {
 			&Config{
 				Templates: &TemplateConfigs{
 					&TemplateConfig{
-						Uid: nil,
-						Gid: nil,
+						User:  nil,
+						Group: nil,
 					},
 				},
 			},

--- a/config/template.go
+++ b/config/template.go
@@ -64,19 +64,19 @@ type TemplateConfig struct {
 	// secrets from Vault.
 	Perms *os.FileMode `mapstructure:"perms"`
 
-	// Uid is the numeric uid that will be set when creating the file on disk.
+	// User is the username or uid that will be set when creating the file on disk.
 	// Useful when simply setting Perms is not enough.
 	//
 	// Platform dependent: this doesn't work on Windows but it fails gracefully
 	// with a warning
-	Uid *int `mapstructure:"uid"`
+	User *string `mapstructure:"user"`
 
-	// Gid is the numeric gid that will be set when creating the file on disk.
+	// Group is the group name or gid that will be set when creating the file on disk.
 	// Useful when simply setting Perms is not enough.
 	//
 	// Platform dependent: this doesn't work on Windows but it fails gracefully
 	// with a warning
-	Gid *int `mapstructure:"gid"`
+	Group *string `mapstructure:"group"`
 
 	// Source is the path on disk to the template contents to evaluate. Either
 	// this or Contents should be specified, but not both.

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -780,8 +780,8 @@ func (r *Runner) runTemplate(tmpl *template.Template, runCtx *templateRunCtx) (*
 			DryStream:      r.outStream,
 			Path:           config.StringVal(templateConfig.Destination),
 			Perms:          config.FileModeVal(templateConfig.Perms),
-			Uid:            templateConfig.Uid,
-			Gid:            templateConfig.Gid,
+			User:           config.StringVal(templateConfig.User),
+			Group:          config.StringVal(templateConfig.Group),
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "error rendering "+templateConfig.Display())

--- a/renderer/file_ownership.go
+++ b/renderer/file_ownership.go
@@ -5,6 +5,8 @@ package renderer
 
 import (
 	"os"
+	"os/user"
+	"strconv"
 	"syscall"
 )
 
@@ -20,30 +22,48 @@ func getFileOwnership(path string) (*int, *int) {
 	return intPtr(int(st.Uid)), intPtr(int(st.Gid))
 }
 
-func setFileOwnership(path string, uid, gid *int) error {
-	wantedUid := sanitizeUidGid(uid)
-	wantedGid := sanitizeUidGid(gid)
-	if wantedUid == -1 && wantedGid == -1 {
+func setFileOwnership(path string, uid, gid int) error {
+	if uid == -1 && gid == -1 {
 		return nil //noop
 	}
-	return os.Chown(path, wantedUid, wantedGid)
+	return os.Chown(path, uid, gid)
 }
 
-func isChownNeeded(path string, uid, gid *int) bool {
-	wantedUid := sanitizeUidGid(uid)
-	wantedGid := sanitizeUidGid(gid)
-	if wantedUid == -1 && wantedGid == -1 {
+func isChownNeeded(path string, uid, gid int) bool {
+	if uid == -1 && gid == -1 {
 		return false
 	}
 
 	currUid, currGid := getFileOwnership(path)
-	return wantedUid != *currUid || wantedGid != *currGid
+	return uid != *currUid || gid != *currGid
 }
 
-// sanitizeUidGid sanitizes the uid/gid so that can be an input for os.Chown
-func sanitizeUidGid(id *int) int {
-	if id == nil {
-		return -1
+// parseUidGid parses the uid/gid so that it can be input to os.Chown
+func parseUidGid(s string) (int, error) {
+	if s == "" {
+		return -1, nil
 	}
-	return *id
+	return strconv.Atoi(s)
+}
+
+func lookupUser(s string) (int, error) {
+	if id, err := parseUidGid(s); err == nil {
+		return id, nil
+	}
+	u, err := user.Lookup(s)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(u.Uid)
+}
+
+func lookupGroup(s string) (int, error) {
+	if id, err := parseUidGid(s); err == nil {
+		return id, nil
+	}
+	u, err := user.LookupGroup(s)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(u.Gid)
 }

--- a/renderer/file_ownership_windows.go
+++ b/renderer/file_ownership_windows.go
@@ -4,27 +4,35 @@
 package renderer
 
 import (
-	"log"
+	"fmt"
 )
 
+var notSupportedError error = fmt.Errorf("managing file ownership is not supported on Windows")
+
 func setFileOwnership(path string, uid, gid int) error {
-	return nil
+	if uid == -1 && gid == -1 {
+		return nil
+	}
+	return notSupportedError
 }
 
 func isChownNeeded(path string, wantedUid, wantedGid int) (bool, error) {
-	return false, nil
+	if wantedUid == -1 && wantedGid == -1 {
+		return false, nil
+	}
+	return false, notSupportedError
 }
 
 func lookupUser(user string) (int, error) {
-	if user != "" {
-		log.Printf("[WARN] (runner) cannot set user for rendered files on Windows")
+	if user == "" {
+		return -1, nil
 	}
-	return -1, nil
+	return 0, notSupportedError
 }
 
 func lookupGroup(group string) (int, error) {
-	if group != "" {
-		log.Printf("[WARN] (runner) cannot set group for rendered files on Windows")
+	if group == "" {
+		return -1, nil
 	}
-	return -1, nil
+	return 0, notSupportedError
 }

--- a/renderer/file_ownership_windows.go
+++ b/renderer/file_ownership_windows.go
@@ -7,13 +7,24 @@ import (
 	"log"
 )
 
-func setFileOwnership(path string, uid, gid *int) error {
-	if uid != nil || gid != nil {
-		log.Printf("[WARN] (runner) cannot set uid/gid for rendered files on Windows")
-	}
+func setFileOwnership(path string, uid, gid int) error {
 	return nil
 }
 
-func isChownNeeded(path string, wantedUid, wantedGid *int) bool {
+func isChownNeeded(path string, wantedUid, wantedGid int) bool {
 	return false
+}
+
+func lookupUser(user string) (int, error) {
+	if user != "" {
+		log.Printf("[WARN] (runner) cannot set user for rendered files on Windows")
+	}
+	return -1, nil
+}
+
+func lookupGroup(group string) (int, error) {
+	if group != "" {
+		log.Printf("[WARN] (runner) cannot set group for rendered files on Windows")
+	}
+	return -1, nil
 }

--- a/renderer/file_ownership_windows.go
+++ b/renderer/file_ownership_windows.go
@@ -11,8 +11,8 @@ func setFileOwnership(path string, uid, gid int) error {
 	return nil
 }
 
-func isChownNeeded(path string, wantedUid, wantedGid int) bool {
-	return false
+func isChownNeeded(path string, wantedUid, wantedGid int) (bool, error) {
+	return false, nil
 }
 
 func lookupUser(user string) (int, error) {

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -36,7 +36,7 @@ type RenderInput struct {
 	DryStream      io.Writer
 	Path           string
 	Perms          os.FileMode
-	Uid, Gid       *int
+	User, Group    string
 }
 
 // RenderResult is returned and stored. It contains the status of the render
@@ -66,10 +66,19 @@ func Render(i *RenderInput) (*RenderResult, error) {
 		return nil, errors.Wrap(err, "failed reading file")
 	}
 
+	uid, err := lookupUser(i.User)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed looking up user")
+	}
+	gid, err := lookupGroup(i.Group)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed looking up group")
+	}
+
 	var chownNeeded bool
 
 	if fileExists {
-		chownNeeded = isChownNeeded(i.Path, i.Uid, i.Gid)
+		chownNeeded = isChownNeeded(i.Path, uid, gid)
 	}
 
 	if bytes.Equal(existing, i.Contents) && fileExists && !chownNeeded {
@@ -87,7 +96,7 @@ func Render(i *RenderInput) (*RenderResult, error) {
 			return nil, errors.Wrap(err, "failed writing file")
 		}
 
-		if err = setFileOwnership(i.Path, i.Uid, i.Gid); err != nil {
+		if err = setFileOwnership(i.Path, uid, gid); err != nil {
 			return nil, errors.Wrap(err, "failed setting file ownership")
 		}
 	}

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -78,7 +78,11 @@ func Render(i *RenderInput) (*RenderResult, error) {
 	var chownNeeded bool
 
 	if fileExists {
-		chownNeeded = isChownNeeded(i.Path, uid, gid)
+		chownNeeded, err = isChownNeeded(i.Path, uid, gid)
+		if err != nil {
+			log.Printf("[WARN] (runner) could not determine existing output file's permissions")
+			chownNeeded = true
+		}
 	}
 
 	if bytes.Equal(existing, i.Contents) && fileExists && !chownNeeded {

--- a/renderer/renderer_test.go
+++ b/renderer/renderer_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"testing"
 )
 
@@ -320,8 +321,6 @@ func TestRender_Chown(t *testing.T) {
 
 	// Can't change uid unless root, but can try
 	// changing the group id.
-	// setting Uid to -1 means no change
-	wantedUid := -1
 
 	// we enumerate the groups the current user (running the tests) belongs to
 	callerGroups, err := os.Getgroups()
@@ -365,8 +364,7 @@ func TestRender_Chown(t *testing.T) {
 		rr, err := Render(&RenderInput{
 			Path:     path,
 			Contents: contents,
-			Uid:      intPtr(wantedUid),
-			Gid:      intPtr(wantedGid),
+			Group:    strconv.Itoa(wantedGid),
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -410,8 +408,7 @@ func TestRender_Chown(t *testing.T) {
 		rr, err := Render(&RenderInput{
 			Path:     path,
 			Contents: diff_contents,
-			Uid:      intPtr(wantedUid),
-			Gid:      intPtr(wantedGid),
+			Group:    strconv.Itoa(wantedGid),
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -443,8 +440,7 @@ func TestRender_Chown(t *testing.T) {
 		rr, err := Render(&RenderInput{
 			Path:     path,
 			Contents: contents,
-			Uid:      intPtr(wantedUid),
-			Gid:      intPtr(wantedGid),
+			Group:    strconv.Itoa(wantedGid),
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -476,8 +472,7 @@ func TestRender_Chown(t *testing.T) {
 		rr, err := Render(&RenderInput{
 			Path:     path,
 			Contents: contents,
-			Uid:      intPtr(wantedUid),
-			Gid:      intPtr(wantedGid),
+			Group:    strconv.Itoa(wantedGid),
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -496,7 +491,7 @@ func TestRender_Chown(t *testing.T) {
 		}
 	})
 
-	t.Run("should-be-noop-when-missing-uid", func(t *testing.T) {
+	t.Run("should-be-noop-when-missing-user", func(t *testing.T) {
 
 		outDir, err := ioutil.TempDir("", "")
 		if err != nil {
@@ -523,7 +518,7 @@ func TestRender_Chown(t *testing.T) {
 		rr, err := Render(&RenderInput{
 			Path:     path,
 			Contents: diff_contents,
-			Gid:      intPtr(-1),
+			Group:    "",
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -542,7 +537,7 @@ func TestRender_Chown(t *testing.T) {
 		}
 	})
 
-	t.Run("should-be-noop-when-missing-gid", func(t *testing.T) {
+	t.Run("should-be-noop-when-missing-group", func(t *testing.T) {
 
 		outDir, err := ioutil.TempDir("", "")
 		if err != nil {
@@ -569,7 +564,7 @@ func TestRender_Chown(t *testing.T) {
 		rr, err := Render(&RenderInput{
 			Path:     path,
 			Contents: diff_contents,
-			Uid:      intPtr(-1),
+			User:     "",
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -588,7 +583,7 @@ func TestRender_Chown(t *testing.T) {
 		}
 	})
 
-	t.Run("should-be-noop-when-uid-and-gid-are-both-set-to-minus1", func(t *testing.T) {
+	t.Run("should-be-noop-when-user-and-group-are-both-empty", func(t *testing.T) {
 
 		outDir, err := ioutil.TempDir("", "")
 		if err != nil {
@@ -615,8 +610,8 @@ func TestRender_Chown(t *testing.T) {
 		rr, err := Render(&RenderInput{
 			Path:     path,
 			Contents: diff_contents,
-			Uid:      intPtr(-1),
-			Gid:      intPtr(-1),
+			User:     "",
+			Group:    "",
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/renderer/renderer_test.go
+++ b/renderer/renderer_test.go
@@ -376,10 +376,13 @@ func TestRender_Chown(t *testing.T) {
 				rr.WouldRender, rr.DidRender)
 		}
 
-		gotUid, gotGid := getFileOwnership(path)
-		if *gotGid != wantedGid {
+		gotUid, gotGid, err := getFileOwnership(path)
+		if err != nil {
+			t.Fatalf("getFileOwnership: %s", err)
+		}
+		if gotGid != wantedGid {
 			t.Fatalf("Bad render results; gotUid: %v, wantedGid: %v, gotGid: %v",
-				*gotUid, wantedGid, *gotGid)
+				gotUid, wantedGid, gotGid)
 		}
 
 	})
@@ -420,10 +423,13 @@ func TestRender_Chown(t *testing.T) {
 				rr.WouldRender, rr.DidRender)
 		}
 
-		gotUid, gotGid := getFileOwnership(path)
-		if *gotGid != wantedGid {
+		gotUid, gotGid, err := getFileOwnership(path)
+		if err != nil {
+			t.Fatalf("getFileOwnership: %s", err)
+		}
+		if gotGid != wantedGid {
 			t.Fatalf("Bad render results; gotUid: %v, wantedGid: %v, gotGid: %v",
-				*gotUid, wantedGid, *gotGid)
+				gotUid, wantedGid, gotGid)
 		}
 
 	})
@@ -452,10 +458,13 @@ func TestRender_Chown(t *testing.T) {
 				rr.WouldRender, rr.DidRender)
 		}
 
-		gotUid, gotGid := getFileOwnership(path)
-		if *gotGid != wantedGid {
+		gotUid, gotGid, err := getFileOwnership(path)
+		if err != nil {
+			t.Fatalf("getFileOwnership: %s", err)
+		}
+		if gotGid != wantedGid {
 			t.Fatalf("Bad render results; gotUid: %v, wantedGid: %v, gotGid: %v",
-				*gotUid, wantedGid, *gotGid)
+				gotUid, wantedGid, gotGid)
 		}
 
 	})
@@ -484,10 +493,13 @@ func TestRender_Chown(t *testing.T) {
 				rr.WouldRender, rr.DidRender)
 		}
 
-		gotUid, gotGid := getFileOwnership(path)
-		if *gotGid != wantedGid {
+		gotUid, gotGid, err := getFileOwnership(path)
+		if err != nil {
+			t.Fatalf("getFileOwnership: %s", err)
+		}
+		if gotGid != wantedGid {
 			t.Fatalf("Bad render results; gotUid: %v, wantedGid: %v, gotGid: %v",
-				*gotUid, wantedGid, *gotGid)
+				gotUid, wantedGid, gotGid)
 		}
 	})
 
@@ -512,8 +524,10 @@ func TestRender_Chown(t *testing.T) {
 		}
 
 		// getting file uid:gid for the default behaviour
-		wantUid, wantGid := getFileOwnership(path)
-
+		wantUid, wantGid, err := getFileOwnership(path)
+		if err != nil {
+			t.Fatalf("getFileOwnership: %s", err)
+		}
 		diff_contents := []byte("not-first")
 		rr, err := Render(&RenderInput{
 			Path:     path,
@@ -530,10 +544,13 @@ func TestRender_Chown(t *testing.T) {
 				rr.WouldRender, rr.DidRender)
 		}
 
-		gotUid, gotGid := getFileOwnership(path)
-		if *gotUid != *wantUid || *gotGid != *wantGid {
+		gotUid, gotGid, err := getFileOwnership(path)
+		if err != nil {
+			t.Fatalf("getFileOwnership: %s", err)
+		}
+		if gotUid != wantUid || gotGid != wantGid {
 			t.Fatalf("Bad render results; we shouldn't have altered uid/gid. wantUid: %v, wantGid: %v, gotUid: %v, gotGid: %v ",
-				*wantUid, *wantGid, *gotUid, *gotGid)
+				wantUid, wantGid, gotUid, gotGid)
 		}
 	})
 
@@ -558,7 +575,10 @@ func TestRender_Chown(t *testing.T) {
 		}
 
 		// getting file uid:gid for the default behaviour
-		wantUid, wantGid := getFileOwnership(path)
+		wantUid, wantGid, err := getFileOwnership(path)
+		if err != nil {
+			t.Fatalf("getFileOwnership: %s", err)
+		}
 
 		diff_contents := []byte("not-first")
 		rr, err := Render(&RenderInput{
@@ -576,10 +596,13 @@ func TestRender_Chown(t *testing.T) {
 				rr.WouldRender, rr.DidRender)
 		}
 
-		gotUid, gotGid := getFileOwnership(path)
-		if *gotUid != *wantUid || *gotGid != *wantGid {
+		gotUid, gotGid, err := getFileOwnership(path)
+		if err != nil {
+			t.Fatalf("getFileOwnership: %s", err)
+		}
+		if gotUid != wantUid || gotGid != wantGid {
 			t.Fatalf("Bad render results; we shouldn't have altered uid/gid. wantUid: %v, wantGid: %v, gotUid: %v, gotGid: %v ",
-				*wantUid, *wantGid, *gotUid, *gotGid)
+				wantUid, wantGid, gotUid, gotGid)
 		}
 	})
 
@@ -604,7 +627,10 @@ func TestRender_Chown(t *testing.T) {
 		}
 
 		// getting file uid:gid for the default behaviour
-		wantUid, wantGid := getFileOwnership(path)
+		wantUid, wantGid, err := getFileOwnership(path)
+		if err != nil {
+			t.Fatalf("getFileOwnership: %s", err)
+		}
 
 		diff_contents := []byte("not-first")
 		rr, err := Render(&RenderInput{
@@ -623,10 +649,13 @@ func TestRender_Chown(t *testing.T) {
 				rr.WouldRender, rr.DidRender)
 		}
 
-		gotUid, gotGid := getFileOwnership(path)
-		if *gotUid != *wantUid || *gotGid != *wantGid {
+		gotUid, gotGid, err := getFileOwnership(path)
+		if err != nil {
+			t.Fatalf("getFileOwnership: %s", err)
+		}
+		if gotUid != wantUid || gotGid != wantGid {
 			t.Fatalf("Bad render results; we shouldn't have altered uid/gid. wantUid: %v, wantGid: %v, gotUid: %v, gotGid: %v ",
-				*wantUid, *wantGid, *gotUid, *gotGid)
+				wantUid, wantGid, gotUid, gotGid)
 		}
 	})
 }


### PR DESCRIPTION
As proposed in https://github.com/hashicorp/consul-template/pull/1531#issuecomment-1023156588, this changes the new file ownership specification from integer `uid`/`gid` to string `user`/`group` that can either be a decimal id or a user/group name. This is both for convenience and for future compatibility with Windows. This change allows us to implement Windows support in the future without changing the public interface in consul-template and Nomad. One catch in the context of Nomad is that user/group names would be looked up on the host, not e.g. inside the Docker container as users may expect.

I also fixed a potential nil dereference via af770eccf6ec1fd2b6722621cea4af50042adb1e and made `Render(...)` fail when trying to set file ownership on Windows analogous to how it fails if `Chmod` fails via [`5be1f70`](https://github.com/hashicorp/consul-template/pull/1541/commits/5be1f708cd67dc7136e8534b924cb67cd244cd6f).

Tagging @eikenb because they kindly offered to review.