### PR TITLE
filter out vault secrets from template errors

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"crypto/md5"
 	"encoding/hex"
+	"fmt"
 	"io/ioutil"
+	"strings"
 	"text/template"
 
 	"github.com/Masterminds/sprig"
@@ -233,7 +235,7 @@ func (t *Template) Execute(i *ExecuteInput) (*ExecuteResult, error) {
 	// Execute the template into the writer
 	var b bytes.Buffer
 	if err := tmpl.Execute(&b, nil); err != nil {
-		return nil, errors.Wrap(err, "execute")
+		return nil, errors.Wrap(redactinator(&used, i.Brain, err), "execute")
 	}
 
 	return &ExecuteResult{
@@ -241,6 +243,20 @@ func (t *Template) Execute(i *ExecuteInput) (*ExecuteResult, error) {
 		Missing: &missing,
 		Output:  b.Bytes(),
 	}, nil
+}
+
+func redactinator(used *dep.Set, b *Brain, err error) error {
+	pairs := make([]string, 0, used.Len())
+	for _, d := range used.List() {
+		if data, ok := b.Recall(d); ok {
+			if vd, ok := data.(*dep.Secret); ok {
+				for _, v := range vd.Data {
+					pairs = append(pairs, fmt.Sprintf("%v", v), "[redacted]")
+				}
+			}
+		}
+	}
+	return fmt.Errorf(strings.NewReplacer(pairs...).Replace(err.Error()))
 }
 
 // funcMapInput is input to the funcMap, which builds the template functions.

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -8,6 +8,8 @@ import (
 	"os/user"
 	"reflect"
 	"strconv"
+	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -2048,6 +2050,48 @@ func TestTemplate_Execute(t *testing.T) {
 				t.Errorf("\nexp: %#v\nact: %#v", tc.e, string(a.Output))
 			}
 		})
+	}
+}
+
+func TestTemplate_error_secret_leak(t *testing.T) {
+	tmplinput := &NewTemplateInput{
+		Contents: `{{ with secret "secret/foo" }}
+					{{- range $key, $value := .Data.zip }}
+						export {{ $key }}="{{ $value }}"
+					{{- end }}
+				{{ end }}`,
+	}
+	execinput := &ExecuteInput{
+		Brain: func() *Brain {
+			b := NewBrain()
+			b.RWMutex = sync.RWMutex{}
+			d, err := dep.NewVaultReadQuery("secret/foo")
+			if err != nil {
+				t.Fatal(err)
+			}
+			b.Remember(d, &dep.Secret{
+				LeaseID:       "abcd1234",
+				LeaseDuration: 120,
+				Renewable:     true,
+				Data: map[string]interface{}{
+					"zip": struct {
+						Zap string
+					}{
+						Zap: "zoo",
+					},
+				},
+			})
+			return b
+		}(),
+	}
+
+	tpl, err := NewTemplate(tmplinput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = tpl.Execute(execinput)
+	if strings.Contains(err.Error(), "zoo") {
+		t.Error("error contains secret... (zoo)\n", err.Error())
 	}
 }
 


### PR DESCRIPTION
Template execute errors would return the values related to the error in certain cases and these could end up in the logs. This makes sure that if those values are vault secrets they are redacted.