### PR TITLE
Support Nomad Secure Variables

### DIFF
--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -21,6 +21,7 @@ const (
 	prefixRe      = `/?(?P<prefix>[^@]+)`
 	tagRe         = `((?P<tag>[[:word:]=:\.\-\_]+)\.)?`
 	regionRe      = `(@(?P<region>[[:word:]\.\-\_]+))?`
+	svPathRe      = `/?(?P<path>[^@]+)`
 )
 
 type Type int

--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -413,3 +413,24 @@ func Fatalf(format string, args ...interface{}) {
 	fmt.Printf(format, args...)
 	runtime.Goexit()
 }
+
+func (v *nomadServer) CreateSecureVariable(path string, data map[string]string) error {
+	sv := nomadapi.NewSecureVariable(path)
+	for k, v := range data {
+		sv.Items[k] = v
+	}
+	_, err := testClients.Nomad().SecureVariables().Update(sv, nil)
+	if err != nil {
+		fmt.Println(err)
+	}
+	return err
+}
+
+// deleteSecureVariable lets us delete keys as needed for tests
+func (v *nomadServer) deleteSecureVariable(path string) error {
+	_, err := testClients.Nomad().SecureVariables().Delete(path, nil)
+	if err != nil {
+		fmt.Println(err)
+	}
+	return err
+}

--- a/dependency/nomad_secure_variables_get.go
+++ b/dependency/nomad_secure_variables_get.go
@@ -1,0 +1,106 @@
+package dependency
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+	"regexp"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	// Ensure implements
+	_ Dependency = (*SVGetQuery)(nil)
+
+	// SVGetQueryRe is the regular expression to use.
+	SVGetQueryRe = regexp.MustCompile(`\A` + svPathRe + `\z`)
+)
+
+// SVGetQuery queries the KV store for a single key.
+type SVGetQuery struct {
+	stopCh chan struct{}
+
+	path       string
+	blockOnNil bool
+}
+
+// NewSVGetQuery parses a string into a dependency.
+func NewSVGetQuery(s string) (*SVGetQuery, error) {
+	if s != "" && !SVGetQueryRe.MatchString(s) {
+		return nil, fmt.Errorf("nomad.secure_variables.get: invalid format: %q", s)
+	}
+
+	m := regexpMatch(SVGetQueryRe, s)
+	return &SVGetQuery{
+		stopCh: make(chan struct{}, 1),
+		path:   m["path"],
+	}, nil
+}
+
+// Fetch queries the Nomad API defined by the given client.
+func (d *SVGetQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interface{}, *ResponseMetadata, error) {
+	select {
+	case <-d.stopCh:
+		return nil, nil, ErrStopped
+	default:
+	}
+
+	opts = opts.Merge(&QueryOptions{})
+
+	log.Printf("[TRACE] %s: GET %s", d, &url.URL{
+		Path:     "/v1/var/" + d.path,
+		RawQuery: opts.String(),
+	})
+
+	// NOTE: The Peek method of the Nomad SV API will check a value, return it
+	// if it exists, but return a nil value and NO error if it is not found.
+	sv, qm, err := clients.Nomad().SecureVariables().Peek(d.path, opts.ToNomadOpts())
+	if err != nil {
+		return nil, nil, errors.Wrap(err, d.String())
+	}
+
+	rm := &ResponseMetadata{
+		LastIndex:   qm.LastIndex,
+		LastContact: qm.LastContact,
+		BlockOnNil:  d.blockOnNil,
+	}
+
+	if sv == nil {
+		log.Printf("[TRACE] %s: returned nil", d)
+		return nil, rm, nil
+	}
+
+	items := NewNomadSecureVariable(sv).Items
+	log.Printf("[TRACE] %s: returned %q", d, sv.Path)
+	return items, rm, nil
+}
+
+// EnableBlocking turns this into a blocking KV query.
+func (d *SVGetQuery) EnableBlocking() {
+	d.blockOnNil = true
+}
+
+// CanShare returns a boolean if this dependency is shareable.
+func (d *SVGetQuery) CanShare() bool {
+	return true
+}
+
+// String returns the human-friendly version of this dependency.
+func (d *SVGetQuery) String() string {
+	path := d.path
+	if d.blockOnNil {
+		return fmt.Sprintf("nomad.secure_variables.block(%s)", path)
+	}
+	return fmt.Sprintf("nomad.secure_variables.get(%s)", path)
+}
+
+// Stop halts the dependency's fetch function.
+func (d *SVGetQuery) Stop() {
+	close(d.stopCh)
+}
+
+// Type returns the type of this dependency.
+func (d *SVGetQuery) Type() Type {
+	return TypeNomad
+}

--- a/dependency/nomad_secure_variables_get_test.go
+++ b/dependency/nomad_secure_variables_get_test.go
@@ -1,0 +1,294 @@
+package dependency
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	nomadapi "github.com/hashicorp/nomad/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSVGetQuery(t *testing.T) {
+
+	cases := []struct {
+		name string
+		i    string
+		exp  *SVGetQuery
+		err  bool
+	}{
+		{
+			"empty",
+			"",
+			&SVGetQuery{},
+			false,
+		},
+
+		{
+			"dc_only",
+			"@dc1",
+			nil,
+			true,
+		},
+		{
+			"path",
+			"path",
+			&SVGetQuery{
+				path: "path",
+			},
+			false,
+		},
+		{
+			"dots",
+			"path.with.dots",
+			&SVGetQuery{
+				path: "path.with.dots",
+			},
+			false,
+		},
+		{
+			"slashes",
+			"path/with/slashes",
+			&SVGetQuery{
+				path: "path/with/slashes",
+			},
+			false,
+		},
+		{
+			"dashes",
+			"path-with-dashes",
+			&SVGetQuery{
+				path: "path-with-dashes",
+			},
+			false,
+		},
+		{
+			"leading_slash",
+			"/leading/slash",
+			&SVGetQuery{
+				path: "leading/slash",
+			},
+			false,
+		},
+		{
+			"trailing_slash",
+			"trailing/slash/",
+			&SVGetQuery{
+				path: "trailing/slash/",
+			},
+			false,
+		},
+		{
+			"underscores",
+			"path_with_underscores",
+			&SVGetQuery{
+				path: "path_with_underscores",
+			},
+			false,
+		},
+		{
+			"special_characters",
+			"config/facet:größe-lf-si",
+			&SVGetQuery{
+				path: "config/facet:größe-lf-si",
+			},
+			false,
+		},
+		{
+			"splat",
+			"config/*/timeouts/",
+			&SVGetQuery{
+				path: "config/*/timeouts/",
+			},
+			false,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			act, err := NewSVGetQuery(tc.i)
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+
+			if act != nil {
+				act.stopCh = nil
+			}
+
+			assert.Equal(t, tc.exp, act)
+		})
+	}
+	fmt.Println("done")
+}
+
+func TestSVGetQuery_Fetch(t *testing.T) {
+
+	type svmap map[string]string
+	_ = testNomad.CreateSecureVariable("test-kv-get/path", svmap{"bar": "barp"})
+
+	cases := []struct {
+		name string
+		i    string
+		exp  interface{}
+	}{
+		{
+			"exists",
+			"test-kv-get/path",
+			NewNomadSecureVariable(&nomadapi.SecureVariable{
+				Namespace: "default",
+				Path:      "test-kv-get/path",
+				Items: nomadapi.SecureVariableItems{
+					"bar": "barp",
+				},
+			}).Items,
+		},
+		{
+			"no_exist",
+			"test-kv-get/not/a/real/path/like/ever",
+			nil,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			d, err := NewSVGetQuery(tc.i)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			act, _, err := d.Fetch(testClients, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.exp != nil {
+				testNomadSVEquivalent(t, tc.exp, act)
+			} else {
+				assert.Nil(t, act)
+			}
+		})
+	}
+
+	t.Run("stops", func(t *testing.T) {
+		d, err := NewSVGetQuery("test-kv-get/path")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		dataCh := make(chan interface{}, 1)
+		errCh := make(chan error, 1)
+		go func() {
+			for {
+				data, _, err := d.Fetch(testClients, nil)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				dataCh <- data
+			}
+		}()
+
+		select {
+		case err := <-errCh:
+			t.Fatal(err)
+		case <-dataCh:
+		}
+
+		d.Stop()
+
+		select {
+		case err := <-errCh:
+			if err != ErrStopped {
+				t.Fatal(err)
+			}
+		case <-time.After(200 * time.Millisecond):
+			t.Errorf("did not stop")
+		}
+	})
+
+	t.Run("fires_changes", func(t *testing.T) {
+		d, err := NewSVGetQuery("test-kv-get/path")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, qm, err := d.Fetch(testClients, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		dataCh := make(chan interface{}, 1)
+		errCh := make(chan error, 1)
+		go func() {
+			for {
+				data, _, err := d.Fetch(testClients, &QueryOptions{WaitIndex: qm.LastIndex})
+				if err != nil {
+					errCh <- err
+					return
+				}
+				dataCh <- data
+				return
+			}
+		}()
+
+		_ = testNomad.CreateSecureVariable("test-kv-get/path", svmap{"bar": "barp", "car": "carp"})
+
+		select {
+		case err := <-errCh:
+			t.Fatal(err)
+		case data := <-dataCh:
+			exp := NewNomadSecureVariable(&nomadapi.SecureVariable{
+				Namespace: "default",
+				Path:      "test-kv-get/path",
+				Items:     nomadapi.SecureVariableItems{"bar": "barp", "car": "carp"},
+			})
+			testNomadSVEquivalent(t, exp.Items, data)
+		}
+	})
+}
+
+func TestSVGetQuery_String(t *testing.T) {
+
+	cases := []struct {
+		name string
+		i    string
+		exp  string
+	}{
+		{
+			"path",
+			"path",
+			"nomad.secure_variables.get(path)",
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			d, err := NewSVGetQuery(tc.i)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, tc.exp, d.String())
+		})
+	}
+}
+
+func testNomadSVEquivalent(t *testing.T, expIf, actIf interface{}) {
+	if expIf == nil && actIf == nil {
+		return
+	}
+	if expIf == nil || actIf == nil {
+		t.Fatalf("Mismatched nil and value.\na: %v\nb:%v", expIf, actIf)
+	}
+	exp, ok := expIf.(NomadSVItems)
+	require.True(t, ok, "exp is not NomadSVItems, got %T", expIf)
+	act, ok := actIf.(NomadSVItems)
+	require.True(t, ok, "act is not NomadSVItems, got %T", actIf)
+
+	expMeta := exp.Metadata()
+	actMeta := act.Metadata()
+	require.NotNil(t, expMeta, "Expected non-nil expMeta.Metadata()")
+	require.NotNil(t, actMeta, "Expected non-nil intMeta.Metadata()")
+	require.Equal(t, expMeta.Namespace, actMeta.Namespace)
+	require.Equal(t, expMeta.Path, actMeta.Path)
+	require.ElementsMatch(t, exp.Tuples(), act.Tuples())
+}

--- a/dependency/nomad_secure_variables_list.go
+++ b/dependency/nomad_secure_variables_list.go
@@ -1,0 +1,100 @@
+package dependency
+
+import (
+	"encoding/gob"
+	"fmt"
+	"log"
+	"net/url"
+	"regexp"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	// Ensure implements
+	_ Dependency = (*SVListQuery)(nil)
+
+	// SVListQueryRe is the regular expression to use.
+	SVListQueryRe = regexp.MustCompile(`\A` + prefixRe + `\z`)
+)
+
+func init() {
+	gob.Register([]*NomadSVMeta{})
+}
+
+// SVListQuery queries the SV store for the metadata for keys matching the given
+// prefix.
+type SVListQuery struct {
+	stopCh chan struct{}
+
+	prefix string
+}
+
+// NewSVListQuery parses a string into a dependency.
+func NewSVListQuery(s string) (*SVListQuery, error) {
+	if s != "" && !SVListQueryRe.MatchString(s) {
+		return nil, fmt.Errorf("nomad.secure_variables.list: invalid format: %q", s)
+	}
+
+	m := regexpMatch(SVListQueryRe, s)
+	return &SVListQuery{
+		stopCh: make(chan struct{}, 1),
+		prefix: m["prefix"],
+	}, nil
+}
+
+// Fetch queries the Nomad API defined by the given client.
+func (d *SVListQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interface{}, *ResponseMetadata, error) {
+	select {
+	case <-d.stopCh:
+		return nil, nil, ErrStopped
+	default:
+	}
+
+	opts = opts.Merge(&QueryOptions{})
+
+	log.Printf("[TRACE] %s: GET %s", d, &url.URL{
+		Path:     "/v1/vars/",
+		RawQuery: opts.String(),
+	})
+
+	list, qm, err := clients.Nomad().SecureVariables().PrefixList(d.prefix, opts.ToNomadOpts())
+	if err != nil {
+		return nil, nil, errors.Wrap(err, d.String())
+	}
+
+	log.Printf("[TRACE] %s: returned %d paths", d, len(list))
+
+	vars := make([]*NomadSVMeta, 0, len(list))
+	for _, sv := range list {
+		vars = append(vars, NewNomadSVMeta(sv))
+	}
+
+	rm := &ResponseMetadata{
+		LastIndex:   qm.LastIndex,
+		LastContact: qm.LastContact,
+	}
+
+	return vars, rm, nil
+}
+
+// CanShare returns a boolean if this dependency is shareable.
+func (d *SVListQuery) CanShare() bool {
+	return true
+}
+
+// String returns the human-friendly version of this dependency.
+func (d *SVListQuery) String() string {
+	prefix := d.prefix
+	return fmt.Sprintf("nomad.secure_variables.list(%s)", prefix)
+}
+
+// Stop halts the dependency's fetch function.
+func (d *SVListQuery) Stop() {
+	close(d.stopCh)
+}
+
+// Type returns the type of this dependency.
+func (d *SVListQuery) Type() Type {
+	return TypeNomad
+}

--- a/dependency/nomad_secure_variables_list_test.go
+++ b/dependency/nomad_secure_variables_list_test.go
@@ -1,0 +1,300 @@
+package dependency
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSVListQuery(t *testing.T) {
+
+	cases := []struct {
+		name string
+		i    string
+		exp  *SVListQuery
+		err  bool
+	}{
+		{
+			"empty",
+			"",
+			&SVListQuery{},
+			false,
+		},
+		{
+			"prefix",
+			"prefix",
+			&SVListQuery{
+				prefix: "prefix",
+			},
+			false,
+		},
+		{
+			"dots",
+			"prefix.with.dots",
+			&SVListQuery{
+				prefix: "prefix.with.dots",
+			},
+			false,
+		},
+		{
+			"slashes",
+			"prefix/with/slashes",
+			&SVListQuery{
+				prefix: "prefix/with/slashes",
+			},
+			false,
+		},
+		{
+			"dashes",
+			"prefix-with-dashes",
+			&SVListQuery{
+				prefix: "prefix-with-dashes",
+			},
+			false,
+		},
+		{
+			"leading_slash",
+			"/leading/slash",
+			&SVListQuery{
+				prefix: "leading/slash",
+			},
+			false,
+		},
+		{
+			"trailing_slash",
+			"trailing/slash/",
+			&SVListQuery{
+				prefix: "trailing/slash/",
+			},
+			false,
+		},
+		{
+			"underscores",
+			"prefix_with_underscores",
+			&SVListQuery{
+				prefix: "prefix_with_underscores",
+			},
+			false,
+		},
+		{
+			"special_characters",
+			"config/facet:größe-lf-si",
+			&SVListQuery{
+				prefix: "config/facet:größe-lf-si",
+			},
+			false,
+		},
+		{
+			"splat",
+			"config/*/timeouts/",
+			&SVListQuery{
+				prefix: "config/*/timeouts/",
+			},
+			false,
+		},
+		{
+			"slash",
+			"/",
+			&SVListQuery{
+				prefix: "/",
+			},
+			false,
+		},
+		{
+			"slash-slash",
+			"//",
+			&SVListQuery{
+				prefix: "/",
+			},
+			false,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			act, err := NewSVListQuery(tc.i)
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+
+			if act != nil {
+				act.stopCh = nil
+			}
+
+			assert.Equal(t, tc.exp, act)
+		})
+	}
+}
+
+func TestSVListQuery_Fetch(t *testing.T) {
+
+	type svmap map[string]string
+	_ = testNomad.CreateSecureVariable("test-kv-list/prefix/foo", svmap{"bar": "barp"})
+	_ = testNomad.CreateSecureVariable("test-kv-list/prefix/zip", svmap{"zap": "zapp"})
+	_ = testNomad.CreateSecureVariable("test-kv-list/prefix/wave/ocean", svmap{"sleek": "sleekp"})
+
+	cases := []struct {
+		name string
+		i    string
+		exp  []*NomadSVMeta
+	}{
+		{
+			"exists",
+			"test-kv-list/prefix",
+			[]*NomadSVMeta{
+				{Namespace: "default", Path: "test-kv-list/prefix/foo"},
+				{Namespace: "default", Path: "test-kv-list/prefix/wave/ocean"},
+				{Namespace: "default", Path: "test-kv-list/prefix/zip"},
+			},
+		},
+		{
+			"trailing",
+			"test-kv-list/prefix/",
+			[]*NomadSVMeta{
+				{Namespace: "default", Path: "test-kv-list/prefix/foo"},
+				{Namespace: "default", Path: "test-kv-list/prefix/wave/ocean"},
+				{Namespace: "default", Path: "test-kv-list/prefix/zip"},
+			},
+		},
+		{
+			"no_exist",
+			"test-kv-list/not/a/real/prefix/like/ever",
+			[]*NomadSVMeta{},
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			d, err := NewSVListQuery(tc.i)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			act, _, err := d.Fetch(testClients, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for _, p := range act.([]*NomadSVMeta) {
+				p.CreateIndex = 0
+				p.CreateTime = 0
+				p.ModifyIndex = 0
+				p.ModifyTime = 0
+			}
+
+			assert.ElementsMatch(t, tc.exp, act)
+		})
+	}
+
+	t.Run("stops", func(t *testing.T) {
+		d, err := NewSVListQuery("test-kv-list/prefix")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		dataCh := make(chan interface{}, 1)
+		errCh := make(chan error, 1)
+		go func() {
+			for {
+				data, _, err := d.Fetch(testClients, nil)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				dataCh <- data
+			}
+		}()
+
+		select {
+		case err := <-errCh:
+			t.Fatal(err)
+		case <-dataCh:
+		}
+
+		d.Stop()
+
+		select {
+		case err := <-errCh:
+			if err != ErrStopped {
+				t.Fatal(err)
+			}
+		case <-time.After(250 * time.Millisecond):
+			t.Errorf("did not stop")
+		}
+	})
+
+	t.Run("fires_changes", func(t *testing.T) {
+		d, err := NewSVListQuery("test-kv-list/prefix/")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, qm, err := d.Fetch(testClients, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		dataCh := make(chan interface{}, 1)
+		errCh := make(chan error, 1)
+		go func() {
+			for {
+				data, _, err := d.Fetch(testClients, &QueryOptions{WaitIndex: qm.LastIndex})
+				if err != nil {
+					errCh <- err
+					return
+				}
+				dataCh <- data
+				return
+			}
+		}()
+
+		_ = testNomad.CreateSecureVariable("test-kv-list/prefix/foo", svmap{"new-bar": "new-barp"})
+
+		select {
+		case err := <-errCh:
+			t.Fatal(err)
+		case data := <-dataCh:
+			svs := data.([]*NomadSVMeta)
+			if len(svs) == 0 {
+				t.Fatal("bad length")
+			}
+
+			// Zero out the dynamic elements
+			act := svs[0]
+			act.CreateIndex = 0
+			act.CreateTime = 0
+			act.ModifyIndex = 0
+			act.ModifyTime = 0
+
+			exp := &NomadSVMeta{Namespace: "default", Path: "test-kv-list/prefix/foo"}
+			assert.Equal(t, exp, act)
+		}
+	})
+}
+
+func TestSVListQuery_String(t *testing.T) {
+
+	cases := []struct {
+		name string
+		i    string
+		exp  string
+	}{
+		{
+			"prefix",
+			"prefix",
+			"nomad.secure_variables.list(prefix)",
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			d, err := NewSVListQuery(tc.i)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, tc.exp, d.String())
+		})
+	}
+}

--- a/dependency/nomad_secure_variables_structs.go
+++ b/dependency/nomad_secure_variables_structs.go
@@ -109,7 +109,7 @@ func (i NomadSVItems) Parent() *NomadSecureVariable {
 }
 
 // NomadSVItem enriches the basic string values in a api.SecureVariable's Items
-// map with additional helper funcs for formatting and access to it's parent
+// map with additional helper funcs for formatting and access to its parent
 // item. This enables us to have the template funcs start at the Items
 // collection without the user having to delve to it themselves and to minimize
 // the number of template funcs that we have to provide for coverage.
@@ -130,6 +130,8 @@ type NomadSVMeta struct {
 	CreateIndex, ModifyIndex uint64
 	CreateTime, ModifyTime   nanoTime
 }
+
+func (s NomadSVMeta) String() string { return s.Path }
 
 // nanoTime is the typical storage encoding for times in Nomad's backend. They
 // are not pretty for consul-template consumption, so this gives us a type to

--- a/dependency/nomad_secure_variables_structs.go
+++ b/dependency/nomad_secure_variables_structs.go
@@ -1,0 +1,140 @@
+package dependency
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/hashicorp/nomad/api"
+)
+
+// NewNomadSVMeta is used to create a NomadSVMeta from a Nomad API
+// SecureVariableMetadata response.
+func NewNomadSVMeta(in *api.SecureVariableMetadata) *NomadSVMeta {
+	return &NomadSVMeta{
+		Namespace:   in.Namespace,
+		Path:        in.Path,
+		CreateIndex: in.CreateIndex,
+		ModifyIndex: in.ModifyIndex,
+		CreateTime:  nanoTime(in.CreateTime),
+		ModifyTime:  nanoTime(in.ModifyTime),
+	}
+}
+
+// NewNomadSecureVariable is used to create a NomadSecureVariable from a Nomad
+// API SecureVariable response.
+func NewNomadSecureVariable(in *api.SecureVariable) *NomadSecureVariable {
+	out := NomadSecureVariable{
+		Namespace:   in.Namespace,
+		Path:        in.Path,
+		CreateIndex: in.CreateIndex,
+		ModifyIndex: in.ModifyIndex,
+		CreateTime:  nanoTime(in.CreateTime),
+		ModifyTime:  nanoTime(in.ModifyTime),
+		Items:       map[string]NomadSVItem{},
+		sv:          in,
+	}
+
+	items := make(NomadSVItems, len(in.Items))
+	for k, v := range in.Items {
+		items[k] = NomadSVItem{k, v, &out}
+	}
+	out.Items = items
+	return &out
+}
+
+// NomadSecureVariable is a template friendly container struct that allows for
+// the NomadVar funcs to start inside of Items and have a rational way back up
+// to the SecureVariable that is JSON structurally equivalent to the API response.
+// This struct's zero value is not trivially usable and should be created with
+// NewNomadSecureVariable--especially when outside of the dependency package as
+// there is no access to sv.
+type NomadSecureVariable struct {
+	Namespace, Path          string
+	CreateIndex, ModifyIndex uint64
+	CreateTime, ModifyTime   nanoTime
+	Items                    NomadSVItems
+	sv                       *api.SecureVariable
+}
+
+func (cv NomadSecureVariable) Metadata() *NomadSVMeta {
+	return NewNomadSVMeta(cv.sv.Metadata())
+}
+
+type NomadSVItems map[string]NomadSVItem
+
+// Keys returns a sorted list of the Item map's keys.
+func (v NomadSVItems) Keys() []string {
+	out := make([]string, 0, len(v))
+	for k := range v {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Values produces a key-sorted list of the Items map's values
+func (v NomadSVItems) Values() []string {
+	out := make([]string, 0, len(v))
+	for _, k := range v.Keys() {
+		out = append(out, v[k].String())
+	}
+	return out
+}
+
+// Tuples produces a key-sorted list of K,V tuple structs from the Items map's
+// values
+func (v NomadSVItems) Tuples() []struct{ K, V string } {
+	out := make([]struct{ K, V string }, 0, len(v))
+	for _, k := range v.Keys() {
+		out = append(out, struct{ K, V string }{K: k, V: v[k].String()})
+	}
+	return out
+}
+
+// Metadata returns this item's parent's metadata
+func (i NomadSVItems) Metadata() *NomadSVMeta {
+	for _, v := range i {
+		return v.parent.Metadata()
+	}
+	return nil
+}
+
+// Parent returns the item's container object
+func (i NomadSVItems) Parent() *NomadSecureVariable {
+	for _, v := range i {
+		return v.Parent()
+	}
+	return nil
+}
+
+// NomadSVItem enriches the basic string values in a api.SecureVariable's Items
+// map with additional helper funcs for formatting and access to it's parent
+// item. This enables us to have the template funcs start at the Items
+// collection without the user having to delve to it themselves and to minimize
+// the number of template funcs that we have to provide for coverage.
+type NomadSVItem struct {
+	Key, Value string
+	parent     *NomadSecureVariable
+}
+
+func (v NomadSVItem) String() string               { return v.Value }
+func (v NomadSVItem) Metadata() *NomadSVMeta       { return v.parent.Metadata() }
+func (v NomadSVItem) Parent() *NomadSecureVariable { return v.parent }
+func (v NomadSVItem) MarshalJSON() ([]byte, error) { return []byte(fmt.Sprintf("%q", v.Value)), nil }
+
+// NomadSVMeta provides the same fields as api.SecureVariableMetadata
+// but aliases the times into a more template friendly alternative.
+type NomadSVMeta struct {
+	Namespace, Path          string
+	CreateIndex, ModifyIndex uint64
+	CreateTime, ModifyTime   nanoTime
+}
+
+// nanoTime is the typical storage encoding for times in Nomad's backend. They
+// are not pretty for consul-template consumption, so this gives us a type to
+// add receivers on.
+type nanoTime int64
+
+func (t nanoTime) String() string  { return fmt.Sprintf("%v", time.Unix(0, int64(t))) }
+func (t nanoTime) Time() time.Time { return time.Unix(0, int64(t)) }

--- a/docs/templating-language.md
+++ b/docs/templating-language.md
@@ -98,6 +98,10 @@ provides the following functions:
 - [Nomad Functions](#nomad-functions)
   - [nomadServices](#nomadservices)
   - [nomadService](#nomadservice)
+  - [nomadVarList](#nomadvarlist)
+  - [nomadVarListSafe](#nomadvarlistsafe)
+  - [nomadVar](#nomadvar)
+  - [nomadVarExists](#nomadvarexists)
 - [Debugging Functions](#debugging)
   - [spew_dump](#spew_dump)
   - [spew_sdump](#spew_sdump)
@@ -1695,7 +1699,7 @@ For example:
 ## Sprig Functions
 
 Consul-template provides access to the Sprig library
-in templates. To use a Sprig function in your template, prepend `sprig_` to the function name.  A full list of Sprig functions can be found in the [Sprig Function Documentation](http://masterminds.github.io/sprig/)
+in templates. To use a Sprig function in your template, prepend `sprig_` to the function name. A full list of Sprig functions can be found in the [Sprig Function Documentation](http://masterminds.github.io/sprig/)
 
 ---
 
@@ -1810,13 +1814,14 @@ This can also be used with a pipe function.
 ## Nomad Functions
 
 Nomad service registrations can be queried using the `nomadServices` and `nomadService` functions.
+Nomad secure variables can be queried using the `nomadVarList` and `nomadVar` functions.
 Typically these will be used from within a Nomad [template](https://www.nomadproject.io/docs/job-specification/template#nomad-services) configuration.
 
 ### `nomadServices`
 
 This can be used to query the names of services registered in Nomad.
 
-```nomadServices
+```golang
 {{ range nomadServices }}
   {{ .Name .Tags }}
 {{ end }}
@@ -1826,7 +1831,7 @@ This can be used to query the names of services registered in Nomad.
 
 This can be used to query for additional information about each instance of a service registered in Nomad.
 
-```nomadService
+```golang
 {{ range nomadService "my-app" }}
   {{ .Address }} {{ .Port }}
 {{ end}}
@@ -1838,11 +1843,151 @@ the number of instances desired, a unique but consistent identifier associated w
 
 Typically the unique identifier would be the allocation ID in a Nomad job.
 
-```nomadService
+```golang
 {{$allocID := env "NOMAD_ALLOC_ID" -}}
 {{range nomadService 3 $allocID "redis"}}
   {{.Address}} {{.Port}} | {{.Tags}} @ {{.Datacenter}}
 {{- end}}
+```
+
+## Nomad Secure Variables
+
+Consul-template can access Nomad secure variables and use their values as output
+to or to control template rendering flow.
+
+### `nomadVarList`
+
+This can be used to list the paths of Nomad secure variables available to the
+currently running template based on Nomad ACLs. You can provide an optional
+prefix to filter the path list by as a parameter. The value returned is a slice
+of NomadSVMeta objects, which print their `Path` value when used as a string.
+
+```golang
+{{ nomadVarList "<PREFIX>" }}
+```
+
+Example:
+
+```golang
+{{ range nomadVarList }}
+  {{ . }}
+{{ end }}
+```
+
+You can provide a prefix to filter the path list as an optional parameter to the
+`nomadVarList` function.
+
+```golang
+{{ range nomadVarList "path/to/filter"}}
+  {{ . }}
+{{ end }}
+```
+
+### `nomadVarListSafe`
+
+Same as [`nomadVarList`](#nomadvarlist), but refuses to render template if the
+secure variable list query returns blank/empty data.
+
+#### The `NomadSVMeta` Type
+
+```golang
+type NomadSVMeta struct {
+	Namespace, Path          string
+	CreateIndex, ModifyIndex uint64
+	CreateTime, ModifyTime   nanoTime
+}
+```
+
+The `nanoTime` type contains Unix nanoseconds since the epoch. It's String method
+prints it out as a formatted date/time value. It also has a `Time` method that
+can be used to retrieve a Go `time.Time` for further manipuation.
+
+### `nomadVar`
+
+Query [Nomad][nomad] for the Items at the given secure variable path. If the path
+does not exist or the caller does not have access to it, Consul Template will
+block rendering until the path is available. To avoid blocking, wrap `nomadVar`
+calls with [`nomadVarExists`](#nomadvarexists).
+
+The `nomadVar` function returns a map of NomadSVItems structs. Each member of the
+map corresponds to a member of the secure variable's `Items` collection. Each map
+value also contains helper methods to get the secure variable metadata and a
+link to the parent secure variable.
+
+```golang
+{{ nomadVar "<PATH>" }}
+```
+
+For example:
+
+Supposing a secure variable exists at the path `nomad/jobs/redis`, with a single
+key/value pair in its Items collection—`maxconns`:`15`
+
+```golang
+{{ with nomadVar "nomad/jobs/redis" }}{{ .maxconns }}{{ end }}
+```
+
+renders
+
+```text
+15
+```
+
+#### The `NomadSVItems` Type
+
+Calls to the `nomadVar` function return a value of type `NomadSVItems`. This
+value is a map of `string` to `NomadSVItem` elements. It provides some
+convenience methods:
+
+* `Keys`: produces a sorted list of keys to this `NomadSVItems` map.
+
+* `Values`: produces a key-sorted list.
+
+* `Tuples`: produces a key-sorted list of K,V tuple structs.
+
+* `Metadata`: returns this collection's parent metadata as a `NomadSVMeta`
+
+* `Parent`: returns the consul-template version (NomadSecureVariable) of a full
+    secure variable, which has the Metadata values and Items collection as peers.
+
+#### The `NomadSVItem` Type
+
+Specific item of a NomadSVItems collection that are directly accessed by name or
+the elements that are obtained while ranging the return of `nomadVar` are of type
+`NomadSVItem`.
+
+```golang
+type NomadSVItem struct {
+	Key, Value string
+}
+```
+
+`NomadSVItem` objects also provide helper methods:
+
+* `Metadata`: returns this item's parent's metadata as a `NomadSVMeta`
+
+* `Parent`: returns the consul-template version (NomadSecureVariable) of the
+    secure variable that contains this item.
+
+### `nomadVarExists`
+
+Query [Nomad][nomad] to see if a secure variable exists at the given path. If
+a variable exists, this will return true, false otherwise. Unlike
+[`nomadVar`](#nomadvar), this function will not block if the secure variable
+does not exist, which can be useful for controlling flow.
+
+```golang
+{{ nomadVarExists "<PATH>" }}
+```
+
+For example:
+
+```golang
+{{ if nomadVarExists "app/beta_active" }}
+  # ...
+{{ else }}
+  # ...
+{{ end }}
 ```
 
 ## Debugging Functions
@@ -1943,7 +2088,7 @@ map[foo:map[bar:true baz:string theAnswer:42]]
 
 outputs
 
-```
+```golang
 map[foo:map[bar:true baz:string theAnswer:42]]
 ```
 
@@ -1955,7 +2100,7 @@ map[foo:map[bar:true baz:string theAnswer:42]]
 
 outputs
 
-```
+```golang
 map[foo:map[bar:true baz:string theAnswer:42]]
 ```
 
@@ -1967,7 +2112,7 @@ map[foo:map[bar:true baz:string theAnswer:42]]
 
 outputs
 
-```
+```golang
 (map[string]interface {})map[foo:(map[string]interface {})map[bar:(bool)true baz:(string)string theAnswer:(float64)42]]
 ```
 
@@ -1981,7 +2126,7 @@ outputs
 
 outputs
 
-```
+```golang
 (map[string]interface {})map[foo:(map[string]interface {})map[theAnswer:(float64)42 bar:(bool)true baz:(string)string]]
 ```
 
@@ -1999,3 +2144,4 @@ If you would prefer to use format strings with a compacted inline printing style
 [consul]: https://www.consul.io "Consul by HashiCorp"
 [text-template]: https://golang.org/pkg/text/template/ "Go's text/template package"
 [vault]: https://www.vaultproject.io "Vault by HashiCorp"
+[nomad]: https://www.nomadproject.io "Nomad by HashiCorp"

--- a/template/nomad_funcs.go
+++ b/template/nomad_funcs.go
@@ -75,3 +75,109 @@ func nomadServiceFunc(b *Brain, used, missing *dep.Set) func(...interface{}) ([]
 		return nil, nil
 	}
 }
+
+// nomadSecureVariableItemsFunc returns a given secure variable rooted at the
+// items map.
+func nomadSecureVariableItemsFunc(b *Brain, used, missing *dep.Set) func(string) (dep.NomadSVItems, error) {
+	return func(s string) (dep.NomadSVItems, error) {
+		if len(s) == 0 {
+			return nil, nil
+		}
+
+		d, err := dep.NewSVGetQuery(s)
+		if err != nil {
+			return nil, err
+		}
+		d.EnableBlocking()
+
+		used.Add(d)
+
+		if value, ok := b.Recall(d); ok {
+			if value == nil {
+				return nil, nil
+			}
+			return value.(dep.NomadSVItems), nil
+		}
+
+		missing.Add(d)
+
+		return nil, nil
+	}
+}
+
+// nomadSecureVariableExistsFunc returns true if a secure variable exists, false
+// otherwise.
+func nomadSecureVariableExistsFunc(b *Brain, used, missing *dep.Set) func(string) (bool, error) {
+	return func(s string) (bool, error) {
+		if len(s) == 0 {
+			return false, nil
+		}
+
+		d, err := dep.NewSVGetQuery(s)
+		if err != nil {
+			return false, err
+		}
+
+		used.Add(d)
+
+		if value, ok := b.Recall(d); ok {
+			return value != nil, nil
+		}
+
+		missing.Add(d)
+
+		return false, nil
+	}
+}
+
+func nomadSafeSecureVariablesFunc(b *Brain, used, missing *dep.Set) func(string) ([]*dep.NomadSVMeta, error) {
+	// call nomadSecureVariablesFunc but explicitly mark that empty data set
+	// returned on monitored secure variable prefix is NOT safe
+	return nomadSecureVariablesFunc(b, used, missing, false)
+}
+
+// nomadSecureVariablesFunc returns or accumulates nomad secure variable prefix
+// list dependencies.
+func nomadSecureVariablesFunc(b *Brain, used, missing *dep.Set, emptyIsSafe bool) func(string) ([]*dep.NomadSVMeta, error) {
+	return func(s string) ([]*dep.NomadSVMeta, error) {
+		result := []*dep.NomadSVMeta{}
+
+		if len(s) == 0 {
+			return result, nil
+		}
+
+		d, err := dep.NewSVListQuery(s)
+		if err != nil {
+			return result, err
+		}
+
+		used.Add(d)
+
+		// Only return non-empty top-level keys
+		value, ok := b.Recall(d)
+		if ok {
+			result = append(result, value.([]*dep.NomadSVMeta)...)
+
+			if len(result) == 0 {
+				if emptyIsSafe {
+					// Operator used potentially unsafe nomadSecureVariables
+					// function in the template instead of the safe version.
+					return result, nil
+				}
+			} else {
+				// non empty result is good so we just return the data
+				return result, nil
+			}
+
+			// If we reach this part of the code result is completely empty as
+			// value returned no secure variables. Operator selected to use
+			// safeSecureVariables on the specific secure variable prefix so we
+			// will refuse to render template by marking d as missing
+		}
+
+		// b.Recall either returned an error or safeSecureVariables entered unsafe case
+		missing.Add(d)
+
+		return result, nil
+	}
+}

--- a/template/template.go
+++ b/template/template.go
@@ -298,8 +298,12 @@ func funcMap(i *funcMapInput) template.FuncMap {
 		"pkiCert":      pkiCertFunc(i.brain, i.used, i.missing, i.destination),
 
 		// Nomad Functions.
-		"nomadServices": nomadServicesFunc(i.brain, i.used, i.missing),
-		"nomadService":  nomadServiceFunc(i.brain, i.used, i.missing),
+		"nomadServices":    nomadServicesFunc(i.brain, i.used, i.missing),
+		"nomadService":     nomadServiceFunc(i.brain, i.used, i.missing),
+		"nomadVarList":     nomadSecureVariablesFunc(i.brain, i.used, i.missing, true),
+		"nomadVarListSafe": nomadSafeSecureVariablesFunc(i.brain, i.used, i.missing),
+		"nomadVar":         nomadSecureVariableItemsFunc(i.brain, i.used, i.missing),
+		"nomadVarExists":   nomadSecureVariableExistsFunc(i.brain, i.used, i.missing),
 
 		// Scratch
 		"scratch": func() *Scratch { return &scratch },

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -2090,6 +2090,38 @@ func TestTemplate_Execute(t *testing.T) {
 			"list list/foo list/foo/zip ",
 			false,
 		},
+		{
+			"func_nomadSecureVariables_no_arg",
+			&NewTemplateInput{
+				Contents: `{{ range nomadVarList }}{{ .Path }} {{ end }}`,
+			},
+			&ExecuteInput{
+				Brain: func() *Brain {
+					b := NewBrain()
+					d, err := dep.NewSVListQuery("")
+					if err != nil {
+						t.Fatal(err)
+					}
+					b.Remember(d, []*dep.NomadSVMeta{
+						{Path: "list"},
+						{Path: "list/foo"},
+						{Path: "list/foo/zip"},
+					})
+					return b
+				}(),
+			},
+			"list list/foo list/foo/zip ",
+			false,
+		},
+		{
+			"func_nomadSecureVariables_too_many_args",
+			&NewTemplateInput{
+				Contents: `{{ range nomadVarList "a" "b" }}{{ .Path }} {{ end }}`,
+			},
+			nil,
+			"",
+			true,
+		},
 	}
 
 	//	struct {
@@ -2101,7 +2133,7 @@ func TestTemplate_Execute(t *testing.T) {
 	//	}
 
 	for i, tc := range cases {
-		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%03d_%s", i, tc.name), func(t *testing.T) {
 			tpl, err := NewTemplate(tc.ti)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
This PR extends consul-template to support Nomad Secure Variables. It adds 4 additional functions:
- nomadVars
- nomadVarsSafe
- nomadVar
- nomadVarExists

There is a circular dependency issue with Nomad, so the tests won't pass until Nomad has released a version that contains secure variables. I'm not sure how exactly to manage this, but I need to get the PR up at least.