### PR TITLE
Issue 1428 fix no reload signal

### DIFF
--- a/child/child.go
+++ b/child/child.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/hashicorp/consul-template/signals"
 )
 
 func init() {
@@ -383,9 +385,14 @@ func (c *Child) signal(s os.Signal) error {
 	}
 
 	sig, ok := s.(syscall.Signal)
-	if !ok {
+	switch {
+	case !ok:
 		return fmt.Errorf("bad signal: %s", s)
+	case sig == signals.SIGNULL:
+		// skip on SIGNULL (ie. no signal)
+		return nil
 	}
+
 	pid := c.cmd.Process.Pid
 	if c.setpgid {
 		// kill takes negative pid to indicate that you want to use gpid

--- a/cli_test.go
+++ b/cli_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul-template/config"
+	"github.com/hashicorp/consul-template/signals"
 	"github.com/hashicorp/consul-template/test"
 	gatedio "github.com/hashicorp/go-gatedio"
 )
@@ -425,6 +426,14 @@ func TestCLI_ParseFlags(t *testing.T) {
 			[]string{"-reload-signal", "SIGUSR1"},
 			&config.Config{
 				ReloadSignal: config.Signal(syscall.SIGUSR1),
+			},
+			false,
+		},
+		{
+			"reload-signal-signil",
+			[]string{"-reload-signal", "SIGNULL"},
+			&config.Config{
+				ReloadSignal: config.Signal(signals.SIGNULL),
 			},
 			false,
 		},

--- a/config/convert.go
+++ b/config/convert.go
@@ -145,7 +145,7 @@ func SignalPresent(s *os.Signal) bool {
 	if s == nil {
 		return false
 	}
-	return *s != signals.SIGNIL
+	return *s != signals.SIGNULL
 }
 
 // String returns a pointer to the given string.

--- a/config/convert_test.go
+++ b/config/convert_test.go
@@ -442,7 +442,7 @@ func TestSignalPresent(t *testing.T) {
 		},
 		{
 			"present_zero_value",
-			Signal(signals.SIGNIL),
+			Signal(signals.SIGNULL),
 			false,
 		},
 	}

--- a/signals/mapstructure.go
+++ b/signals/mapstructure.go
@@ -25,7 +25,7 @@ func StringToSignalFunc() mapstructure.DecodeHookFunc {
 		}
 
 		if data == nil || data.(string) == "" {
-			return SIGNIL, nil
+			return SIGNULL, nil
 		}
 
 		return Parse(data.(string))

--- a/signals/nil.go
+++ b/signals/nil.go
@@ -1,7 +1,0 @@
-package signals
-
-// NilSignal is a special signal that is blank or "nil"
-type NilSignal int
-
-func (s *NilSignal) String() string { return "SIGNIL" }
-func (s *NilSignal) Signal()        {}

--- a/signals/signals.go
+++ b/signals/signals.go
@@ -5,10 +5,11 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"syscall"
 )
 
-// SIGNIL is the nil signal.
-var SIGNIL os.Signal = new(NilSignal)
+// SIGNULL is the nil/zero signal.
+var SIGNULL os.Signal = syscall.Signal(0)
 
 // ValidSignals is the list of all valid signals. This is built at runtime
 // because it is OS-dependent.

--- a/signals/signals_unix.go
+++ b/signals/signals_unix.go
@@ -13,6 +13,7 @@ import (
 // SIGURG  - used by the golang scheduler for parallel runtime.
 
 var SignalLookup = map[string]os.Signal{
+	"SIGNULL":   SIGNULL,
 	"SIGABRT":  syscall.SIGABRT,
 	"SIGALRM":  syscall.SIGALRM,
 	"SIGBUS":   syscall.SIGBUS,

--- a/signals/signals_windows.go
+++ b/signals/signals_windows.go
@@ -9,6 +9,7 @@ import (
 )
 
 var SignalLookup = map[string]os.Signal{
+	"SIGNULL":  SIGNULL,
 	"SIGABRT": syscall.SIGABRT,
 	"SIGALRM": syscall.SIGALRM,
 	"SIGBUS":  syscall.SIGBUS,


### PR DESCRIPTION
Converted odd SIGNIL type that wouldn't work with syscall type assertion and allow for differentiating between it and an error into SIGNULL, `syscall.Signal(0)`. SIGNULL works here as it allows for the type assertion to work and for a test to skip the signal when found. It is safe as it already exists in practice in a similar role with the POSIX `kill` command where it indidates no signal.

Fixes #1428
Fixes #1442