### PR TITLE
nomad: add support for querying consistent subset of services

### DIFF
--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -53,6 +53,7 @@ type QueryOptions struct {
 	Datacenter        string
 	Region            string
 	Near              string
+	Choose            string
 	RequireConsistent bool
 	VaultGrace        time.Duration
 	WaitIndex         uint64
@@ -92,6 +93,10 @@ func (q *QueryOptions) Merge(o *QueryOptions) *QueryOptions {
 		r.Near = o.Near
 	}
 
+	if o.Choose != "" {
+		r.Choose = o.Choose
+	}
+
 	if o.RequireConsistent != false {
 		r.RequireConsistent = o.RequireConsistent
 	}
@@ -119,9 +124,16 @@ func (q *QueryOptions) ToConsulOpts() *consulapi.QueryOptions {
 }
 
 func (q *QueryOptions) ToNomadOpts() *nomadapi.QueryOptions {
+	var params map[string]string
+	if q.Choose != "" {
+		params = map[string]string{
+			"choose": q.Choose,
+		}
+	}
 	return &nomadapi.QueryOptions{
 		AllowStale: q.AllowStale,
 		Region:     q.Region,
+		Params:     params,
 		WaitIndex:  q.WaitIndex,
 		WaitTime:   q.WaitTime,
 	}
@@ -144,6 +156,10 @@ func (q *QueryOptions) String() string {
 
 	if q.Near != "" {
 		u.Add("near", q.Near)
+	}
+
+	if q.Choose != "" {
+		u.Add("choose", q.Choose)
 	}
 
 	if q.RequireConsistent {

--- a/dependency/nomad_service.go
+++ b/dependency/nomad_service.go
@@ -17,6 +17,8 @@ var (
 
 	// NomadServiceQueryRe is the regex that is used to understand a service
 	// specific Nomad query.
+	//
+	// e.g. "<tag=value>.<name>@<region>"
 	NomadServiceQueryRe = regexp.MustCompile(`\A` + tagRe + serviceNameRe + regionRe + `\z`)
 )
 
@@ -46,6 +48,7 @@ type NomadServiceQuery struct {
 	region string
 	name   string
 	tag    string
+	choose string
 }
 
 // NewNomadServiceQuery parses a string into a NomadServiceQuery which is
@@ -56,12 +59,28 @@ func NewNomadServiceQuery(s string) (*NomadServiceQuery, error) {
 	}
 
 	m := regexpMatch(NomadServiceQueryRe, s)
+
 	return &NomadServiceQuery{
 		stopCh: make(chan struct{}, 1),
 		region: m["region"],
 		name:   m["name"],
 		tag:    m["tag"],
 	}, nil
+}
+
+// NewNomadServiceChooseQuery parses s using NewNomadServiceQuery, and then also
+// configures the resulting query with the choose parameter set according to the
+// count and key arguments.
+func NewNomadServiceChooseQuery(count int, key, s string) (*NomadServiceQuery, error) {
+	query, err := NewNomadServiceQuery(s)
+	if err != nil {
+		return nil, err
+	}
+
+	choose := fmt.Sprintf("%d|%s", count, key)
+	query.choose = choose
+
+	return query, nil
 }
 
 // Fetch queries the Nomad API defined by the given client and returns a slice
@@ -75,6 +94,7 @@ func (d *NomadServiceQuery) Fetch(client *ClientSet, opts *QueryOptions) (interf
 
 	opts = opts.Merge(&QueryOptions{
 		Region: d.region,
+		Choose: d.choose,
 	})
 
 	u := &url.URL{
@@ -137,6 +157,9 @@ func (d *NomadServiceQuery) String() string {
 	}
 	if d.region != "" {
 		name = name + "@" + d.region
+	}
+	if d.choose != "" {
+		name = name + ":" + d.choose
 	}
 	return fmt.Sprintf("nomad.service(%s)", name)
 }

--- a/dependency/nomad_services_test.go
+++ b/dependency/nomad_services_test.go
@@ -53,17 +53,16 @@ func TestNewNomadServicesQueryQuery(t *testing.T) {
 	}
 }
 
-func TestNomadServicesQuery_Fetch(t *testing.T) {
-
+func TestNomadServicesQuery_Fetch_1arg(t *testing.T) {
 	cases := []struct {
-		name string
-		i    string
-		exp  []*NomadServicesSnippet
+		name    string
+		service string
+		exp     []*NomadServicesSnippet
 	}{
 		{
-			"all",
-			"",
-			[]*NomadServicesSnippet{
+			name:    "all",
+			service: "",
+			exp: []*NomadServicesSnippet{
 				&NomadServicesSnippet{
 					Name: "example-cache",
 					Tags: ServiceTags([]string{"tag1", "tag2"}),
@@ -74,7 +73,7 @@ func TestNomadServicesQuery_Fetch(t *testing.T) {
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
-			d, err := NewNomadServicesQuery(tc.i)
+			d, err := NewNomadServicesQuery(tc.service)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -88,6 +87,7 @@ func TestNomadServicesQuery_Fetch(t *testing.T) {
 		})
 	}
 }
+
 func TestNomadServicesQuery_String(t *testing.T) {
 
 	cases := []struct {

--- a/docs/templating-language.md
+++ b/docs/templating-language.md
@@ -95,6 +95,9 @@ provides the following functions:
   - [modulo](#modulo)
   - [minimum](#minimum)
   - [maximum](#maximum)
+- [Nomad Functions](#nomad-functions)
+  - [nomadServices](#nomadservices)
+  - [nomadService](#nomadservice)
 - [Debugging Functions](#debugging)
   - [spew_dump](#spew_dump)
   - [spew_sdump](#spew_sdump)
@@ -1778,6 +1781,44 @@ This can also be used with a pipe function.
 
 ```golang
 {{ 5 | maximum 2 }} // 2
+```
+
+## Nomad Functions
+
+Nomad service registrations can be queried using the `nomadServices` and `nomadService` functions.
+Typically these will be used from within a Nomad [template](https://www.nomadproject.io/docs/job-specification/template#nomad-services) configuration.
+
+### `nomadServices`
+
+This can be used to query the names of services registered in Nomad.
+
+```nomadServices
+{{ range nomadServices }}
+  {{ .Name .Tags }}
+{{ end }}
+```
+
+### `nomadService`
+
+This can be used to query for additional information about each instance of a service registered in Nomad.
+
+```nomadService
+{{ range nomadService "my-app" }}
+  {{ .Address }} {{ .Port }}
+{{ end}}
+```
+
+The `nomadService` function also supports basic load-balancing via a [rendezvous hashing](https://en.wikipedia.org/wiki/Rendezvous_hashing)
+algorithm implemented in Nomad's API. To activate this behavior, the function requires three arguments in this order:
+the number of instances desired, a unique but consistent identifier associated with the requester, and the service name.
+
+Typically the unique identifier would be the allocation ID in a Nomad job.
+
+```nomadService
+{{$allocID := env "NOMAD_ALLOC_ID" -}}
+{{range nomadService 3 $allocID "redis"}}
+  {{.Address}} {{.Port}} | {{.Tags}} @ {{.Datacenter}}
+{{- end}}
 ```
 
 ## Debugging Functions


### PR DESCRIPTION
Nomad's service API is adding a `?choose` parameter (https://github.com/hashicorp/nomad/pull/12862), making use of
[HRW hashing](https://en.wikipedia.org/wiki/Rendezvous_hashing) to deterministically select a subset of services given a hash key (e.g. `allocID`).

Make use of this API in `consul-template` by expanding the `nomadService` function to accept 3 parameters (in addition to the existing 1). These parameters are `<count>`, `<key>`, `<service>`.

Example usage (in Nomad template):

```
{{$allocID := env "NOMAD_ALLOC_ID" -}}
{{range nomadService 3 $allocID "redis"}}
  {{.Address}} {{.Port}} | {{.Tags}} @ {{.Datacenter}}
{{- end}}
```

Since Nomad depends on this CT change being included in Nomad before the feature works via Nomad, I'm holding off on the integration test until this PR gets merged, and the PR to import the new CT gets merged into Nomad.

In the meantime, the Nomad `f-choose-services` branch can be used to play with the feature. 

```
➜ nomad version 
Nomad v1.3.1-dev (56b93a7f32c355736cea4e478a1eefebdcc42e3c)
```

<details><summary>Example job with some redis tasks</summary>

```hcl
job "redis" {
  datacenters = ["dc1"]

  group "caches2" {
    count = 2

    network {
      port "db" {
        to = 6379
      }
    }

    service {
      provider = "nomad"
      port = "db"
      name = "redis"
      tags = ["two"]
    }

    task "redis" {
      driver = "docker"

      config {
        image = "redis:3.2"
        ports = ["db"]
      }

      resources {
	cores = 1
        memory = 100
      }
    }
  }  

  group "caches3" {
    count = 3

    network {
      port "db" {
        to = 6379
      }
    }

    service {
      provider = "nomad"
      port = "db"
      name = "redis"
      tags = ["three"]
    }

    task "redis" {
      driver = "docker"

      config {
        image = "redis:3.2"
        ports = ["db"]
      }

      resources {
	cores = 1
        memory = 100
      }
    }
  }
}
```
</details>

Example job to make use of the 3 argument `nomadService` CT function 

```hcl
job "cat" {
  datacenters = ["dc1"]
  type = "batch"

  group "option1" {
    task "cat" {
      driver = "exec"

      config {
	command = "cat"
	args = ["local/redis.txt"]
      }

      template {
	destination = "local/redis.txt"
	data = <<EOH
# CHOSEN
{{$allocID := env "NOMAD_ALLOC_ID" -}}
{{range nomadService 3 $allocID "redis"}} 
  {{.Address}} {{.Port}} | {{.Tags}} @ {{.Datacenter}}
{{- end}}

# ALL
{{range nomadService "redis"}} 
  {{.Address}} {{.Port}} | {{.Tags}} @ {{.Datacenter}}
{{- end}}
EOH
      }
    }
  }
}
```

Running 

```
➜ nomad job run redis.nomad 
...
➜ nomad job run cat.nomad
...
➜ nomad alloc logs 8324ce89 
# CHOSEN
 
  127.0.0.1 26222 | [three] @ dc1 
  127.0.0.1 31856 | [two] @ dc1 
  127.0.0.1 28212 | [two] @ dc1

# ALL
 
  127.0.0.1 26222 | [three] @ dc1 
  127.0.0.1 28212 | [two] @ dc1 
  127.0.0.1 31856 | [two] @ dc1 
  127.0.0.1 31027 | [three] @ dc1 
  127.0.0.1 20531 | [three] @ dc1
```
