### PR TITLE
Add NomadConfig Retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 This project provides a convenient way to populate values from [Consul][consul]
 into the file system using the `consul-template` daemon.
 
-The daemon `consul-template` queries a [Consul][consul] or [Vault][vault]
+The daemon `consul-template` queries a [Consul][consul], [Vault][vault], or [Nomad][nomad]
 cluster and updates any number of specified templates on the file system. As an
 added bonus, it can optionally run arbitrary commands when the update process
 completes. Please see the [examples folder][examples] for some scenarios where
@@ -130,6 +130,7 @@ Template.
 * [Consul Catalog](https://learn.hashicorp.com/consul/developer-configuration/consul-template#use-case-discover-all-services)
 * [Vault Agent Templates](https://learn.hashicorp.com/vault/identity-access-management/agent-templates)
 * [Vault Secrets](https://www.vaultproject.io/docs/agent/template#example-template)
+* [Nomad Native Service Discovery](https://learn.hashicorp.com/tutorials/nomad/schedule-edge-services)
 
 ## Configuration
 
@@ -228,6 +229,9 @@ The current processes environment is used when executing commands with the follo
 - `CONSUL_HTTP_AUTH`
 - `CONSUL_HTTP_SSL`
 - `CONSUL_HTTP_SSL_VERIFY`
+- `NOMAD_ADDR`
+- `NOMAD_NAMESPACE`
+- `NOMAD_TOKEN`
 
 These environment variables are exported with their current values when the
 command executes. Other Consul tooling reads these environment variables,
@@ -453,3 +457,4 @@ go test ./... -run SomeTestFunction_name
 [releases]: https://releases.hashicorp.com/consul-template "Consul Template Releases"
 [vault]: https://www.vaultproject.io "Vault by HashiCorp"
 [go]: https://golang.org "Go programming language"
+[nomad]: https://www.nomadproject.io "Nomad By HashiCorp"

--- a/config/nomad.go
+++ b/config/nomad.go
@@ -29,6 +29,9 @@ type NomadConfig struct {
 
 	// Transport configures the low-level network connection details.
 	Transport *TransportConfig `mapstructure:"transport"`
+
+	// Retry is the configuration for specifying how to behave on failure.
+	Retry *RetryConfig `mapstructure:"retry"`
 }
 
 func DefaultNomadConfig() *NomadConfig {
@@ -54,6 +57,7 @@ func (n *NomadConfig) Copy() *NomadConfig {
 	o.AuthUsername = n.AuthUsername
 	o.AuthPassword = n.AuthPassword
 	o.Transport = n.Transport.Copy()
+	o.Retry = n.Retry.Copy()
 
 	return &o
 }
@@ -108,6 +112,10 @@ func (n *NomadConfig) Merge(o *NomadConfig) *NomadConfig {
 		r.Transport = r.Transport.Merge(o.Transport)
 	}
 
+	if o.Retry != nil {
+		r.Retry = r.Retry.Merge(o.Retry)
+	}
+
 	return r
 }
 
@@ -149,6 +157,11 @@ func (n *NomadConfig) Finalize() {
 		n.Transport = DefaultTransportConfig()
 	}
 	n.Transport.Finalize()
+
+	if n.Retry == nil {
+		n.Retry = DefaultRetryConfig()
+	}
+	n.Retry.Finalize()
 }
 
 func (n *NomadConfig) GoString() string {
@@ -165,6 +178,7 @@ func (n *NomadConfig) GoString() string {
 		"AuthUsername:%s, "+
 		"AuthPassword:%s, "+
 		"Transport:%#v, "+
+		"Retry:%#v, "+
 		"}",
 		StringGoString(n.Address),
 		BoolGoString(n.Enabled),
@@ -174,5 +188,6 @@ func (n *NomadConfig) GoString() string {
 		StringGoString(n.AuthUsername),
 		StringGoString(n.AuthPassword),
 		n.Transport,
+		n.Retry,
 	)
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,7 @@ configuration.
   - [Consul Template](#consul-template)
   - [Consul](#consul)
   - [Vault](#vault)
+  - [Nomad](#nomad)
   - [Templates](#templates)
   - [Consul Template Modes](#modes)
     - [Once Mode](#once-mode)
@@ -435,6 +436,66 @@ vault {
   }
 
   # This section details the SSL options for connecting to the Vault server.
+  # Please see the SSL options in the Consul section for more information (they
+  # are the same).
+  ssl {
+    # ...
+  }
+}
+```
+
+## Nomad
+
+Enable Consul Template to connect with [Nomad][nomad] by declaring the `nomad`
+block. This configures a Nomad client to query Nomad for native service discovery
+or secrets to render data into templates.
+
+```hcl
+# This denotes the start of the configuration section for Nomad. All values
+# contained in this section pertain to Nomad.
+nomad {
+  # This is the address of the Nomad agent. The protocol (http(s)) portion
+  # of the address is required.
+  #
+  # This value can also be specified via the environment variable NOMAD_ADDR.
+  address = "https://127.0.0.1:4647"
+
+  # This is a Nomad namespace to use for queries.
+  #
+  # This value can also be specified via the environment variable NOMAD_NAMESPACE.
+  namespace = ""
+
+  # This is the token to use when communicating with the Nomad agent.
+  # Like other tools that integrate with Nomad, Consul Template makes the
+  # assumption that you provide it with a Vault token; it does not have the
+  # incorporated logic to generate tokens via Vault's auth methods.
+  #
+  # This value can also be specified via the environment variable NOMAD_TOKEN.
+  # It is highly recommended that you do not put your token in plain-text in a
+  # configuration file.
+  token = ""
+  
+  # The HTTP Basic Auth username to use when authenticating with the Nomad API.
+  auth_username = ""
+
+  # The HTTP Basic Auth password to use when authenticating with the Nomad API.
+  auth_password = ""
+  
+  # This block configures tcp connection options between Consul Template and Nomad.
+  # Please see the transport options in the Consul section for more information (they
+  # are the same).
+  transport {
+    # ...
+  }
+  
+  # This section details the retry options for connecting to Nomad. Please see
+  # the retry options in the Consul section for more information (they are the
+  # same).
+  retry {
+    # ...
+  }
+  
+  # This section details the SSL options for connecting to the Nomad agent.
   # Please see the SSL options in the Consul section for more information (they
   # are the same).
   ssl {

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -1394,6 +1394,7 @@ func newWatcher(c *config.Config, clients *dep.ClientSet, once bool) (*watch.Wat
 		RetryFuncDefault: nil,
 		RetryFuncVault:   watch.RetryFunc(c.Vault.Retry.RetryFunc()),
 		VaultToken:       clients.Vault().Token(),
+		RetryFuncNomad:   watch.RetryFunc(c.Nomad.Retry.RetryFunc()),
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "runner")

--- a/watch/watcher.go
+++ b/watch/watcher.go
@@ -45,6 +45,7 @@ type Watcher struct {
 	retryFuncConsul  RetryFunc
 	retryFuncDefault RetryFunc
 	retryFuncVault   RetryFunc
+	retryFuncNomad   RetryFunc
 }
 
 type NewWatcherInput struct {
@@ -73,6 +74,7 @@ type NewWatcherInput struct {
 	RetryFuncConsul  RetryFunc
 	RetryFuncDefault RetryFunc
 	RetryFuncVault   RetryFunc
+	RetryFuncNomad   RetryFunc
 }
 
 // NewWatcher creates a new watcher using the given API client.
@@ -88,6 +90,7 @@ func NewWatcher(i *NewWatcherInput) (*Watcher, error) {
 		retryFuncConsul:    i.RetryFuncConsul,
 		retryFuncDefault:   i.RetryFuncDefault,
 		retryFuncVault:     i.RetryFuncVault,
+		retryFuncNomad:     i.RetryFuncNomad,
 	}
 
 	// Start a watcher for the Vault renew if that config was specified
@@ -151,6 +154,8 @@ func (w *Watcher) Add(d dep.Dependency) (bool, error) {
 		retryFunc = w.retryFuncConsul
 	case dep.TypeVault:
 		retryFunc = w.retryFuncVault
+	case dep.TypeNomad:
+		retryFunc = w.retryFuncNomad
 	default:
 		retryFunc = w.retryFuncDefault
 	}


### PR DESCRIPTION
This PR introduces a retry configuration option for `NomadConfig`. Since consul-template now includes support for Nomad dependencies, we need this option to maintain behavioral parity with Consul and Vault dependencies. 