### PR TITLE
add -parse-only option

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -422,6 +422,11 @@ func (cli *CLI) ParseFlags(args []string) (
 		return nil
 	}), "once", "")
 
+	flags.Var((funcBoolVar)(func(b bool) error {
+		c.ParseOnly = *(config.Bool(b))
+		return nil
+	}), "parse-only", "")
+
 	flags.Var((funcVar)(func(s string) error {
 		c.PidFile = config.String(s)
 		return nil
@@ -775,6 +780,9 @@ Options:
 
   -once
       Do not run the process as a daemon. This disables wait/quiescence timers.
+
+  -parse-only
+      Do not process templates. Parse them for structure.
 
   -pid-file=<path>
       Path on disk to write the PID of the process

--- a/cli_test.go
+++ b/cli_test.go
@@ -758,6 +758,14 @@ func TestCLI_ParseFlags(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"parse-only",
+			[]string{"-parse-only"},
+			&config.Config{
+				ParseOnly: true,
+			},
+			false,
+		},
 	}
 
 	for i, tc := range cases {

--- a/config/config.go
+++ b/config/config.go
@@ -98,6 +98,10 @@ type Config struct {
 	// Run once, executing each template exactly once, and exit
 	Once bool
 
+	// ParseOnly prevents any rendering and only loads the templates for
+	// checking well formedness.
+	ParseOnly bool
+
 	// BlockQueryWaitTime is amount of time in seconds to do a blocking query for
 	BlockQueryWaitTime *time.Duration `mapstructure:"block_query_wait"`
 }
@@ -163,6 +167,7 @@ func (c *Config) Copy() *Config {
 	}
 
 	o.Once = c.Once
+	o.ParseOnly = c.ParseOnly
 
 	o.BlockQueryWaitTime = c.BlockQueryWaitTime
 
@@ -250,6 +255,7 @@ func (c *Config) Merge(o *Config) *Config {
 	}
 
 	r.Once = o.Once
+	r.ParseOnly = o.ParseOnly
 
 	return r
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2055,6 +2055,18 @@ func TestConfig_Merge(t *testing.T) {
 				},
 			},
 		},
+		{
+			"parse-only",
+			&Config{
+				ParseOnly: false,
+			},
+			&Config{
+				ParseOnly: true,
+			},
+			&Config{
+				ParseOnly: true,
+			},
+		},
 	}
 
 	for i, tc := range cases {

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -225,6 +225,26 @@ func (r *Runner) Start() {
 		r.ErrCh <- err
 		return
 	}
+	if r.config.ParseOnly {
+		log.Printf("[INFO] (runner) ParseOnly mode and all templates parsed")
+
+		if r.child != nil {
+			r.stopDedup()
+			r.stopWatcher()
+
+			log.Printf("[INFO] (runner) waiting for child process to exit")
+			select {
+			case c := <-childExitCh:
+				log.Printf("[INFO] (runner) child process died")
+				r.ErrCh <- NewErrChildDied(c)
+				return
+			case <-r.DoneCh:
+			}
+		}
+
+		r.Stop()
+		return
+	}
 
 	for {
 		// Warn the user if they are watching too many dependencies.

--- a/manager/runner_test.go
+++ b/manager/runner_test.go
@@ -974,6 +974,37 @@ func TestRunner_Start(t *testing.T) {
 			t.Fatal("timeout")
 		}
 	})
+
+	t.Run("parse_only", func(t *testing.T) {
+
+		out, err := ioutil.TempFile("", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(out.Name())
+
+		c := config.DefaultConfig().Merge(&config.Config{
+			Templates: &config.TemplateConfigs{
+				&config.TemplateConfig{
+					Contents:    config.String(`test`),
+					Destination: config.String(out.Name()),
+				},
+			},
+			ParseOnly: true,
+		})
+		c.Finalize()
+
+		r, err := NewRunner(c, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		r.Start()
+
+		if !r.stopped {
+			t.Fatal("expected parse only to stop runner")
+		}
+	})
 }
 
 func TestRunner_quiescence(t *testing.T) {


### PR DESCRIPTION
Allows checking of templates for well formedness without rendering.