### PR TITLE
add codeowners for releng content

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # release configuration
 
-/.release/                              @hashicorp/release-engineering @hashicorp/hc-github-team-consul-ecosystem
-/.github/workflows/build.yml            @hashicorp/release-engineering @hashicorp/hc-github-team-consul-ecosystem
+/.release/                              @hashicorp/release-engineering @hashicorp/github-consul-ecosystem
+/.github/workflows/build.yml            @hashicorp/release-engineering @hashicorp/github-consul-ecosystem

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# release configuration
+
+/.release/                              @hashicorp/release-engineering @hashicorp/hc-github-team-consul-ecosystem
+/.github/workflows/build.yml            @hashicorp/release-engineering @hashicorp/hc-github-team-consul-ecosystem


### PR DESCRIPTION
This locks down changes to release directories so that they require approval from release engineering, and so they have service account rights for pipeline runs and backport-assistant functionality.