### PR TITLE
Issue 1588: pki cert renew bug + duration/renew logic fixes

### DIFF
--- a/dependency/vault_common_test.go
+++ b/dependency/vault_common_test.go
@@ -142,9 +142,9 @@ func setupVaultPKI(clients *ClientSet) {
 	}
 	_, err = vc.Logical().Write("pki/roles/example-dot-com",
 		map[string]interface{}{
-			"allowed_domains":  "example.com",
-			"allow_subdomains": "true",
-			"ttl":              "24h",
+			"allowed_domains":     "example.com",
+			"allow_subdomains":    "true",
+			"not_before_duration": "1s",
 		})
 	if err != nil {
 		panic(err)

--- a/dependency/vault_pki_test.go
+++ b/dependency/vault_pki_test.go
@@ -106,7 +106,7 @@ func Test_VaultPKI_refetch(t *testing.T) {
 	/// above is prep work
 	data := map[string]interface{}{
 		"common_name": "foo.example.com",
-		"ttl":         "2s",
+		"ttl":         "3s",
 		"ip_sans":     "127.0.0.1,192.168.2.2",
 	}
 	d, err := NewVaultPKIQuery("pki/issue/example-dot-com", f.Name(), data)


### PR DESCRIPTION
The code handled the case of getting a cert and using the version on the disk as the cache but missed looping over that logic when the one on disk had expired.

This adds the looping needed to renew the cert when expired and extends the refetch test to validate this functionality.

The second commit could be split out as it's not directly fixing the linked bug, but it is all part of this same code and is needed for this feature to work as intended so I'm including it.

Fixes #1588