### PR TITLE
Updated Makefile to work when Consul-Template is in a Go Workspace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOTAGS ?=
 # Get the project metadata
 OWNER := "hashicorp"
 NAME := "consul-template"
-PROJECT := $(shell go list -m)
+PROJECT := $(shell go list -m | awk '/${NAME}/ {print $0}' )
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD || echo release)
 VERSION := $(shell awk -F\" '/^[ \t]+Version/ { print $$2; exit }' "${CURRENT_DIR}/version/version.go")
 PRERELEASE := $(shell awk -F\" '/^[ \t]+VersionPrerelease/ { print $$2; exit }' "${CURRENT_DIR}/version/version.go")


### PR DESCRIPTION
When in a go workspace, the `go list -m` command emits every module it's been configured with. This addition reduces that list back down to the consul-template module name so that the Makefile works, even when CT is inside a multi-module go workspace.