### PR TITLE
Remove writeToFile reliance on cgo/$USER for UID/GID detection

### DIFF
--- a/template/funcs.go
+++ b/template/funcs.go
@@ -1711,13 +1711,12 @@ func writeToFile(path, username, groupName, permissions string, args ...string) 
 	// Change ownership and permissions
 	var uid int
 	var gid int
-	cu, err := user.Current()
 	if err != nil {
 		return "", err
 	}
 
 	if username == "" {
-		uid, _ = strconv.Atoi(cu.Uid)
+		uid = os.Getuid()
 	} else {
 		var convErr error
 		u, err := user.Lookup(username)
@@ -1733,7 +1732,7 @@ func writeToFile(path, username, groupName, permissions string, args ...string) 
 	}
 
 	if groupName == "" {
-		gid, _ = strconv.Atoi(cu.Gid)
+		gid = os.Getgid()
 	} else {
 		var convErr error
 		g, err := user.LookupGroup(groupName)


### PR DESCRIPTION
@eikenb One _very_ tiny change I hope we can sneak in before 0.28.1. I didn't realize that using `user.Current()` relies solely on the `USER` environment variable if the binary isn't built with CGo. We should absolutely just be grabbing the UID and GID from the `os` package.