### PR TITLE
Fix pkiCert not  working correctly

### DIFF
--- a/dependency/vault_pki.go
+++ b/dependency/vault_pki.go
@@ -83,7 +83,7 @@ func (d *VaultPKIQuery) Fetch(clients *ClientSet, opts *QueryOptions,
 
 	if sleepFor, ok := goodFor(cert); ok {
 		d.sleepCh <- sleepFor
-		return string(pem.EncodeToMemory(block)), nil, nil
+		return respWithMetadata(string(pem.EncodeToMemory(block)))
 	}
 	d.pemBlock = nil
 	return "", &ResponseMetadata{

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -944,6 +944,7 @@ func (r *Runner) init() error {
 			RightDelim:       rightDelim,
 			FunctionDenylist: ctmpl.FunctionDenylist,
 			SandboxPath:      config.StringVal(ctmpl.SandboxPath),
+			Destination:      config.StringVal(ctmpl.Destination),
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixes #1569

And I found one more bug where the destination is not passed correctly into template, so pkiCert can't find the file and think that is it should issue a new cert instead.