### PR TITLE
make sure pki IDs are unique

### DIFF
--- a/dependency/vault_pki.go
+++ b/dependency/vault_pki.go
@@ -220,7 +220,7 @@ func (d *VaultPKIQuery) Stop() {
 
 // String returns the human-friendly version of this dependency.
 func (d *VaultPKIQuery) String() string {
-	return fmt.Sprintf("vault.pki(%s)", d.pkiPath)
+	return fmt.Sprintf("vault.pki(%s->%s)", d.pkiPath, d.filePath)
 }
 
 // Type returns the type of this dependency.

--- a/dependency/vault_pki_test.go
+++ b/dependency/vault_pki_test.go
@@ -13,6 +13,16 @@ import (
 	"github.com/hashicorp/vault/api"
 )
 
+func Test_VaultPKI_uniqueID(t *testing.T) {
+	d1, _ := NewVaultPKIQuery("pki/issue/example-dot-com", "/unique_1", nil)
+	id1 := d1.String()
+	d2, _ := NewVaultPKIQuery("pki/issue/example-dot-com", "/unique_2", nil)
+	id2 := d2.String()
+	if id1 == id2 {
+		t.Errorf("IDs should be unique.\n%s\n%s", id1, id2)
+	}
+}
+
 func Test_VaultPKI_notGoodFor(t *testing.T) {
 	// only test the negation, postive is tested below with pemsificates
 	// fetched in Vault integration tests (creating pemss is non-trivial)

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1964,7 +1964,8 @@ func TestTemplate_Execute(t *testing.T) {
 		{
 			"func_pkiCert",
 			&NewTemplateInput{
-				Contents: `{{ with pkiCert "pki/issue/egs-dot-com" }}{{.Cert}}{{end}}`,
+				Contents:    `{{ with pkiCert "pki/issue/egs-dot-com" }}{{.Cert}}{{end}}`,
+				Destination: "/dev/null",
 			},
 			&ExecuteInput{
 				Brain: func() *Brain {
@@ -1983,7 +1984,8 @@ func TestTemplate_Execute(t *testing.T) {
 		{
 			"func_pkiCert_Data_compat",
 			&NewTemplateInput{
-				Contents: `{{ with pkiCert "pki/issue/egs-dot-com" }}{{.Data.Cert}}{{end}}`,
+				Contents:    `{{ with pkiCert "pki/issue/egs-dot-com" }}{{.Data.Cert}}{{end}}`,
+				Destination: "/dev/null",
 			},
 			&ExecuteInput{
 				Brain: func() *Brain {


### PR DESCRIPTION
This was a classic cut-n-paste error. The PKI code was based on the
existing vault_read.go 'secret' code and missed the fact that the ID of
the pkiCert will be identical for all certs pulled form the same PKI
role path.

The fix will be to adjust the ID to be composed of the pki role path +
the destination path. That should be unique per use case as the
destination path must be unique per Cert.

Fixes #1607 