### PR TITLE
sort: use strictly less-than for less implementations

### DIFF
--- a/config/nomad.go
+++ b/config/nomad.go
@@ -2,7 +2,7 @@ package config
 
 import "fmt"
 
-// NomadConfig is the configuration for connecto to a Nomad agent.
+// NomadConfig is the configuration for connecting to a Nomad agent.
 type NomadConfig struct {
 	// Address is the URI to the Nomad agent.
 	Address *string `mapstructure:"address"`

--- a/dependency/catalog_node.go
+++ b/dependency/catalog_node.go
@@ -175,7 +175,7 @@ func (s ByService) Len() int      { return len(s) }
 func (s ByService) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s ByService) Less(i, j int) bool {
 	if s[i].Service == s[j].Service {
-		return s[i].ID <= s[j].ID
+		return s[i].ID < s[j].ID
 	}
-	return s[i].Service <= s[j].Service
+	return s[i].Service < s[j].Service
 }

--- a/dependency/catalog_nodes.go
+++ b/dependency/catalog_nodes.go
@@ -144,7 +144,7 @@ func (s ByNode) Len() int      { return len(s) }
 func (s ByNode) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s ByNode) Less(i, j int) bool {
 	if s[i].Node == s[j].Node {
-		return s[i].Address <= s[j].Address
+		return s[i].Address < s[j].Address
 	}
-	return s[i].Node <= s[j].Node
+	return s[i].Node < s[j].Node
 }

--- a/dependency/catalog_services.go
+++ b/dependency/catalog_services.go
@@ -119,11 +119,6 @@ func (d *CatalogServicesQuery) Type() Type {
 // ByName is a sortable slice of CatalogService structs.
 type ByName []*CatalogSnippet
 
-func (s ByName) Len() int      { return len(s) }
-func (s ByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-func (s ByName) Less(i, j int) bool {
-	if s[i].Name <= s[j].Name {
-		return true
-	}
-	return false
-}
+func (s ByName) Len() int           { return len(s) }
+func (s ByName) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s ByName) Less(i, j int) bool { return s[i].Name < s[j].Name }

--- a/dependency/health_service.go
+++ b/dependency/health_service.go
@@ -268,7 +268,7 @@ func (s ByNodeThenID) Less(i, j int) bool {
 	if s[i].Node < s[j].Node {
 		return true
 	} else if s[i].Node == s[j].Node {
-		return s[i].ID <= s[j].ID
+		return s[i].ID < s[j].ID
 	}
 	return false
 }

--- a/dependency/nomad_service.go
+++ b/dependency/nomad_service.go
@@ -154,11 +154,6 @@ func (d *NomadServiceQuery) Type() Type {
 // NomadServiceByName is a sortable slice of NomadService structs.
 type NomadServiceByName []*NomadService
 
-func (s NomadServiceByName) Len() int      { return len(s) }
-func (s NomadServiceByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-func (s NomadServiceByName) Less(i, j int) bool {
-	if s[i].Name <= s[j].Name {
-		return true
-	}
-	return false
-}
+func (s NomadServiceByName) Len() int           { return len(s) }
+func (s NomadServiceByName) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s NomadServiceByName) Less(i, j int) bool { return s[i].Name < s[j].Name }

--- a/dependency/nomad_services.go
+++ b/dependency/nomad_services.go
@@ -34,14 +34,9 @@ type NomadServicesSnippet struct {
 // nomadSortableSnippet is a sortable slice of NomadServicesSnippet structs.
 type nomadSortableSnippet []*NomadServicesSnippet
 
-func (s nomadSortableSnippet) Len() int      { return len(s) }
-func (s nomadSortableSnippet) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-func (s nomadSortableSnippet) Less(i, j int) bool {
-	if s[i].Name <= s[j].Name {
-		return true
-	}
-	return false
-}
+func (s nomadSortableSnippet) Len() int           { return len(s) }
+func (s nomadSortableSnippet) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s nomadSortableSnippet) Less(i, j int) bool { return s[i].Name < s[j].Name }
 
 // NomadServicesQuery is the representation of a requested Nomad service
 // dependency from inside a template.

--- a/template/brain.go
+++ b/template/brain.go
@@ -31,7 +31,7 @@ func NewBrain() *Brain {
 
 // Remember accepts a dependency and the data to store associated with that
 // dep. This function converts the given data to a proper type and stores
-// it interally.
+// it internally.
 func (b *Brain) Remember(d dep.Dependency, data interface{}) {
 	b.Lock()
 	defer b.Unlock()


### PR DESCRIPTION
This PR updates implementations of the `sort.Less` interface to use
strictly less-than evalutation of arguments.

https://pkg.go.dev/sort#Interface

	// Less reports whether the element with index i
	// must sort before the element with index j.
	//
	// If both Less(i, j) and Less(j, i) are false,
	// then the elements at index i and j are considered equal.
	// Sort may place equal elements in any order in the final result,
	// while Stable preserves the original input or

I suspect `<=` only causes a problem when used in conjunction with sort.Stable
as the results will not actually be stable. However we do in fact use sort.Stable
in consul-template.

```
➜ rg sort\.Stable
dependency/catalog_node.go
126:	sort.Stable(ByService(services))

dependency/catalog_services.go
86:	sort.Stable(ByName(catalogServices))

dependency/nomad_services.go
108:	sort.Stable(nomadSortableSnippet(services))

dependency/nomad_service.go
120:	sort.Stable(NomadServiceByName(services))

dependency/catalog_nodes.go
98:		sort.Stable(ByNode(nodes))

dependency/health_service.go
204:		sort.Stable(ByNodeThenID(list))
```