### PR TITLE
fix name/use of confusing Block flag

### DIFF
--- a/dependency/connect_ca.go
+++ b/dependency/connect_ca.go
@@ -49,7 +49,6 @@ func (d *ConnectCAQuery) Fetch(clients *ClientSet, opts *QueryOptions) (
 	rm := &ResponseMetadata{
 		LastIndex:   md.LastIndex,
 		LastContact: md.LastContact,
-		Block:       true,
 	}
 
 	return certs.Roots, rm, nil

--- a/dependency/connect_leaf.go
+++ b/dependency/connect_leaf.go
@@ -51,7 +51,6 @@ func (d *ConnectLeafQuery) Fetch(clients *ClientSet, opts *QueryOptions) (
 	rm := &ResponseMetadata{
 		LastIndex:   md.LastIndex,
 		LastContact: md.LastContact,
-		Block:       true,
 	}
 
 	return cert, rm, nil

--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -145,7 +145,7 @@ func (q *QueryOptions) String() string {
 type ResponseMetadata struct {
 	LastIndex   uint64
 	LastContact time.Duration
-	Block       bool
+	BlockOnNil  bool // keep blocking on `nil` data returns
 }
 
 // deepCopyAndSortTags deep copies the tags in the given string slice and then


### PR DESCRIPTION
The Block flag returned in the ResponseMetadata from Fetch was
confusing. It sounds like it should be about blocking query, but it is
really about a query that would normally block but instead is returning
no data/nil. The logic in this case is to just loop around to call Fetch
again instead of returning the nil data.

The only case of this is KV Get. Consul returns a 404 for KV lookups
on invalid paths but the GO API ignores this error and returns nil data
(and nil error) instead. By having it just loop again it is basically
letting you to have a blocking-like call on a key that doesn't exist yet
(but could come into existance).

This change fixes the naming of the flag to be more obvious in its
meaning, adding a few reminder comments as well as cleaning up a bit
of use from the confusion.