### PR TITLE
add new pkiCert template function

### DIFF
--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -44,6 +44,8 @@ func TestMain(m *testing.M) {
 	}
 	testClients = clients
 
+	setupVaultPKI(clients)
+
 	consul_agent := testClients.consul.client.Agent()
 	// service with meta data
 	serviceMetaService := &api.AgentServiceRegistration{

--- a/dependency/vault_pki.go
+++ b/dependency/vault_pki.go
@@ -1,0 +1,166 @@
+package dependency
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	// Ensure implements
+	_ Dependency = (*VaultPKIQuery)(nil)
+)
+
+// VaultPKIQuery is the dependency to Vault for a secret
+type VaultPKIQuery struct {
+	stopCh  chan struct{}
+	sleepCh chan time.Duration
+
+	pkiPath  string
+	data     map[string]interface{}
+	filePath string
+	// populated from cert data
+	pemBlock   *pem.Block
+	expiration time.Time
+}
+
+// NewVaultReadQuery creates a new datacenter dependency.
+func NewVaultPKIQuery(urlpath, filepath string, data map[string]interface{}) (*VaultPKIQuery, error) {
+	urlpath = strings.TrimSpace(urlpath)
+	urlpath = strings.Trim(urlpath, "/")
+	if urlpath == "" {
+		return nil, fmt.Errorf("vault.read: invalid format: %q", urlpath)
+	}
+
+	secretURL, err := url.Parse(urlpath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &VaultPKIQuery{
+		stopCh:   make(chan struct{}, 1),
+		sleepCh:  make(chan time.Duration, 1),
+		pkiPath:  secretURL.Path,
+		data:     data,
+		filePath: filepath,
+	}, nil
+}
+
+// Fetch queries the Vault API
+func (d *VaultPKIQuery) Fetch(clients *ClientSet, opts *QueryOptions,
+) (interface{}, *ResponseMetadata, error) {
+	select {
+	case <-d.stopCh:
+		return nil, nil, ErrStopped
+	default:
+	}
+	select {
+	case dur := <-d.sleepCh:
+		time.Sleep(dur)
+	default:
+	}
+
+	var encPEM []byte
+	var err error
+	if encPEM, err = os.ReadFile(d.filePath); err != nil || len(encPEM) == 0 {
+		// no need to write to file as it is the template dest
+		encPEM, err = d.fetchPEM(clients)
+	}
+	if err != nil {
+		return nil, nil, errors.Wrap(err, d.String())
+	}
+
+	block, cert, err := getCert(encPEM)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if sleepFor, ok := goodFor(cert); ok {
+		d.sleepCh <- sleepFor
+		return string(pem.EncodeToMemory(block)), nil, nil
+	}
+	d.pemBlock = nil
+	return "", &ResponseMetadata{
+		LastContact: 0,
+		LastIndex:   0,
+	}, nil
+}
+
+// returns time left in 90% of the original lease
+// boolean returns false if time has already past
+func goodFor(cert *x509.Certificate) (time.Duration, bool) {
+	start, end := cert.NotBefore.Unix(), cert.NotAfter.Unix()
+	// use 90% of the cert duration
+	goodfor := ((end - start) * 9) / 10
+	sleepFor := time.Until(time.Unix(start+goodfor, 0))
+	return sleepFor, sleepFor > 0
+}
+
+// loops through all pem encoded blocks in the byte stream
+// returning the first certificate found (ignoring CAs and chain certs)
+func getCert(encoded []byte) (*pem.Block, *x509.Certificate, error) {
+	var block *pem.Block
+	var firstErr error
+	for {
+		block, encoded = pem.Decode(encoded)
+		if block != nil {
+			cert, err := x509.ParseCertificate(block.Bytes)
+			switch {
+			case err == nil && !cert.IsCA:
+				return block, cert, nil
+			case firstErr == nil:
+				firstErr = err
+			}
+			continue
+		}
+		break
+	}
+	return nil, nil, errors.Wrap(firstErr, "failed to parse cert")
+}
+
+//
+func (d *VaultPKIQuery) fetchPEM(clients *ClientSet) ([]byte, error) {
+	vaultSecret, err := clients.Vault().Logical().Write(d.pkiPath, d.data)
+	switch {
+	case err != nil:
+		return nil, errors.Wrap(err, d.String())
+	case vaultSecret == nil:
+		return nil, fmt.Errorf("no secret exists at %s", d.pkiPath)
+	}
+	printVaultWarnings(d, vaultSecret.Warnings)
+	encPEM, ok := vaultSecret.Data["certificate"].(string)
+	if !ok {
+		return nil, fmt.Errorf("secret didn't include cert")
+	}
+	return []byte(encPEM), nil
+}
+
+func (d *VaultPKIQuery) stopChan() chan struct{} {
+	return d.stopCh
+}
+
+// CanShare returns if this dependency is shareable.
+func (d *VaultPKIQuery) CanShare() bool {
+	return false
+}
+
+// Stop halts the given dependency's fetch.
+func (d *VaultPKIQuery) Stop() {
+	close(d.stopCh)
+}
+
+// String returns the human-friendly version of this dependency.
+func (d *VaultPKIQuery) String() string {
+	return fmt.Sprintf("vault.pki(%s)", d.pkiPath)
+}
+
+// Type returns the type of this dependency.
+func (d *VaultPKIQuery) Type() Type {
+	return TypeVault
+}

--- a/dependency/vault_pki_test.go
+++ b/dependency/vault_pki_test.go
@@ -1,0 +1,212 @@
+// go:build ignore
+
+package dependency
+
+import (
+	"bytes"
+	"encoding/pem"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/consul-template/renderer"
+	"github.com/hashicorp/vault/api"
+)
+
+func Test_VaultPKI_notGoodFor(t *testing.T) {
+	// only test the negation, postive is tested below with certificates
+	// fetched in Vault integration tests (creating certs is non-trivial)
+	_, cert, err := getCert([]byte(goodCert))
+	if err != nil {
+		t.Error(err)
+	}
+	dur, ok := goodFor(cert)
+	if ok != false {
+		t.Error("should be false")
+	}
+	// duration should be negative as cert has already expired
+	// but still tests cert time parsing (it'd be 0 if there was an issue)
+	if dur >= 0 {
+		t.Error("cert shouldn't be 0 or positive (old cert)")
+	}
+}
+
+func Test_VaultPKI_getCert(t *testing.T) {
+	// tests w/ valid cert
+	for _, testcert := range []string{goodCert, goodBad, badGood, goodCertAfterCA, goodCertGarbo} {
+		pemBlk, cert, err := getCert([]byte(testcert))
+		if err != nil {
+			t.Fatal(err) // Fatal to avoid panic's below
+		}
+		got := strings.TrimRight(string(pem.EncodeToMemory(pemBlk)), "\n")
+		want := strings.TrimRight(strings.TrimSpace(goodCert), "\n")
+		if got != want {
+			t.Errorf("certs didn't match:\ngot: %v\nwant: %v", got, want)
+		}
+		if err := cert.VerifyHostname("foo.example.com"); err != nil {
+			t.Error(err)
+		}
+	}
+	// tests w/o valid cert (test error)
+	expectedErr := "x509: malformed certificate"
+	for _, badcert := range []string{badCert, badPlusCA, badPlusGarbo} {
+		_, _, err := getCert([]byte(badcert))
+		switch {
+		case err == nil:
+			t.Errorf("error should not be nil")
+		case !strings.Contains(err.Error(), expectedErr):
+			t.Errorf("wrong error; wanted: '%s', got: '%s'", expectedErr, err)
+		}
+	}
+}
+
+func Test_VaultPKI_fetchPEM(t *testing.T) {
+	clients := testClients
+
+	data := map[string]interface{}{
+		"common_name": "foo.example.com",
+		"ttl":         "2h",
+		"ip_sans":     "127.0.0.1,192.168.2.2",
+	}
+	d, err := NewVaultPKIQuery("pki/issue/example-dot-com", "/dev/null", data)
+	if err != nil {
+		t.Error(err)
+	}
+	encPEM, err := d.fetchPEM(clients)
+	if err != nil {
+		t.Error(err)
+	}
+	if !bytes.Contains(encPEM, []byte("CERTIFICATE")) {
+		t.Errorf("certificate not fetched, got: %s", string(encPEM))
+	}
+	// test path error
+	d, err = NewVaultPKIQuery("pki/issue/does-not-exist", "/dev/null", data)
+	if err != nil {
+		t.Error(err)
+	}
+	_, err = d.fetchPEM(clients)
+	var respErr *api.ResponseError
+	if !errors.As(err, &respErr) {
+		t.Error(err)
+	}
+}
+
+func Test_VaultPKI_refetch(t *testing.T) {
+	f, err := os.CreateTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Remove(f.Name())
+	defer os.Remove(f.Name())
+
+	clients := testClients
+	/// above is prep work
+	data := map[string]interface{}{
+		"common_name": "foo.example.com",
+		"ttl":         "2h",
+		"ip_sans":     "127.0.0.1,192.168.2.2",
+	}
+	d, err := NewVaultPKIQuery("pki/issue/example-dot-com", f.Name(), data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	act1, _, err := d.Fetch(clients, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cert1, ok := act1.(string)
+	if !ok || !strings.Contains(cert1, "BEGIN") {
+		t.Fatalf("expected a cert but found: %s", cert1)
+	}
+
+	// Fake template rendering file to disk
+	renderer.Render(&renderer.RenderInput{
+		Contents: []byte(cert1),
+		Path:     f.Name(),
+	})
+
+	// re-fetch, should be the same cert pulled from the file
+	// if re-fetched from Vault it will be different
+	<-d.sleepCh // drain sleepCh so we don't wait
+	act2, _, err := d.Fetch(clients, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cert2, ok := act2.(string)
+	if !ok || !strings.Contains(cert2, "BEGIN") {
+		t.Fatalf("expected a cert but found: %s", cert2)
+	}
+
+	if cert1 != cert2 {
+		t.Errorf("certs don't match and should. cert1: %s, cert2: %s", cert1, cert2)
+	}
+}
+
+const goodCert = `
+-----BEGIN CERTIFICATE-----
+MIIDWTCCAkGgAwIBAgIUUARA+vQExU8zjdsX/YXMMu1K5FkwDQYJKoZIhvcNAQEL
+BQAwFjEUMBIGA1UEAxMLZXhhbXBsZS5jb20wHhcNMjIwMzAxMjIzMzAzWhcNMjIw
+MzA0MjIzMzMzWjAaMRgwFgYDVQQDEw9mb28uZXhhbXBsZS5jb20wggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDD3sktiNGo/CSvtL84+GIcsuDzp1VFjG++
+8P682ZPiqPGjrgwe3P8ypyhQv6I8ZGOyu7helMqBN/S1mrhmHWUONy/4o95QWDsJ
+CGw4H44dRil5hKC6K8BUrf79XGAGIQJr3T6I5CCwxukfYhU/+xNE3dq5AgLrIIB2
+BtzZA6m1T5CmgAzSzI1byTjaRpxOJjucI37iKzkx7AkYS5hGfVsFmJgGi/UXhvzK
+uwnHHIq9rLItx7p261dJV8mxRDFaf4x+4bZh2kYkEaG8REOfyHSCJ78RniWbF/DN
+Jtgh8bT2/938/ecBtWcTN+psICD62DJii6988FD2qS+Yd8Eu8M5rAgMBAAGjgZow
+gZcwDgYDVR0PAQH/BAQDAgOoMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcD
+AjAdBgNVHQ4EFgQUfmm32UJb3xJNxfA7ZB0Q5RXsQIkwHwYDVR0jBBgwFoAUDoYJ
+CtobWJrR1xmTsYJd9buj2jwwJgYDVR0RBB8wHYIPZm9vLmV4YW1wbGUuY29thwR/
+AAABhwTAqAEpMA0GCSqGSIb3DQEBCwUAA4IBAQBzB+RM2PSZPmDG3xJssS1litV8
+TOlGtBAOUi827W68kx1lprp35c9Jyy7l4AAu3Q1+az3iDQBfYBazq89GOZeXRvml
+x9PVCjnXP2E7mH9owA6cE+Z1cLN/5h914xUZCb4t9Ahu04vpB3/bnoucXdM5GJsZ
+EJylY99VsC/bZKPCheZQnC/LtFBC31WEGYb8rnB7gQxmH99H91+JxnJzYhT1a6lw
+arHERAKScrZMTrYPLt2YqYoeyO//aCuT9YW6YdIa9jPQhzjeMKXywXLetE+Ip18G
+eB01bl42Y5WwHl0IrjfbEevzoW0+uhlUlZ6keZHr7bLn/xuRCUkVfj3PRlMl
+-----END CERTIFICATE-----
+`
+
+const goodCA = `
+-----BEGIN CERTIFICATE-----
+MIIDNTCCAh2gAwIBAgIUbJ/1ELw6X6OUg6YeVtsTqg20G2swDQYJKoZIhvcNAQEL
+BQAwFjEUMBIGA1UEAxMLZXhhbXBsZS5jb20wHhcNMjIwMzAxMjIzMjQ3WhcNMjMw
+MzAxMjIzMzE2WjAWMRQwEgYDVQQDEwtleGFtcGxlLmNvbTCCASIwDQYJKoZIhvcN
+AQEBBQADggEPADCCAQoCggEBAPAiGf1Shr7e/AA7VGsaQiMKz9+HoTgrt4mJIAPu
+aelNavl7umr1AckEc7g+zGYauJmhfsPalS5BlvZ1hjBhgi4g1MsKf/64BLfxkxJH
+HLX2kAEUBzFWBeX0EE/rl0pb81afZv+6Kyi2X6cN3kFC0gEtF1BScAoWEKWYx9xz
+oPzB7Qql4BKaZ8KXgeryDIQ4Zbg2yKwSdS9TILGMylvqCdne5UkQP7bGW0i4C7r9
+noDtJZIo83vzH6YlN99C66pLm8m3qnKgWk5clIizlh9lw0XEQKZQ69tRNuxRSF5r
+6XVaDWoYEOm+gJ7DRoKEHqA4ov1BbfLEocvEzjfcrulb1bsCAwEAAaN7MHkwDgYD
+VR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFA6GCQraG1ia
+0dcZk7GCXfW7o9o8MB8GA1UdIwQYMBaAFA6GCQraG1ia0dcZk7GCXfW7o9o8MBYG
+A1UdEQQPMA2CC2V4YW1wbGUuY29tMA0GCSqGSIb3DQEBCwUAA4IBAQC2yfszyLyX
+7Yhuzvda3EYKTsfiXA6+Cqx7TZVyIHF0AgEkeIaDmmB5Gh6cizvtpHpwLwB94UWq
+LNda6gzocChpC34A2xZ5QLCk+xeNrC1rHH+wk90K9ac+G5rtVQhzNKXBMup6GZFu
+zOi+yS9f/oKtx0obrjG/NVtYcxAZ/2Zv1Mu4MLuw9EGrWztvEOImd8G22sgigsbJ
+WR7VgKRCphRGmfp/SlI3c/zYScHHanZ3umQvilPmftPX+BxVFA5FhCUUimkZEJMq
++hmBcwd8e1LZLz7Mz5IsrN6+lRZ78T+zV8sxNdF1mIWs+ZsrmzQBZq4Q0uLjDiD/
+v57ZY8gIDE5E
+-----END CERTIFICATE-----
+`
+const goodCertAfterCA = goodCA + goodCert
+const goodCertGarbo = `
+aa983w4;/amndsfm908q26035vc;ng902338(%@%!@QY!&DVLMNSALX>PT(RQ!QO*%@
+` + goodCert + `
+!Q)(*@^YUO!Q#MN%$#WP(G^&+_!%)!+^%$Y	:!#QLKENFVJ)	!#*&%YHTM
+`
+const badCert = `
+-----BEGIN CERTIFICATE-----
+MIIDWTCCAkGgAwIBAgIUUARA+vQExU8zjdsX/YXMMu1K5FkwDQYJKoZIhvcNAQEL
+eB01bl42Y5WwHl0IrjfbEevzoW0+uhlUlZ6keZHr7bLn/xuRCUkVfj3PRlMl
+-----END CERTIFICATE-----
+`
+const badPlusCA = badCert + goodCA
+const badPlusGarbo = `
+aa983w4;/amndsfm908q26035vc;ng902338(%@%!@QY!&DVLMNSALX>PT(RQ!QO*%@
+` + badCert + `
+!Q)(*@^YUO!Q#MN%$#WP(G^&+_!%)!+^%$Y	:!#QLKENFVJ)	!#*&%YHTM
+`
+const badGood = badCert + goodCert
+const goodBad = goodCert + badCert

--- a/dependency/vault_read_test.go
+++ b/dependency/vault_read_test.go
@@ -520,27 +520,14 @@ func TestVaultReadQuery_Fetch_KVv2(t *testing.T) {
 func TestVaultReadQuery_Fetch_PKI_Anonymous(t *testing.T) {
 	clients := testClients
 
-	err := clients.Vault().Sys().Mount("pki", &api.MountInput{
-		Type: "pki",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	vc := clients.Vault()
-	_, err = vc.Logical().Write("sys/policies/acl/secrets-only",
+	_, err := vc.Logical().Write("sys/policies/acl/secrets-only",
 		map[string]interface{}{
 			"policy": `path "secret/*" { capabilities = ["create", "read"] }`,
 		})
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	_, err = vc.Logical().Write("pki/root/generate/internal",
-		map[string]interface{}{
-			"common_name": "example.com",
-			"ttl":         "24h",
-		})
 
 	anonClient := NewClientSet()
 	anonClient.CreateVaultClient(&CreateVaultClientInput{
@@ -567,6 +554,7 @@ func TestVaultReadQuery_Fetch_PKI_Anonymous(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected secret but found %v", reflect.TypeOf(act))
 	}
+
 	cert, ok := sec.Data["certificate"].(string)
 	if !ok || !strings.Contains(cert, "BEGIN") {
 		t.Fatalf("expected a cert but found: %v", cert)

--- a/docs/templating-language.md
+++ b/docs/templating-language.md
@@ -20,6 +20,7 @@ provides the following functions:
   - [nodes](#nodes)
   - [secret](#secret)
   - [secrets](#secrets)
+  - [pkiCert](#pkicert)
   - [service](#service)
   - [services](#services)
   - [tree](#tree)
@@ -588,6 +589,25 @@ You should probably never do this.
 Please also note that Vault does not support
 blocking queries. To understand the implications, please read the note at the
 end of the `secret` function.
+
+### `pkiCert`
+
+Query [Vault][vault] for a PKI certificate. It returns the certificate PEM
+encoded in a string. It only returns the PKI certificate, not the CA, key or
+any other informaion about the certificate.
+
+**Special Note**: This function uses the template file destination as a cache
+for the certificate to prevent Consul-Template from re-fetching it on reload or
+restart. This special behavior is to better work with Vault's PKI behavior of
+always returning a new certificate even if the current one is still good. Using
+the destination file as a local "cache" allows Consul-Template to check for the
+certificate in that local file and, if found, parse it and checks it's valid
+date range only fetching a new certificate if the local one has expired.
+
+
+```golang
+{{ pkiCert "pki/issue/my-domain-dot-com" "common_name=foo.example.com" }}
+```
 
 ### `service`
 

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -333,6 +333,43 @@ func nodesFunc(b *Brain, used, missing *dep.Set) func(...string) ([]*dep.Node, e
 	}
 }
 
+// pkiCertFunc returns a PKI cert from Vault
+func pkiCertFunc(b *Brain, used, missing *dep.Set, destPath string) func(...string) (interface{}, error) {
+	return func(s ...string) (interface{}, error) {
+		if len(s) == 0 {
+			return nil, nil
+		}
+
+		path, rest := s[0], s[1:]
+		data := make(map[string]interface{})
+		for _, str := range rest {
+			if len(str) == 0 {
+				continue
+			}
+			parts := strings.SplitN(str, "=", 2)
+			if len(parts) != 2 {
+				return nil, fmt.Errorf("not k=v pair %q", str)
+			}
+
+			k, v := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+			data[k] = v
+		}
+
+		d, err := dep.NewVaultPKIQuery(path, destPath, data)
+		if err != nil {
+			return nil, err
+		}
+
+		used.Add(d)
+		if value, ok := b.Recall(d); ok {
+			return value, nil
+		}
+		missing.Add(d)
+
+		return nil, nil
+	}
+}
+
 // secretFunc returns or accumulates secret dependencies from Vault.
 func secretFunc(b *Brain, used, missing *dep.Set) func(...string) (interface{}, error) {
 	return func(s ...string) (interface{}, error) {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1929,6 +1929,25 @@ func TestTemplate_Execute(t *testing.T) {
 			false,
 		},
 		{
+			"func_pkiCert",
+			&NewTemplateInput{
+				Contents: `{{ pkiCert "pki/issue/egs-dot-com" }}`,
+			},
+			&ExecuteInput{
+				Brain: func() *Brain {
+					b := NewBrain()
+					d, err := dep.NewVaultPKIQuery("pki/issue/egs-dot-com", "/dev/null", nil)
+					if err != nil {
+						t.Fatal(err)
+					}
+					b.Remember(d, testCert)
+					return b
+				}(),
+			},
+			testCert,
+			false,
+		},
+		{
 			"spew_sdump_simple_output",
 			&NewTemplateInput{
 				Contents: `{{ timestamp "2006-01-02" | spew_sdump }}`,
@@ -1993,7 +2012,7 @@ func Test_writeToFile(t *testing.T) {
 
 	cases := []struct {
 		name        string
-		filePath   string
+		filePath    string
 		content     string
 		username    string
 		groupName   string
@@ -2190,3 +2209,26 @@ func Test_writeToFile(t *testing.T) {
 		})
 	}
 }
+
+const testCert = `
+-----BEGIN CERTIFICATE-----
+MIIDWTCCAkGgAwIBAgIUUARA+vQExU8zjdsX/YXMMu1K5FkwDQYJKoZIhvcNAQEL
+BQAwFjEUMBIGA1UEAxMLZXhhbXBsZS5jb20wHhcNMjIwMzAxMjIzMzAzWhcNMjIw
+MzA0MjIzMzMzWjAaMRgwFgYDVQQDEw9mb28uZXhhbXBsZS5jb20wggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDD3sktiNGo/CSvtL84+GIcsuDzp1VFjG++
+8P682ZPiqPGjrgwe3P8ypyhQv6I8ZGOyu7helMqBN/S1mrhmHWUONy/4o95QWDsJ
+CGw4H44dRil5hKC6K8BUrf79XGAGIQJr3T6I5CCwxukfYhU/+xNE3dq5AgLrIIB2
+BtzZA6m1T5CmgAzSzI1byTjaRpxOJjucI37iKzkx7AkYS5hGfVsFmJgGi/UXhvzK
+uwnHHIq9rLItx7p261dJV8mxRDFaf4x+4bZh2kYkEaG8REOfyHSCJ78RniWbF/DN
+Jtgh8bT2/938/ecBtWcTN+psICD62DJii6988FD2qS+Yd8Eu8M5rAgMBAAGjgZow
+gZcwDgYDVR0PAQH/BAQDAgOoMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcD
+AjAdBgNVHQ4EFgQUfmm32UJb3xJNxfA7ZB0Q5RXsQIkwHwYDVR0jBBgwFoAUDoYJ
+CtobWJrR1xmTsYJd9buj2jwwJgYDVR0RBB8wHYIPZm9vLmV4YW1wbGUuY29thwR/
+AAABhwTAqAEpMA0GCSqGSIb3DQEBCwUAA4IBAQBzB+RM2PSZPmDG3xJssS1litV8
+TOlGtBAOUi827W68kx1lprp35c9Jyy7l4AAu3Q1+az3iDQBfYBazq89GOZeXRvml
+x9PVCjnXP2E7mH9owA6cE+Z1cLN/5h914xUZCb4t9Ahu04vpB3/bnoucXdM5GJsZ
+EJylY99VsC/bZKPCheZQnC/LtFBC31WEGYb8rnB7gQxmH99H91+JxnJzYhT1a6lw
+arHERAKScrZMTrYPLt2YqYoeyO//aCuT9YW6YdIa9jPQhzjeMKXywXLetE+Ip18G
+eB01bl42Y5WwHl0IrjfbEevzoW0+uhlUlZ6keZHr7bLn/xuRCUkVfj3PRlMl
+-----END CERTIFICATE-----
+`


### PR DESCRIPTION
The new pkiCert template function and its dependency. Common PKI dependency testing setup code was placed in vault_common and called in TestMain. Documentation and template tests round things out.

Most of this is pretty standard new-template-function stuff. The main differing point for this Dependency is that it is specialized to the certificate and uses the rendered template destination file as a cache for the certificate, reading it in and checking the dates to see if it is still valid. If so it reuses it, if not (or if it's not there) it fetches a new one. It tries to handle this 'cache' file as forgivingly as possible, skipping over other CA certificates and text for the PEM encoded/formatted certificate. It should skip any CA, root or intermediary/chain.

Fixes #1259 