### PR TITLE
pkiCert now gets the Cert, Private key and CA

### DIFF
--- a/dependency/vault_pki.go
+++ b/dependency/vault_pki.go
@@ -1,6 +1,7 @@
 package dependency
 
 import (
+	"bytes"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -15,6 +16,14 @@ import (
 
 // Ensure implements
 var _ Dependency = (*VaultPKIQuery)(nil)
+
+// Return type containing PEMs as strings
+type PemEncoded struct{ Cert, Key, CA string }
+
+// a wrapper to mimic v2 secrets Data wrapper
+func (p PemEncoded) Data() PemEncoded {
+	return p
+}
 
 // VaultPKIQuery is the dependency to Vault for a secret
 type VaultPKIQuery struct {
@@ -49,8 +58,7 @@ func NewVaultPKIQuery(urlpath, filepath string, data map[string]interface{}) (*V
 }
 
 // Fetch queries the Vault API
-func (d *VaultPKIQuery) Fetch(clients *ClientSet, opts *QueryOptions,
-) (interface{}, *ResponseMetadata, error) {
+func (d *VaultPKIQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interface{}, *ResponseMetadata, error) {
 	select {
 	case <-d.stopCh:
 		return nil, nil, ErrStopped
@@ -63,49 +71,46 @@ func (d *VaultPKIQuery) Fetch(clients *ClientSet, opts *QueryOptions,
 	}
 
 	needsRenewal := fmt.Errorf("needs renewal")
-	getPEM := func(renew bool) ([]byte, error) {
-		var encPEM []byte
-		var err error
-		encPEM, err = os.ReadFile(d.filePath)
-		if renew || err != nil || len(encPEM) == 0 {
-			encPEM, err = d.fetchPEM(clients)
+	getPEMs := func(renew bool) (PemEncoded, error) {
+		rawPems, err := os.ReadFile(d.filePath)
+		if renew || err != nil || len(rawPems) == 0 {
+			rawPems, err = d.fetchPEMs(clients)
 			// no need to write cert to file as it is the template dest
 		}
 		if err != nil {
-			return nil, err
+			return PemEncoded{}, err
 		}
 
-		block, cert, err := getCert(encPEM)
+		encPems, cert, err := pemsCert(rawPems)
 		if err != nil {
-			return nil, err
+			return encPems, err
 		}
 
 		if sleepFor, ok := goodFor(cert); ok {
 			d.sleepCh <- sleepFor
-			return pem.EncodeToMemory(block), nil
+			return encPems, nil
 		}
-		return []byte{}, needsRenewal
+		return encPems, needsRenewal
 	}
 
-	pemBytes, err := getPEM(false)
+	encPems, err := getPEMs(false)
 	switch err {
 	case nil:
 	case needsRenewal:
-		pemBytes, err = getPEM(true)
+		encPems, err = getPEMs(true)
 		if err != nil {
-			return nil, nil, err
+			return PemEncoded{}, nil, err
 		}
 	default:
-		return nil, nil, err
+		return PemEncoded{}, nil, err
 	}
-	return respWithMetadata(string(pemBytes))
+	return respWithMetadata(encPems)
 }
 
 // returns time left in ~90% of the original lease and a boolean
 // that returns false if cert needs renewing, true otherwise
 func goodFor(cert *x509.Certificate) (time.Duration, bool) {
-	// These are all int64's with Seconds since the Epoch
-	// handy for the math
+	// These are all int64's with Seconds since the Epoch, handy for the math
 	start, end := cert.NotBefore.Unix(), cert.NotAfter.Unix()
 	now := time.Now().UTC().Unix()
 	if end <= now { // already expired
@@ -124,34 +129,44 @@ func goodFor(cert *x509.Certificate) (time.Duration, bool) {
 		// between 87% and 93%
 		gooddur = gooddur + ((gooddur / 100) * int64(r.Intn(6)-3))
 	}
-	sleepFor := time.Duration(gooddur * 1e9)
+	sleepFor := time.Duration(gooddur * 1e9) // basically: gooddur*time.Second
 	return sleepFor, true
 }
 
 // loops through all pem encoded blocks in the byte stream
-// returning the first certificate found (ignoring CAs and chain certs)
-func getCert(encoded []byte) (*pem.Block, *x509.Certificate, error) {
+// returning the CA, Certificate and Private Key PEM strings
+// also returns the cert for the Certificate as we have it and need it
+func pemsCert(encoded []byte) (PemEncoded, *x509.Certificate, error) {
 	var block *pem.Block
-	var firstErr error
+	var cert *x509.Certificate
+	var encPems PemEncoded
 	for {
+		// scan, find and parse PEM blocks
 		block, encoded = pem.Decode(encoded)
-		if block != nil {
-			cert, err := x509.ParseCertificate(block.Bytes)
-			switch {
-			case err == nil && !cert.IsCA:
-				return block, cert, nil
-			case firstErr == nil:
-				firstErr = err
-			}
+		switch {
+		case block == nil: // end of scan, no more PEMs found
+			return encPems, cert, nil
+		case strings.HasSuffix(block.Type, "PRIVATE KEY"):
+			// PKCS#1 and PKCS#8 matching to find private key
+			encPems.Key = string(pem.EncodeToMemory(block))
 			continue
 		}
-		break
+		// CERTIFICATE PEM blocks (Cert and CA) are left
+		maybeCert, err := x509.ParseCertificate(block.Bytes)
+		switch {
+		case err != nil:
+			return PemEncoded{}, nil, err
+		case maybeCert.IsCA:
+			encPems.CA = string(pem.EncodeToMemory(block))
+		default: // the certificate
+			cert = maybeCert
+			encPems.Cert = string(pem.EncodeToMemory(block))
+		}
 	}
-	return nil, nil, errors.Wrap(firstErr, "failed to parse cert")
 }
 
-//
-func (d *VaultPKIQuery) fetchPEM(clients *ClientSet) ([]byte, error) {
+// Vault call to fetch the PKI Cert PEM data
+func (d *VaultPKIQuery) fetchPEMs(clients *ClientSet) ([]byte, error) {
 	vaultSecret, err := clients.Vault().Logical().Write(d.pkiPath, d.data)
 	switch {
 	case err != nil:
@@ -160,11 +175,15 @@ func (d *VaultPKIQuery) fetchPEM(clients *ClientSet) ([]byte, error) {
 		return nil, fmt.Errorf("no secret exists at %s", d.pkiPath)
 	}
 	printVaultWarnings(d, vaultSecret.Warnings)
-	encPEM, ok := vaultSecret.Data["certificate"].(string)
-	if !ok {
-		return nil, fmt.Errorf("secret didn't include cert")
+	pems := bytes.Buffer{}
+	for _, v := range vaultSecret.Data {
+		switch v := v.(type) {
+		case string:
+			pems.WriteString(v + "\n")
+		}
 	}
-	return []byte(encPEM), nil
+
+	return pems.Bytes(), nil
 }
 
 func (d *VaultPKIQuery) stopChan() chan struct{} {

--- a/dependency/vault_pki_test.go
+++ b/dependency/vault_pki_test.go
@@ -4,7 +4,6 @@ package dependency
 
 import (
 	"bytes"
-	"encoding/pem"
 	"errors"
 	"os"
 	"strings"
@@ -15,43 +14,55 @@ import (
 )
 
 func Test_VaultPKI_notGoodFor(t *testing.T) {
-	// only test the negation, postive is tested below with certificates
-	// fetched in Vault integration tests (creating certs is non-trivial)
-	_, cert, err := getCert([]byte(validCert))
+	// only test the negation, postive is tested below with pemsificates
+	// fetched in Vault integration tests (creating pemss is non-trivial)
+	_, cert, err := pemsCert([]byte(validCert))
 	if err != nil {
 		t.Error(err)
 	}
 	dur, ok := goodFor(cert)
 	if ok != false {
-		t.Error("should be false", dur)
+		t.Error("should be false")
 	}
-	// duration should be negative as cert has already expired
-	// but still tests cert time parsing (it'd be 0 if there was an issue)
+	// duration should be negative as pems has already expired
+	// but still tests pems time parsing (it'd be 0 if there was an issue)
 	if dur > 0 {
-		t.Error("cert shouldn't positive (old cert)")
+		t.Error("duration shouldn't be positive (old cert)")
 	}
 }
 
-func Test_VaultPKI_getCert(t *testing.T) {
-	// tests w/ valid cert
-	for _, testcert := range []string{validCert, validBad, badGood, validCertAfterCA, validCertGarbo} {
-		pemBlk, cert, err := getCert([]byte(testcert))
-		if err != nil {
-			t.Fatal(err) // Fatal to avoid panic's below
-		}
-		got := strings.TrimRight(string(pem.EncodeToMemory(pemBlk)), "\n")
-		want := strings.TrimRight(strings.TrimSpace(validCert), "\n")
-		if got != want {
-			t.Errorf("certs didn't match:\ngot: %v\nwant: %v", got, want)
-		}
-		if err := cert.VerifyHostname("foo.example.com"); err != nil {
-			t.Error(err)
-		}
+func Test_VaultPKI_pemsCert(t *testing.T) {
+	// tests w/ valid pems, and having it hidden behind various things
+	want := strings.TrimRight(strings.TrimSpace(validCert), "\n")
+	for k, testpems := range validPermutations() {
+		t.Run(k, func(t *testing.T) {
+			pems, cert, err := pemsCert([]byte(testpems))
+			if err != nil {
+				t.Fatal(err) // Fatal to avoid panic's below
+			}
+			if cert == nil {
+				t.Fatal("cert should not be nil")
+			}
+			for k, p := range map[string]string{
+				"cert": pems.Cert, "key": pems.Key, "ca": pems.CA,
+			} {
+				if p == "" {
+					t.Error("Missing PEM:", k)
+				}
+			}
+			got := strings.TrimRight(pems.Cert, "\n")
+			if got != want {
+				t.Errorf("pemss didn't match:\ngot: %v\nwant: %v", got, want)
+			}
+			if err := cert.VerifyHostname("foo.example.com"); err != nil {
+				t.Error(err)
+			}
+		})
 	}
-	// tests w/o valid cert (test error)
+	// tests w/o valid pems (test error)
 	expectedErr := "x509: malformed certificate"
-	for _, badcert := range []string{badCert, badPlusCA, badPlusGarbo} {
-		_, _, err := getCert([]byte(badcert))
+	for _, badpems := range []string{badCert, badPlusCA, badPlusGarbo} {
+		_, _, err := pemsCert([]byte(badpems))
 		switch {
 		case err == nil:
 			t.Errorf("error should not be nil")
@@ -73,19 +84,19 @@ func Test_VaultPKI_fetchPEM(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	encPEM, err := d.fetchPEM(clients)
+	encPEM, err := d.fetchPEMs(clients)
 	if err != nil {
 		t.Error(err)
 	}
 	if !bytes.Contains(encPEM, []byte("CERTIFICATE")) {
-		t.Errorf("certificate not fetched, got: %s", string(encPEM))
+		t.Errorf("pemsificate not fetched, got: %s", string(encPEM))
 	}
 	// test path error
 	d, err = NewVaultPKIQuery("pki/issue/does-not-exist", "/dev/null", data)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = d.fetchPEM(clients)
+	_, err = d.fetchPEMs(clients)
 	var respErr *api.ResponseError
 	if !errors.As(err, &respErr) {
 		t.Error(err)
@@ -121,23 +132,24 @@ func Test_VaultPKI_refetch(t *testing.T) {
 		t.Error("Fetch returned nil for response metadata.")
 	}
 
-	cert1, ok := act1.(string)
-	if !ok || !strings.Contains(cert1, "BEGIN") {
-		t.Fatalf("expected a cert but found: %s", cert1)
+	pems1, ok := act1.(PemEncoded)
+	if !ok || !strings.Contains(pems1.Cert, "BEGIN CERTIFICATE") {
+		t.Fatalf("expected a pems but found: %s", pems1)
 	}
 
 	// Fake template rendering file to disk
+	allPems1 := strings.Join([]string{pems1.Cert, pems1.Key, pems1.CA}, "\n")
 	_, err = renderer.Render(&renderer.RenderInput{
-		Contents: []byte(cert1),
+		Contents: []byte(allPems1),
 		Path:     f.Name(),
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// re-fetch, should be the same cert pulled from the file
+	// re-fetch, should be the same pems pulled from the file
 	// if re-fetched from Vault it will be different
-	<-d.sleepCh // drain sleepCh so we don't wait and reuse the cached copy
+	<-d.sleepCh // drain sleepCh to trigger reusing the cached copy
 	act2, rm, err := d.Fetch(clients, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -146,16 +158,16 @@ func Test_VaultPKI_refetch(t *testing.T) {
 		t.Error("Fetch returned nil for response metadata.")
 	}
 
-	cert2, ok := act2.(string)
-	if !ok || !strings.Contains(cert2, "BEGIN") {
-		t.Fatalf("expected a cert but found: %s", cert2)
+	pems2, ok := act2.(PemEncoded)
+	if !ok || !strings.Contains(pems2.Cert, "BEGIN CERTIFICATE") {
+		t.Fatalf("expected a pems but found: %s", pems2)
+	}
+	// using cached copy, so should be a match
+	if pems1 != pems2 {
+		t.Errorf("pemss don't match and should.")
 	}
 
-	if cert1 != cert2 {
-		t.Errorf("certs don't match and should.")
-	}
-
-	// Don't pre-drain here as we want it to get a new cert
+	// Don't pre-drain here as we want it to get a new pems
 	act3, rm, err := d.Fetch(clients, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -164,67 +176,117 @@ func Test_VaultPKI_refetch(t *testing.T) {
 		t.Error("Fetch returned nil for response metadata.")
 	}
 
-	cert3, ok := act3.(string)
-	if !ok || !strings.Contains(cert2, "BEGIN") {
-		t.Fatalf("expected a cert but found: %s", cert2)
+	pems3, ok := act3.(PemEncoded)
+	if !ok || !strings.Contains(pems3.Cert, "BEGIN CERTIFICATE") {
+		t.Fatalf("expected a pems but found: %s", pems2)
 	}
 
-	if cert2 == cert3 {
-		t.Errorf("certs match and shouldn't.")
+	if pems2 == pems3 {
+		t.Errorf("pemss match and shouldn't.")
 	}
 }
 
 const validCert = `
 -----BEGIN CERTIFICATE-----
-MIIDWTCCAkGgAwIBAgIUUARA+vQExU8zjdsX/YXMMu1K5FkwDQYJKoZIhvcNAQEL
-BQAwFjEUMBIGA1UEAxMLZXhhbXBsZS5jb20wHhcNMjIwMzAxMjIzMzAzWhcNMjIw
-MzA0MjIzMzMzWjAaMRgwFgYDVQQDEw9mb28uZXhhbXBsZS5jb20wggEiMA0GCSqG
-SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDD3sktiNGo/CSvtL84+GIcsuDzp1VFjG++
-8P682ZPiqPGjrgwe3P8ypyhQv6I8ZGOyu7helMqBN/S1mrhmHWUONy/4o95QWDsJ
-CGw4H44dRil5hKC6K8BUrf79XGAGIQJr3T6I5CCwxukfYhU/+xNE3dq5AgLrIIB2
-BtzZA6m1T5CmgAzSzI1byTjaRpxOJjucI37iKzkx7AkYS5hGfVsFmJgGi/UXhvzK
-uwnHHIq9rLItx7p261dJV8mxRDFaf4x+4bZh2kYkEaG8REOfyHSCJ78RniWbF/DN
-Jtgh8bT2/938/ecBtWcTN+psICD62DJii6988FD2qS+Yd8Eu8M5rAgMBAAGjgZow
+MIIDWTCCAkGgAwIBAgIUaawVY56cY+a0GUYJaL2zsHFBgqQwDQYJKoZIhvcNAQEL
+BQAwFjEUMBIGA1UEAxMLZXhhbXBsZS5jb20wHhcNMjIwNjIxMjEyODIxWhcNMjIw
+NjIxMjEyODI1WjAaMRgwFgYDVQQDEw9mb28uZXhhbXBsZS5jb20wggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDJ3NK6SeJQdxAmXXRcPt5xHYVuUWLjtvHp
+8wAUtMYSvLFrC0XD9YGKxScbLLcnlZdSvD72LYh9R4h7kLjyP9JQnUSPqhixUk2A
+RYuiUTNieppsM7pBMM0UYkyOtb8pLNSnrV4u6ga1iSGZd/3qxSbDd9K0ku9A75qC
+zVLvcO7LqPw6RI8hRDU6Z1qE3MK9upqu/YE8HdhR7og8hZzhU8f7GcuGowNYezBi
+J/hmBW6oxyi0FC9rmZ7SIX3oYyxkW1v/xSM3zw4EKw1JaDFgceyuhQXW0QmgUyTW
+0p7I2DUIccRV7W1w7biERiDfrqzCJaUzTEg2E728269fHpaYa3OpAgMBAAGjgZow
 gZcwDgYDVR0PAQH/BAQDAgOoMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcD
-AjAdBgNVHQ4EFgQUfmm32UJb3xJNxfA7ZB0Q5RXsQIkwHwYDVR0jBBgwFoAUDoYJ
-CtobWJrR1xmTsYJd9buj2jwwJgYDVR0RBB8wHYIPZm9vLmV4YW1wbGUuY29thwR/
-AAABhwTAqAEpMA0GCSqGSIb3DQEBCwUAA4IBAQBzB+RM2PSZPmDG3xJssS1litV8
-TOlGtBAOUi827W68kx1lprp35c9Jyy7l4AAu3Q1+az3iDQBfYBazq89GOZeXRvml
-x9PVCjnXP2E7mH9owA6cE+Z1cLN/5h914xUZCb4t9Ahu04vpB3/bnoucXdM5GJsZ
-EJylY99VsC/bZKPCheZQnC/LtFBC31WEGYb8rnB7gQxmH99H91+JxnJzYhT1a6lw
-arHERAKScrZMTrYPLt2YqYoeyO//aCuT9YW6YdIa9jPQhzjeMKXywXLetE+Ip18G
-eB01bl42Y5WwHl0IrjfbEevzoW0+uhlUlZ6keZHr7bLn/xuRCUkVfj3PRlMl
+AjAdBgNVHQ4EFgQUyivSsb/skEc07dXBKtI2X6+IvfowHwYDVR0jBBgwFoAUOrWo
+wCGHOQKRtIXbtzWHxaGaW00wJgYDVR0RBB8wHYIPZm9vLmV4YW1wbGUuY29thwR/
+AAABhwTAqAICMA0GCSqGSIb3DQEBCwUAA4IBAQCecPeIR2SN+yVqfvURDgH/ZiFB
+xGCTQOv3Chi9M9UeIHhOmfLCkyKrZ6glZHUllXGLDDIrGjwS/a3bshr60hQRISST
+Kcn5zHURLgCFTw4uFrC3hsR9by/PytE5mvMe8arpkiboUYrUIT5OlQmsZNpksbB9
+34fBi72qhhwYC1kzoBkFRMQQtwAgpmLM46pAIbZza7d+vnQRXngb6n/pFnq7gOOM
+KHy/moLj0fK4dmlrjbrvkLJTZt/IFxLNWvj8wGmnLSuIuBt08Rc1McY4gbTySats
+8lpG3zQS6aqGJjLEqjXkvfzWAAS5Xrvcc59a2dc6GZ01Y1ZP6krQ2rJBUEAO
 -----END CERTIFICATE-----
+`
+
+const validKey = `
+-----BEGIN RSA PRIVATE KEY-----
+MIIEogIBAAKCAQEAydzSukniUHcQJl10XD7ecR2FblFi47bx6fMAFLTGEryxawtF
+w/WBisUnGyy3J5WXUrw+9i2IfUeIe5C48j/SUJ1Ej6oYsVJNgEWLolEzYnqabDO6
+QTDNFGJMjrW/KSzUp61eLuoGtYkhmXf96sUmw3fStJLvQO+ags1S73Duy6j8OkSP
+IUQ1OmdahNzCvbqarv2BPB3YUe6IPIWc4VPH+xnLhqMDWHswYif4ZgVuqMcotBQv
+a5me0iF96GMsZFtb/8UjN88OBCsNSWgxYHHsroUF1tEJoFMk1tKeyNg1CHHEVe1t
+cO24hEYg366swiWlM0xINhO9vNuvXx6WmGtzqQIDAQABAoIBAEJGcxVgnqJGhRHj
+iwmiRowi4iUXKX2UGhbyhmtF8uZB94oqmEw/NbnnAvDkHHotnhI25gETcAWZz9Cp
+8l7u31FCYTk94n+Ngw6DRtYTDOjfUgYGcbdnm11+7J3KRCnzoxouTIbgpTVDAboO
+cFp9Qj3ZAF/zAgRy5mrdmMYucOiCTDlNIZtWQz/kW2TUZlukFWDlkqNY2ri+r8aN
+B6ahHmjxCew+VRJ9O2cndM81kx28ex4B7FnLDt7RAyc5JfJ+lefZEzV/vsauy0sS
+BTYZTNpDjBOymvpCUkDpqC26lvamcZdACtGVojfWxVtV5w4lwJi0mdKaWdItJyBo
+RDlfjMUCgYEA8ybFv/OXvyK9PXfavxshW2WNxfV+4U4A18K8Pog8JE/kN7G0aiz2
+m5VZqd2sdC0002LWjm5P7s+wRWMRyiJhiUuWZB8TltLny7+fBDmk49IWZRMtiiVp
+vKoetbGyGGxEV+6gFiNm+UupDPy75/ZkCrdGp/66LOxhsryLqoVTvA8CgYEA1IeE
+JwM5hhfDrY50tFx1Cu0HUvJwll1AJS0Y4KqIsIeC4Km0gritzr+c982ldsv01cH4
+P/fVeeCJHIjuYdJezgv2jbcBlisqFL7YY9fg1S7mveYAq/RxHczVTk9zcA6IMvQs
+d5vzItuQFU0SUQIYQanlizDW/yh1l9H+Me3zfMcCgYAuAITjNwPbnoftDDLvewOJ
+liIHdNXHbImOSIJy1jWCrTbBLraya8VQVCY9k/nflPnskEOFeOtYhCSWTBL+ihin
+8AwI7zQ2kbpW+u7rzrgafhHMl59DBqcFka3ztCW8pyca98ODzLjbq2vVUC+AyEXP
+HTOZ7wBsJWCqfy9xWH4qEwKBgC1Hzi0tr7TVHVi98Dl5NWqlg5j1lG1E4uTIzfMY
+AlVyGb1aCt6LEGTrSDs3slg0Li7Yy9Z9LBtybmQI/JkU5CQMQnSBGDJxcd7Hpnzn
+QrzI6FpvRZddVjheKtgrb1Hhlr0cbtjw/gVgODuBlzRxOM/Mrd5RAo2MhjlZgUoM
+A4ODAoGAb9QJ4NlahKEX68ooC/FToiiUpJ33lAxFXVo0Nl/M8XsjcKDsKVsVDZkt
+/sWSUr3HJ54XMgsTybG9l7poeM6lWN/B+q1O05688Bp3h1Jx4uKCDjouS+u1xViJ
+iUV6/HfQYsykAni+pF6Zomu7ViIpl2u9bXExReB9UDI7LfHU4cg=
+-----END RSA PRIVATE KEY-----
 `
 
 const validCA = `
 -----BEGIN CERTIFICATE-----
-MIIDNTCCAh2gAwIBAgIUbJ/1ELw6X6OUg6YeVtsTqg20G2swDQYJKoZIhvcNAQEL
-BQAwFjEUMBIGA1UEAxMLZXhhbXBsZS5jb20wHhcNMjIwMzAxMjIzMjQ3WhcNMjMw
-MzAxMjIzMzE2WjAWMRQwEgYDVQQDEwtleGFtcGxlLmNvbTCCASIwDQYJKoZIhvcN
-AQEBBQADggEPADCCAQoCggEBAPAiGf1Shr7e/AA7VGsaQiMKz9+HoTgrt4mJIAPu
-aelNavl7umr1AckEc7g+zGYauJmhfsPalS5BlvZ1hjBhgi4g1MsKf/64BLfxkxJH
-HLX2kAEUBzFWBeX0EE/rl0pb81afZv+6Kyi2X6cN3kFC0gEtF1BScAoWEKWYx9xz
-oPzB7Qql4BKaZ8KXgeryDIQ4Zbg2yKwSdS9TILGMylvqCdne5UkQP7bGW0i4C7r9
-noDtJZIo83vzH6YlN99C66pLm8m3qnKgWk5clIizlh9lw0XEQKZQ69tRNuxRSF5r
-6XVaDWoYEOm+gJ7DRoKEHqA4ov1BbfLEocvEzjfcrulb1bsCAwEAAaN7MHkwDgYD
-VR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFA6GCQraG1ia
-0dcZk7GCXfW7o9o8MB8GA1UdIwQYMBaAFA6GCQraG1ia0dcZk7GCXfW7o9o8MBYG
-A1UdEQQPMA2CC2V4YW1wbGUuY29tMA0GCSqGSIb3DQEBCwUAA4IBAQC2yfszyLyX
-7Yhuzvda3EYKTsfiXA6+Cqx7TZVyIHF0AgEkeIaDmmB5Gh6cizvtpHpwLwB94UWq
-LNda6gzocChpC34A2xZ5QLCk+xeNrC1rHH+wk90K9ac+G5rtVQhzNKXBMup6GZFu
-zOi+yS9f/oKtx0obrjG/NVtYcxAZ/2Zv1Mu4MLuw9EGrWztvEOImd8G22sgigsbJ
-WR7VgKRCphRGmfp/SlI3c/zYScHHanZ3umQvilPmftPX+BxVFA5FhCUUimkZEJMq
-+hmBcwd8e1LZLz7Mz5IsrN6+lRZ78T+zV8sxNdF1mIWs+ZsrmzQBZq4Q0uLjDiD/
-v57ZY8gIDE5E
+MIIDNTCCAh2gAwIBAgIURRe+G6nEMYhVGqXpsIyIKVAzqBwwDQYJKoZIhvcNAQEL
+BQAwFjEUMBIGA1UEAxMLZXhhbXBsZS5jb20wHhcNMjIwNjIxMjEyNzUyWhcNMjIw
+NjIzMjEyODIyWjAWMRQwEgYDVQQDEwtleGFtcGxlLmNvbTCCASIwDQYJKoZIhvcN
+AQEBBQADggEPADCCAQoCggEBAMcgv07tmQWfqONmhPcrh8bspesCqKsI3S31+jCh
+sMONB1fjTqTw4CU6ii3BVL+O4Q5Bxi+sRSHunfRPSZE6wCytZrYiJsA2VsEOvBTC
+FKDZ0ieManszb5zw1liaK/IW8yhAM3739Wvz+CJO/Ji1cy3bLaYVQr7hJgNdnexb
+c1gNqR985QrexRF/ftp5YHnopgAmH45Au+CxMuXZqrP4zWvvm/RPvX5gscRj5sA5
+8e1+325EmIFXf6zYuMjx0K9sryuDDKvIDO9KZ1FMkQSj2rXIO81PNz5XCKYl886m
+HO1A9qVHNRHRrfdZfg9xi9naCFxudC7RyuEW5v1pvxKxTVsCAwEAAaN7MHkwDgYD
+VR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFDq1qMAhhzkC
+kbSF27c1h8WhmltNMB8GA1UdIwQYMBaAFDq1qMAhhzkCkbSF27c1h8WhmltNMBYG
+A1UdEQQPMA2CC2V4YW1wbGUuY29tMA0GCSqGSIb3DQEBCwUAA4IBAQC0HcXeqKls
++fWZzNPIkroiBAonRLStXI3R/xcEfT1zOnAOTQUqC75v4HnHFbQdqdikRwuNYDCj
+Okq7idvya6tYyVawJfinXNk7hbZG9NagmdIpAnufl5vrAW/Q3z2yLE0lwwEbByDi
+3s6JegVPnZIaZgDl5+381CdMJebP5L7Xvunp01iJURWAY1t3OyXLxcF7zR1l/HOZ
+m/xetJzhoO/acy/PVOPK+llLLRNTuRCYjCvA2BO73t4IA233rHfycPV7sAtP/BIL
+WMd2uXhevQmufC8kPWlHXlTo3X5gxrEsyBeO3BzjEz76eYq+VdimmkV8qm/Zbccj
+ceJ0WflHmKDF
 -----END CERTIFICATE-----
 `
 
+var validPems = map[string]string{
+	"ca": validCA, "cert": validCert, "key": validKey,
+}
+
+func validPermutations() map[string]string {
+	result := make(map[string]string, 6)
+	for k, v := range validPems {
+		for k1, v1 := range validPems {
+			if v1 != v {
+				for k2, v2 := range validPems {
+					if v2 != v && v2 != v1 {
+						result[k+k1+k2] = v + v1 + v2
+					}
+				}
+			}
+		}
+	}
+	return result
+}
+
 const (
-	validCertAfterCA = validCA + validCert
-	validCertGarbo   = `
+	allValid   = validCert + validKey + validCA
+	validGarbo = `
 aa983w4;/amndsfm908q26035vc;ng902338(%@%!@QY!&DVLMNSALX>PT(RQ!QO*%@
-` + validCert + `
+` + allValid + `
 !Q)(*@^YUO!Q#MN%$#WP(G^&+_!%)!+^%$Y	:!#QLKENFVJ)	!#*&%YHTM
 `
 )

--- a/docs/templating-language.md
+++ b/docs/templating-language.md
@@ -600,8 +600,8 @@ end of the `secret` function.
 ### `pkiCert`
 
 Query [Vault][vault] for a PKI certificate. It returns the certificate PEM
-encoded in a string. It only returns the PKI certificate, not the CA, key or
-any other informaion about the certificate.
+encoded in a string. It returns the PKI Certificate, CA, and the Secret Key as
+the fields: `Cert`, `CA` and `Key`.
 
 **Special Note**: This function uses the template file destination as a cache
 for the certificate to prevent Consul-Template from re-fetching it on reload or
@@ -609,11 +609,19 @@ restart. This special behavior is to better work with Vault's PKI behavior of
 always returning a new certificate even if the current one is still good. Using
 the destination file as a local "cache" allows Consul-Template to check for the
 certificate in that local file and, if found, parse it and checks it's valid
-date range only fetching a new certificate if the local one has expired.
+date range only fetching a new certificate if the local one has expired. It can
+only get re-populate the fields (Cert, CA, Key) if that data is in the file.
+Eg. If you don't include the CA in the file the CA field will be blank when
+loading from cache. And note that you **must** include the Certificate itself
+in this file as it contains the TTL/expiration data.
 
 
 ```golang
-{{ pkiCert "pki/issue/my-domain-dot-com" "common_name=foo.example.com" }}
+{{ with pkiCert "pki/issue/my-domain-dot-com" "common_name=foo.example.com" }}
+Certificate: {{ .Cert }}
+Private Key: {{ .Key }}
+Cert Authority: {{ .CA }}
+{{ end }}
 ```
 
 ### `service`

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1964,7 +1964,7 @@ func TestTemplate_Execute(t *testing.T) {
 		{
 			"func_pkiCert",
 			&NewTemplateInput{
-				Contents: `{{ pkiCert "pki/issue/egs-dot-com" }}`,
+				Contents: `{{ with pkiCert "pki/issue/egs-dot-com" }}{{.Cert}}{{end}}`,
 			},
 			&ExecuteInput{
 				Brain: func() *Brain {
@@ -1973,7 +1973,26 @@ func TestTemplate_Execute(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					b.Remember(d, testCert)
+					b.Remember(d, dep.PemEncoded{Cert: testCert})
+					return b
+				}(),
+			},
+			testCert,
+			false,
+		},
+		{
+			"func_pkiCert_Data_compat",
+			&NewTemplateInput{
+				Contents: `{{ with pkiCert "pki/issue/egs-dot-com" }}{{.Data.Cert}}{{end}}`,
+			},
+			&ExecuteInput{
+				Brain: func() *Brain {
+					b := NewBrain()
+					d, err := dep.NewVaultPKIQuery("pki/issue/egs-dot-com", "/dev/null", nil)
+					if err != nil {
+						t.Fatal(err)
+					}
+					b.Remember(d, dep.PemEncoded{Cert: testCert})
 					return b
 				}(),
 			},


### PR DESCRIPTION
Reworked `PKICert` to return an object with the Cert, the CA and the Private Key. They are stored as stings on a returned struct with appropriate names (Cert, Key, CA).

Fixes #1567 

Note chains were left out as they are difficult/impossible to differentiate from the CA cert and in the file. Plus they are available after the fact from the API.