### PR TITLE
reduce os.Signal noise

### DIFF
--- a/signals/signals.go
+++ b/signals/signals.go
@@ -13,14 +13,18 @@ var SIGNIL os.Signal = new(NilSignal)
 // ValidSignals is the list of all valid signals. This is built at runtime
 // because it is OS-dependent.
 var ValidSignals []string
+var MonitoredSignals []os.Signal
 
 func init() {
 	valid := make([]string, 0, len(SignalLookup))
-	for k := range SignalLookup {
+	monitored := make([]os.Signal, 0, len(SignalLookup))
+	for k, v := range SignalLookup {
 		valid = append(valid, k)
+		monitored = append(monitored, v)
 	}
 	sort.Strings(valid)
 	ValidSignals = valid
+	MonitoredSignals = monitored
 }
 
 // Parse parses the given string as a signal. If the signal is not found,

--- a/signals/signals_unix.go
+++ b/signals/signals_unix.go
@@ -8,15 +8,14 @@ import (
 	"syscall"
 )
 
-// RuntimeSig is set to SIGURG, a signal used by the runtime on *nix systems to
-// manage pre-emptive scheduling.
-const RuntimeSig = syscall.SIGURG
+//// Ignored Signals
+// SIGCHLD - don't propagate these to child process as we manage it instead
+// SIGURG  - used by the golang scheduler for parallel runtime.
 
 var SignalLookup = map[string]os.Signal{
 	"SIGABRT":  syscall.SIGABRT,
 	"SIGALRM":  syscall.SIGALRM,
 	"SIGBUS":   syscall.SIGBUS,
-	"SIGCHLD":  syscall.SIGCHLD,
 	"SIGCONT":  syscall.SIGCONT,
 	"SIGFPE":   syscall.SIGFPE,
 	"SIGHUP":   syscall.SIGHUP,
@@ -36,7 +35,6 @@ var SignalLookup = map[string]os.Signal{
 	"SIGTSTP":  syscall.SIGTSTP,
 	"SIGTTIN":  syscall.SIGTTIN,
 	"SIGTTOU":  syscall.SIGTTOU,
-	"SIGURG":   syscall.SIGURG,
 	"SIGUSR1":  syscall.SIGUSR1,
 	"SIGUSR2":  syscall.SIGUSR2,
 	"SIGWINCH": syscall.SIGWINCH,

--- a/signals/signals_windows.go
+++ b/signals/signals_windows.go
@@ -8,9 +8,6 @@ import (
 	"syscall"
 )
 
-// RuntimeSig is set to nil on windows as it doesn't support the signal (SIGURG)
-var RuntimeSig = os.Signal(nil)
-
 var SignalLookup = map[string]os.Signal{
 	"SIGABRT": syscall.SIGABRT,
 	"SIGALRM": syscall.SIGALRM,


### PR DESCRIPTION
User reported missing signals due to a lot of SIGURG signals (Go
scheduler signals). We added code a while back to ignore SIGURG, but
they still are received and take up channel buffer spots. They had to
bump the buffer size to 100 to get it happy.

Reviewing the code there was a handy list of all the signals we accept
in the local signals/ package. So I trimmed out the ignored signals
(SIGURG and SIGCHLD) and passed that to Notify so I wouldn't get the
ignored signals on the channel.

I also bumped the signal channel size to 10 to be a bit more flexible
there as well.

Fixes #1548