### PR TITLE
Fix changing user and group not working

### DIFF
--- a/config/template.go
+++ b/config/template.go
@@ -158,6 +158,12 @@ func (c *TemplateConfig) Copy() *TemplateConfig {
 
 	o.Source = c.Source
 
+	o.User = c.User
+	o.Group = c.Group
+
+	o.Uid = c.Uid
+	o.Gid = c.Gid
+
 	if c.Wait != nil {
 		o.Wait = c.Wait.Copy()
 	}


### PR DESCRIPTION
fixes #1570

The user/group/uid/gid are parsed correctly but lost after calling copy, which leads to renderer doesn't have any info to change file permission when rendering 