### PR TITLE
fixed typo in docu

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -526,7 +526,7 @@ template {
   # See the Exec section below and the Commands section in the README for more.
   exec {
       command = ["restart", "service", "foo"]
-      timout = "30s"
+      timeout = "30s"
   }
 
   # For backwards compatibility the template block also supports a bare


### PR DESCRIPTION
I just copied the exec part from the docu and did not even see the typo. consul-template threw the error then =)