### PR TITLE
Support Nomad Variables

### DIFF
--- a/dependency/client_set.go
+++ b/dependency/client_set.go
@@ -385,7 +385,7 @@ func (c *ClientSet) CreateNomadClient(i *CreateNomadClientInput) error {
 		}
 	}
 
-	// This transport will attempt to keep connections open to the Vault server.
+	// This transport will attempt to keep connections open to the Nomad server.
 	var dialer TransportDialer
 	dialer = &net.Dialer{
 		Timeout:   i.TransportDialTimeout,

--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -12,15 +12,20 @@ import (
 )
 
 const (
-	dcRe          = `(@(?P<dc>[[:word:]\.\-\_]+))?`
-	keyRe         = `/?(?P<key>[^@]+)`
-	filterRe      = `(\|(?P<filter>[[:word:]\,]+))?`
-	serviceNameRe = `(?P<name>[[:word:]\-\_]+)`
-	nodeNameRe    = `(?P<name>[[:word:]\.\-\_]+)`
-	nearRe        = `(~(?P<near>[[:word:]\.\-\_]+))?`
-	prefixRe      = `/?(?P<prefix>[^@]+)`
-	tagRe         = `((?P<tag>[[:word:]=:\.\-\_]+)\.)?`
-	regionRe      = `(@(?P<region>[[:word:]\.\-\_]+))?`
+	dcRe           = `(@(?P<dc>[[:word:]\.\-\_]+))?`
+	keyRe          = `/?(?P<key>[^@]+)`
+	filterRe       = `(\|(?P<filter>[[:word:]\,]+))?`
+	serviceNameRe  = `(?P<name>[[:word:]\-\_]+)`
+	nodeNameRe     = `(?P<name>[[:word:]\.\-\_]+)`
+	nearRe         = `(~(?P<near>[[:word:]\.\-\_]+))?`
+	prefixRe       = `/?(?P<prefix>[^@]+)`
+	tagRe          = `((?P<tag>[[:word:]=:\.\-\_]+)\.)?`
+	regionRe       = `(@(?P<region>[[:word:]\.\-\_]+))?`
+	nvPathRe       = `/?(?P<path>[^@]+)`
+	nvNamespaceRe  = `(@(?P<namespace>[[:word:]\-\_]+))?`
+	nvListPrefixRe = `/?(?P<prefix>[^@]*)`
+	nvListNSRe     = `(@(?P<namespace>([[:word:]\-\_]+|\*)))?`
+	nvRegionRe     = `(\.(?P<region>[[:word:]\-\_]+))?`
 )
 
 type Type int

--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -413,3 +413,31 @@ func Fatalf(format string, args ...interface{}) {
 	fmt.Printf(format, args...)
 	runtime.Goexit()
 }
+
+func (v *nomadServer) CreateVariable(path string, data map[string]string, opts *nomadapi.WriteOptions) error {
+	nVar := nomadapi.NewVariable(path)
+	for k, v := range data {
+		nVar.Items[k] = v
+	}
+	_, _, err := testClients.Nomad().Variables().Update(nVar, opts)
+	if err != nil {
+		fmt.Println(err)
+	}
+	return err
+}
+func (v *nomadServer) CreateNamespace(name string, opts *nomadapi.WriteOptions) error {
+	ns := nomadapi.Namespace{Name: name}
+	_, err := testClients.Nomad().Namespaces().Register(&ns, opts)
+	if err != nil {
+		fmt.Println(err)
+	}
+	return err
+}
+
+func (v *nomadServer) DeleteVariable(path string, opts *nomadapi.WriteOptions) error {
+	_, err := testClients.Nomad().Variables().Delete(path, opts)
+	if err != nil {
+		fmt.Println(err)
+	}
+	return err
+}

--- a/dependency/nomad_var_get.go
+++ b/dependency/nomad_var_get.go
@@ -1,0 +1,133 @@
+package dependency
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	// Ensure implements
+	_ Dependency = (*NVGetQuery)(nil)
+
+	// NVGetQueryRe is the regular expression to use.
+	NVGetQueryRe = regexp.MustCompile(`\A` + nvPathRe + nvNamespaceRe + nvRegionRe + `\z`)
+)
+
+// NVGetQuery queries the KV store for a single key.
+type NVGetQuery struct {
+	stopCh chan struct{}
+
+	path      string
+	namespace string
+	region    string
+
+	blockOnNil bool
+}
+
+// NewNVGetQuery parses a string into a dependency.
+func NewNVGetQuery(ns, s string) (*NVGetQuery, error) {
+	s = strings.TrimSpace(s)
+	s = strings.Trim(s, "/")
+
+	if s != "" && !NVGetQueryRe.MatchString(s) {
+		return nil, fmt.Errorf("nomad.var.get: invalid format: %q", s)
+	}
+
+	m := regexpMatch(NVGetQueryRe, s)
+	out := &NVGetQuery{
+		stopCh:    make(chan struct{}, 1),
+		path:      m["path"],
+		namespace: m["namespace"],
+		region:    m["region"],
+	}
+	if out.namespace == "" && ns != "" {
+		out.namespace = ns
+	}
+	return out, nil
+}
+
+// Fetch queries the Nomad API defined by the given client.
+func (d *NVGetQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interface{}, *ResponseMetadata, error) {
+	select {
+	case <-d.stopCh:
+		return nil, nil, ErrStopped
+	default:
+	}
+
+	opts = opts.Merge(&QueryOptions{})
+
+	log.Printf("[TRACE] %s: GET %s", d, &url.URL{
+		Path:     "/v1/var/" + d.path,
+		RawQuery: opts.String(),
+	})
+
+	nOpts := opts.ToNomadOpts()
+	nOpts.Namespace = d.namespace
+	nOpts.Region = d.region
+	// NOTE: The Peek method of the Nomad Variables API will check a value,
+	// return it if it exists, but return a nil value and NO error if it is
+	// not found.
+	nVar, qm, err := clients.Nomad().Variables().Peek(d.path, nOpts)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, d.String())
+	}
+
+	rm := &ResponseMetadata{
+		LastIndex:   qm.LastIndex,
+		LastContact: qm.LastContact,
+		BlockOnNil:  d.blockOnNil,
+	}
+
+	if nVar == nil {
+		log.Printf("[TRACE] %s: returned nil", d)
+		return nil, rm, nil
+	}
+
+	items := &NewNomadVariable(nVar).Items
+	log.Printf("[TRACE] %s: returned %q", d, nVar.Path)
+	return items, rm, nil
+}
+
+// EnableBlocking turns this into a blocking KV query.
+func (d *NVGetQuery) EnableBlocking() {
+	d.blockOnNil = true
+}
+
+// CanShare returns a boolean if this dependency is shareable.
+func (d *NVGetQuery) CanShare() bool {
+	return true
+}
+
+// String returns the human-friendly version of this dependency.
+// This value is also used to disambiguate multiple instances in the Brain
+func (d *NVGetQuery) String() string {
+	ns := d.namespace
+	if ns == "" {
+		ns = "default"
+	}
+	region := d.region
+	if region == "" {
+		region = "global"
+	}
+	path := d.path
+	key := fmt.Sprintf("%s@%s.%s", path, ns, region)
+	if d.blockOnNil {
+		return fmt.Sprintf("nomad.var.block(%s)", key)
+	}
+	return fmt.Sprintf("nomad.var.get(%s)", key)
+}
+
+// Stop halts the dependency's fetch function.
+func (d *NVGetQuery) Stop() {
+	close(d.stopCh)
+}
+
+// Type returns the type of this dependency.
+func (d *NVGetQuery) Type() Type {
+	return TypeNomad
+}

--- a/dependency/nomad_var_get_test.go
+++ b/dependency/nomad_var_get_test.go
@@ -1,0 +1,320 @@
+package dependency
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	nomadapi "github.com/hashicorp/nomad/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewNVGetQuery(t *testing.T) {
+
+	cases := []struct {
+		name string
+		i    string
+		exp  *NVGetQuery
+		err  bool
+	}{
+		{
+			"empty",
+			"",
+			&NVGetQuery{},
+			false,
+		},
+
+		{
+			"dc_only",
+			"@dc1",
+			nil,
+			true,
+		},
+		{
+			"path",
+			"path",
+			&NVGetQuery{
+				path: "path",
+			},
+			false,
+		},
+		{
+			"dots",
+			"path.with.dots",
+			&NVGetQuery{
+				path: "path.with.dots",
+			},
+			false,
+		},
+		{
+			"slashes",
+			"path/with/slashes",
+			&NVGetQuery{
+				path: "path/with/slashes",
+			},
+			false,
+		},
+		{
+			"dashes",
+			"path-with-dashes",
+			&NVGetQuery{
+				path: "path-with-dashes",
+			},
+			false,
+		},
+		{
+			"leading_slash",
+			"/leading/slash",
+			&NVGetQuery{
+				path: "leading/slash",
+			},
+			false,
+		},
+		{
+			"trailing_slash",
+			"trailing/slash/",
+			&NVGetQuery{
+				path: "trailing/slash",
+			},
+			false,
+		},
+		{
+			"underscores",
+			"path_with_underscores",
+			&NVGetQuery{
+				path: "path_with_underscores",
+			},
+			false,
+		},
+		{
+			"special_characters",
+			"config/facet:größe-lf-si",
+			&NVGetQuery{
+				path: "config/facet:größe-lf-si",
+			},
+			false,
+		},
+		{
+			"splat",
+			"config/*/timeouts/",
+			&NVGetQuery{
+				path: "config/*/timeouts",
+			},
+			false,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			act, err := NewNVGetQuery("", tc.i)
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+
+			if act != nil {
+				act.stopCh = nil
+			}
+
+			assert.Equal(t, tc.exp, act)
+		})
+	}
+	fmt.Println("done")
+}
+
+func TestNVGetQuery_Fetch(t *testing.T) {
+
+	type nvmap map[string]string
+	_ = testNomad.CreateVariable("test-kv-get/path", nvmap{"bar": "barp"}, nil)
+	_ = testNomad.CreateNamespace("test", nil)
+	_ = testNomad.CreateVariable("test-ns-get/path", nvmap{"car": "carp"}, &nomadapi.WriteOptions{Namespace: "test"})
+	cases := []struct {
+		name string
+		i    string
+		exp  interface{}
+		err  bool
+	}{
+		{
+			"exists",
+			"test-kv-get/path",
+			&NewNomadVariable(&nomadapi.Variable{
+				Namespace: "default",
+				Path:      "test-kv-get/path",
+				Items: nomadapi.VariableItems{
+					"bar": "barp",
+				},
+			}).Items,
+			false,
+		},
+		{
+			"no_exist",
+			"test-kv-get/not/a/real/path/like/ever",
+			nil,
+			false,
+		},
+		{
+			"exists_ns",
+			"test-ns-get/path@test",
+			&NewNomadVariable(&nomadapi.Variable{
+				Namespace: "test",
+				Path:      "test-ns-get/path",
+				Items: nomadapi.VariableItems{
+					"car": "carp",
+				},
+			}).Items,
+			false,
+		},
+		{
+			"exists_badregion",
+			"test-ns-get/path@default.bad",
+			fmt.Errorf("nomad.var.get(test-ns-get/path@default.bad): Unexpected response code: 500 (No path to region)"),
+			true,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			d, err := NewNVGetQuery("", tc.i)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			act, _, err := d.Fetch(testClients, nil)
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+			if err != nil && tc.err {
+				require.Equal(t, tc.exp.(error).Error(), err.Error())
+				return
+			}
+			if tc.exp != nil {
+				testNomadSVEquivalent(t, tc.exp, act)
+			} else {
+				assert.Nil(t, act)
+			}
+		})
+	}
+
+	t.Run("stops", func(t *testing.T) {
+		d, err := NewNVGetQuery("", "test-kv-get/path")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		dataCh := make(chan interface{}, 1)
+		errCh := make(chan error, 1)
+		go func() {
+			for {
+				data, _, err := d.Fetch(testClients, nil)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				dataCh <- data
+			}
+		}()
+
+		select {
+		case err := <-errCh:
+			t.Fatal(err)
+		case <-dataCh:
+		}
+
+		d.Stop()
+
+		select {
+		case err := <-errCh:
+			if err != ErrStopped {
+				t.Fatal(err)
+			}
+		case <-time.After(200 * time.Millisecond):
+			t.Errorf("did not stop")
+		}
+	})
+
+	t.Run("fires_changes", func(t *testing.T) {
+		d, err := NewNVGetQuery("", "test-kv-get/path")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, qm, err := d.Fetch(testClients, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		dataCh := make(chan interface{}, 1)
+		errCh := make(chan error, 1)
+		go func() {
+			for {
+				data, _, err := d.Fetch(testClients, &QueryOptions{WaitIndex: qm.LastIndex})
+				if err != nil {
+					errCh <- err
+					return
+				}
+				dataCh <- data
+				return
+			}
+		}()
+
+		_ = testNomad.CreateVariable("test-kv-get/path", nvmap{"bar": "barp", "car": "carp"}, nil)
+
+		select {
+		case err := <-errCh:
+			t.Fatal(err)
+		case data := <-dataCh:
+			exp := &(NewNomadVariable(&nomadapi.Variable{
+				Namespace: "default",
+				Path:      "test-kv-get/path",
+				Items:     nomadapi.VariableItems{"bar": "barp", "car": "carp"},
+			}).Items)
+			testNomadSVEquivalent(t, exp, data)
+		}
+	})
+}
+
+func TestNVGetQuery_String(t *testing.T) {
+
+	cases := []struct {
+		name string
+		i    string
+		exp  string
+	}{
+		{
+			"path",
+			"path",
+			"nomad.var.get(path@default.global)",
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			d, err := NewNVGetQuery("", tc.i)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, tc.exp, d.String())
+		})
+	}
+}
+
+func testNomadSVEquivalent(t *testing.T, expIf, actIf interface{}) {
+	if expIf == nil && actIf == nil {
+		return
+	}
+	if expIf == nil || actIf == nil {
+		t.Fatalf("Mismatched nil and value.\na: %v\nb:%v", expIf, actIf)
+	}
+	exp, ok := expIf.(*NomadVarItems)
+	require.True(t, ok, "exp is not *NomadVarItems, got %T", expIf)
+	act, ok := actIf.(*NomadVarItems)
+	require.True(t, ok, "act is not *NomadVarItems, got %T", actIf)
+
+	expMeta := exp.Metadata()
+	actMeta := act.Metadata()
+	require.NotNil(t, expMeta, "Expected non-nil expMeta.Metadata()")
+	require.NotNil(t, actMeta, "Expected non-nil intMeta.Metadata()")
+	require.Equal(t, expMeta.Namespace, actMeta.Namespace)
+	require.Equal(t, expMeta.Path, actMeta.Path)
+	require.ElementsMatch(t, exp.Tuples(), act.Tuples())
+}

--- a/dependency/nomad_var_list.go
+++ b/dependency/nomad_var_list.go
@@ -1,0 +1,136 @@
+package dependency
+
+import (
+	"encoding/gob"
+	"fmt"
+	"log"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/pkg/errors"
+)
+
+var (
+	// Ensure implements
+	_ Dependency = (*NVListQuery)(nil)
+
+	// NVListQueryRe is the regular expression to use.
+	NVListQueryRe = regexp.MustCompile(`\A` + nvListPrefixRe + nvListNSRe + nvRegionRe + `\z`)
+)
+
+func init() {
+	gob.Register([]*NomadVarMeta{})
+}
+
+// NVListQuery queries the SV store for the metadata for keys matching the given
+// prefix.
+type NVListQuery struct {
+	stopCh    chan struct{}
+	namespace string
+	region    string
+	prefix    string
+}
+
+// NewNVListQuery parses a string into a dependency.
+func NewNVListQuery(ns, s string) (*NVListQuery, error) {
+	if s != "" && !NVListQueryRe.MatchString(s) {
+		return nil, fmt.Errorf("nomad.var.list: invalid format: %q", s)
+	}
+
+	m := regexpMatch(NVListQueryRe, s)
+	out := &NVListQuery{
+		stopCh:    make(chan struct{}, 1),
+		namespace: m["namespace"],
+		region:    m["region"],
+		prefix:    m["prefix"],
+	}
+
+	// Handle paths that are only slashes and discard them
+	if strings.Trim(out.prefix, "/") == "" {
+		out.prefix = ""
+	}
+
+	if out.namespace == "" && ns != "" {
+		out.namespace = ns
+	}
+
+	return out, nil
+}
+
+// Fetch queries the Nomad API defined by the given client.
+func (d *NVListQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interface{}, *ResponseMetadata, error) {
+	select {
+	case <-d.stopCh:
+		return nil, nil, ErrStopped
+	default:
+	}
+
+	opts = opts.Merge(&QueryOptions{})
+
+	log.Printf("[TRACE] %s: GET %s", d, &url.URL{
+		Path:     "/v1/vars/",
+		RawQuery: opts.String(),
+	})
+
+	nOpts := opts.ToNomadOpts()
+	nOpts.Namespace = d.namespace
+	nOpts.Region = d.region
+	list, qm, err := clients.Nomad().Variables().PrefixList(d.prefix, nOpts)
+	if err != nil && !strings.Contains(err.Error(), "Permission denied") {
+		return nil, nil, errors.Wrap(err, d.String())
+	}
+
+	log.Printf("[TRACE] %s: returned %d paths", d, len(list))
+
+	vars := make([]*NomadVarMeta, 0, len(list))
+	for _, nVar := range list {
+		vars = append(vars, NewNomadVarMeta(nVar))
+	}
+
+	// 404's don't return QueryMeta.
+	if qm == nil {
+		qm = &api.QueryMeta{
+			LastIndex: 1,
+		}
+	}
+
+	rm := &ResponseMetadata{
+		LastIndex:   qm.LastIndex,
+		LastContact: qm.LastContact,
+	}
+
+	return vars, rm, nil
+}
+
+// CanShare returns a boolean if this dependency is shareable.
+func (d *NVListQuery) CanShare() bool {
+	return true
+}
+
+// String returns the human-friendly version of this dependency.
+func (d *NVListQuery) String() string {
+	ns := d.namespace
+	if ns == "" {
+		ns = "default"
+	}
+	region := d.region
+	if region == "" {
+		region = "global"
+	}
+	prefix := d.prefix
+	key := fmt.Sprintf("%s@%s.%s", prefix, ns, region)
+
+	return fmt.Sprintf("nomad.var.list(%s)", key)
+}
+
+// Stop halts the dependency's fetch function.
+func (d *NVListQuery) Stop() {
+	close(d.stopCh)
+}
+
+// Type returns the type of this dependency.
+func (d *NVListQuery) Type() Type {
+	return TypeNomad
+}

--- a/dependency/nomad_var_list_test.go
+++ b/dependency/nomad_var_list_test.go
@@ -1,0 +1,371 @@
+package dependency
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	nomadapi "github.com/hashicorp/nomad/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewNVListQuery(t *testing.T) {
+
+	cases := []struct {
+		name string
+		i    string
+		exp  *NVListQuery
+		err  bool
+	}{
+		{
+			"empty",
+			"",
+			&NVListQuery{},
+			false,
+		},
+		{
+			"prefix",
+			"prefix",
+			&NVListQuery{
+				prefix: "prefix",
+			},
+			false,
+		},
+		{
+			"dots",
+			"prefix.with.dots",
+			&NVListQuery{
+				prefix: "prefix.with.dots",
+			},
+			false,
+		},
+		{
+			"slashes",
+			"prefix/with/slashes",
+			&NVListQuery{
+				prefix: "prefix/with/slashes",
+			},
+			false,
+		},
+		{
+			"dashes",
+			"prefix-with-dashes",
+			&NVListQuery{
+				prefix: "prefix-with-dashes",
+			},
+			false,
+		},
+		{
+			"leading_slash",
+			"/leading/slash",
+			&NVListQuery{
+				prefix: "leading/slash",
+			},
+			false,
+		},
+		{
+			"trailing_slash",
+			"trailing/slash/",
+			&NVListQuery{
+				prefix: "trailing/slash/",
+			},
+			false,
+		},
+		{
+			"underscores",
+			"prefix_with_underscores",
+			&NVListQuery{
+				prefix: "prefix_with_underscores",
+			},
+			false,
+		},
+		{
+			"special_characters",
+			"config/facet:größe-lf-si",
+			&NVListQuery{
+				prefix: "config/facet:größe-lf-si",
+			},
+			false,
+		},
+		{
+			"splat",
+			"config/*/timeouts/",
+			&NVListQuery{
+				prefix: "config/*/timeouts/",
+			},
+			false,
+		},
+		{
+			"slash",
+			"/",
+			&NVListQuery{
+				prefix: "",
+			},
+			false,
+		},
+		{
+			"slash-slash",
+			"//",
+			&NVListQuery{
+				prefix: "",
+			},
+			false,
+		},
+		{
+			"path-NS",
+			"a/b@test",
+			&NVListQuery{
+				prefix:    "a/b",
+				namespace: "test",
+			},
+			false,
+		},
+		{
+			"path-splatNS",
+			"a/b@*",
+			&NVListQuery{
+				prefix:    "a/b",
+				namespace: "*",
+			},
+			false,
+		},
+		{
+			"path-NS-region",
+			"a/b@test.dc2",
+			&NVListQuery{
+				prefix:    "a/b",
+				namespace: "test",
+				region:    "dc2",
+			},
+			false,
+		},
+		{
+			"path-splatNS-region",
+			"a/b@*.dc2",
+			&NVListQuery{
+				prefix:    "a/b",
+				namespace: "*",
+				region:    "dc2",
+			},
+			false,
+		},
+		{
+			"path-bad_splatNS-region",
+			"a/b@bad*.dc2",
+			nil,
+			true,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			act, err := NewNVListQuery("", tc.i)
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+
+			if act != nil {
+				act.stopCh = nil
+			}
+
+			assert.Equal(t, tc.exp, act)
+		})
+	}
+}
+
+func TestNVListQuery_Fetch(t *testing.T) {
+
+	type nvmap map[string]string
+	_ = testNomad.CreateVariable("test-kv-list/prefix/foo", nvmap{"bar": "barp"}, nil)
+	_ = testNomad.CreateVariable("test-kv-list/prefix/zip", nvmap{"zap": "zapp"}, nil)
+	_ = testNomad.CreateVariable("test-kv-list/prefix/wave/ocean", nvmap{"sleek": "sleekp"}, nil)
+
+	nsOpt := &nomadapi.WriteOptions{Namespace: "test"}
+	_ = testNomad.CreateVariable("test-kv-list/prefix/foo", nvmap{"bar": "barp"}, nsOpt)
+	_ = testNomad.CreateVariable("test-kv-list/prefix/zip", nvmap{"zap": "zapp"}, nsOpt)
+	_ = testNomad.CreateVariable("test-kv-list/prefix/wave/ocean", nvmap{"sleek": "sleekp"}, nsOpt)
+
+	cases := []struct {
+		name string
+		i    string
+		exp  []*NomadVarMeta
+	}{
+		{
+			"exists",
+			"test-kv-list/prefix",
+			[]*NomadVarMeta{
+				{Namespace: "default", Path: "test-kv-list/prefix/foo"},
+				{Namespace: "default", Path: "test-kv-list/prefix/wave/ocean"},
+				{Namespace: "default", Path: "test-kv-list/prefix/zip"},
+			},
+		},
+		{
+			"trailing",
+			"test-kv-list/prefix/",
+			[]*NomadVarMeta{
+				{Namespace: "default", Path: "test-kv-list/prefix/foo"},
+				{Namespace: "default", Path: "test-kv-list/prefix/wave/ocean"},
+				{Namespace: "default", Path: "test-kv-list/prefix/zip"},
+			},
+		},
+		{
+			"no_exist",
+			"test-kv-list/not/a/real/prefix/like/ever",
+			[]*NomadVarMeta{},
+		},
+		{
+			"exists_ns",
+			"test-kv-list/prefix@test",
+			[]*NomadVarMeta{
+				{Namespace: "test", Path: "test-kv-list/prefix/foo"},
+				{Namespace: "test", Path: "test-kv-list/prefix/wave/ocean"},
+				{Namespace: "test", Path: "test-kv-list/prefix/zip"},
+			},
+		},
+		{
+			"splat",
+			"test-kv-list/prefix@*",
+			[]*NomadVarMeta{
+				{Namespace: "default", Path: "test-kv-list/prefix/foo"},
+				{Namespace: "default", Path: "test-kv-list/prefix/wave/ocean"},
+				{Namespace: "default", Path: "test-kv-list/prefix/zip"},
+				{Namespace: "test", Path: "test-kv-list/prefix/foo"},
+				{Namespace: "test", Path: "test-kv-list/prefix/wave/ocean"},
+				{Namespace: "test", Path: "test-kv-list/prefix/zip"},
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			d, err := NewNVListQuery("", tc.i)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			act, _, err := d.Fetch(testClients, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for _, p := range act.([]*NomadVarMeta) {
+				p.CreateIndex = 0
+				p.CreateTime = 0
+				p.ModifyIndex = 0
+				p.ModifyTime = 0
+			}
+
+			assert.ElementsMatch(t, tc.exp, act)
+		})
+	}
+
+	t.Run("stops", func(t *testing.T) {
+		d, err := NewNVListQuery("", "test-kv-list/prefix")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		dataCh := make(chan interface{}, 1)
+		errCh := make(chan error, 1)
+		go func() {
+			for {
+				data, _, err := d.Fetch(testClients, nil)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				dataCh <- data
+			}
+		}()
+
+		select {
+		case err := <-errCh:
+			t.Fatal(err)
+		case <-dataCh:
+		}
+
+		d.Stop()
+
+		select {
+		case err := <-errCh:
+			if err != ErrStopped {
+				t.Fatal(err)
+			}
+		case <-time.After(250 * time.Millisecond):
+			t.Errorf("did not stop")
+		}
+	})
+
+	t.Run("fires_changes", func(t *testing.T) {
+		d, err := NewNVListQuery("", "test-kv-list/prefix/")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, qm, err := d.Fetch(testClients, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		dataCh := make(chan interface{}, 1)
+		errCh := make(chan error, 1)
+		go func() {
+			for {
+				data, _, err := d.Fetch(testClients, &QueryOptions{WaitIndex: qm.LastIndex})
+				if err != nil {
+					errCh <- err
+					return
+				}
+				dataCh <- data
+				return
+			}
+		}()
+
+		_ = testNomad.CreateVariable("test-kv-list/prefix/foo", nvmap{"new-bar": "new-barp"}, nil)
+
+		select {
+		case err := <-errCh:
+			t.Fatal(err)
+		case data := <-dataCh:
+			nVars := data.([]*NomadVarMeta)
+			if len(nVars) == 0 {
+				t.Fatal("bad length")
+			}
+
+			// Zero out the dynamic elements
+			act := nVars[0]
+			act.CreateIndex = 0
+			act.CreateTime = 0
+			act.ModifyIndex = 0
+			act.ModifyTime = 0
+
+			exp := &NomadVarMeta{Namespace: "default", Path: "test-kv-list/prefix/foo"}
+			assert.Equal(t, exp, act)
+		}
+	})
+}
+
+func TestNVListQuery_String(t *testing.T) {
+
+	cases := []struct {
+		name string
+		i    string
+		exp  string
+	}{
+		{
+			"prefix",
+			"prefix",
+			"nomad.var.list(prefix@default.global)",
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			d, err := NewNVListQuery("", tc.i)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, tc.exp, d.String())
+		})
+	}
+}

--- a/dependency/nomad_var_structs.go
+++ b/dependency/nomad_var_structs.go
@@ -1,0 +1,153 @@
+package dependency
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/hashicorp/nomad/api"
+)
+
+// NewNomadVarMeta is used to create a NomadVarMeta from a Nomad API
+// VariableMetadata response.
+func NewNomadVarMeta(in *api.VariableMetadata) *NomadVarMeta {
+	return &NomadVarMeta{
+		Namespace:   in.Namespace,
+		Path:        in.Path,
+		CreateIndex: in.CreateIndex,
+		ModifyIndex: in.ModifyIndex,
+		CreateTime:  nanoTime(in.CreateTime),
+		ModifyTime:  nanoTime(in.ModifyTime),
+	}
+}
+
+// NewNomadVariable is used to create a NomadVariable from a Nomad
+// API Variable response.
+func NewNomadVariable(in *api.Variable) *NomadVariable {
+	out := NomadVariable{
+		Namespace:   in.Namespace,
+		Path:        in.Path,
+		CreateIndex: in.CreateIndex,
+		ModifyIndex: in.ModifyIndex,
+		CreateTime:  nanoTime(in.CreateTime),
+		ModifyTime:  nanoTime(in.ModifyTime),
+		Items:       map[string]NomadVarItem{},
+		nVar:        in,
+	}
+
+	items := make(NomadVarItems, len(in.Items))
+	for k, v := range in.Items {
+		items[k] = NomadVarItem{k, v, &out}
+	}
+	out.Items = items
+	return &out
+}
+
+// NomadVariable is a template friendly container struct that allows for
+// the NomadVar funcs to start inside of Items and have a rational way back up
+// to the Variable that is JSON structurally equivalent to the API response.
+// This struct's zero value is not trivially usable and should be created with
+// NewNomadVariable--especially when outside of the dependency package as
+// there is no access to nVar.
+type NomadVariable struct {
+	Namespace, Path          string
+	CreateIndex, ModifyIndex uint64
+	CreateTime, ModifyTime   nanoTime
+	Items                    NomadVarItems
+	nVar                     *api.Variable
+}
+
+func (cv NomadVariable) Metadata() *NomadVarMeta {
+	return NewNomadVarMeta(cv.nVar.Metadata())
+}
+
+type NomadVarItems map[string]NomadVarItem
+
+// Keys returns a sorted list of the Item map's keys.
+func (v NomadVarItems) Keys() []string {
+	out := make([]string, 0, len(v))
+	for k := range v {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Values produces a key-sorted list of the Items map's values
+func (v NomadVarItems) Values() []string {
+	out := make([]string, 0, len(v))
+	for _, k := range v.Keys() {
+		out = append(out, v[k].String())
+	}
+	return out
+}
+
+// Tuples produces a key-sorted list of K,V tuple structs from the Items map's
+// values
+func (v NomadVarItems) Tuples() []struct{ K, V string } {
+	out := make([]struct{ K, V string }, 0, len(v))
+	for _, k := range v.Keys() {
+		out = append(out, struct{ K, V string }{K: k, V: v[k].String()})
+	}
+	return out
+}
+
+// Metadata returns this item's parent's metadata
+func (i NomadVarItems) Metadata() *NomadVarMeta {
+	for _, v := range i {
+		return v.parent.Metadata()
+	}
+	return nil
+}
+
+// Parent returns the item's container object
+func (i NomadVarItems) Parent() *NomadVariable {
+	for _, v := range i {
+		return v.Parent()
+	}
+	return nil
+}
+
+func (i NomadVarItems) ItemsMap() map[string]interface{} {
+	if len(i) == 0 {
+		return nil
+	}
+	out := make(map[string]interface{})
+	for k, v := range i {
+		out[k] = v.String()
+	}
+	return out
+}
+
+// NomadVarItem enriches the basic string values in a api.Variable's Items
+// map with additional helper funcs for formatting and access to its parent
+// item. This enables us to have the template funcs start at the Items
+// collection without the user having to delve to it themselves and to minimize
+// the number of template funcs that we have to provide for coverage.
+type NomadVarItem struct {
+	Key, Value string
+	parent     *NomadVariable
+}
+
+func (v NomadVarItem) String() string               { return v.Value }
+func (v NomadVarItem) Metadata() *NomadVarMeta      { return v.parent.Metadata() }
+func (v NomadVarItem) Parent() *NomadVariable       { return v.parent }
+func (v NomadVarItem) MarshalJSON() ([]byte, error) { return []byte(fmt.Sprintf("%q", v.Value)), nil }
+
+// NomadVarMeta provides the same fields as api.VariableMetadata
+// but aliases the times into a more template friendly alternative.
+type NomadVarMeta struct {
+	Namespace, Path          string
+	CreateIndex, ModifyIndex uint64
+	CreateTime, ModifyTime   nanoTime
+}
+
+func (s NomadVarMeta) String() string { return s.Path }
+
+// nanoTime is the typical storage encoding for times in Nomad's backend. They
+// are not pretty for consul-template consumption, so this gives us a type to
+// add receivers on.
+type nanoTime int64
+
+func (t nanoTime) String() string  { return fmt.Sprintf("%v", time.Unix(0, int64(t))) }
+func (t nanoTime) Time() time.Time { return time.Unix(0, int64(t)) }

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/logutils v1.0.0
-	github.com/hashicorp/nomad/api v0.0.0-20220707195938-75f4c2237b28
+	github.com/hashicorp/nomad/api v0.0.0-20221006174558-2aa7e66bdb52
 	github.com/hashicorp/serf v0.9.7 // indirect
 	github.com/hashicorp/vault/api v1.8.1
 	github.com/imdario/mergo v0.3.13

--- a/go.sum
+++ b/go.sum
@@ -41,7 +41,7 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/docker/go-units v0.3.3 h1:Xk8S3Xj5sLGlG5g67hJmYMmUgXv5N4PhkjJHHqrwnTk=
+github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -98,8 +98,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -180,8 +180,8 @@ github.com/hashicorp/mdns v1.0.4/go.mod h1:mtBihi+LeNXGtG8L9dX59gAEa12BDtBQSp4v/
 github.com/hashicorp/memberlist v0.3.0/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/hashicorp/memberlist v0.3.1 h1:MXgUXLqva1QvpVEDQW1IQLG0wivQAtmFlHRQ+1vWZfM=
 github.com/hashicorp/memberlist v0.3.1/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/hashicorp/nomad/api v0.0.0-20220707195938-75f4c2237b28 h1:fo8EbQ6tc9hYqxik9CAdFMqy48TW8hh2I3znysPqf+0=
-github.com/hashicorp/nomad/api v0.0.0-20220707195938-75f4c2237b28/go.mod h1:FslB+3eLbZgkuPWffqO1GeNzBFw1SuVqN2PXsMNe0Fg=
+github.com/hashicorp/nomad/api v0.0.0-20221006174558-2aa7e66bdb52 h1:O7oUpvlilRu3CWMiQtQF/pkF6ZUSWmjD0sn+T8oqewo=
+github.com/hashicorp/nomad/api v0.0.0-20221006174558-2aa7e66bdb52/go.mod h1:1dS8jZqAXhEreBcb26wpaV4Llk2cLO2sucuDKI+oTIs=
 github.com/hashicorp/serf v0.9.7 h1:hkdgbqizGQHuU5IPqYM1JdSMV8nKfpuOnZYXssk9muY=
 github.com/hashicorp/serf v0.9.7/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
 github.com/hashicorp/vault/api v1.8.0/go.mod h1:uJrw6D3y9Rv7hhmS17JQC50jbPDAZdjZoTtrCCxxs7E=
@@ -289,6 +289,7 @@ github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkB
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/shoenig/test v0.4.0 h1:3X4xG/Chx7mzi0h71Sm6Vo38q0EYaQIBZpYFRcA1HVM=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -391,7 +392,6 @@ golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190907020128-2ca718005c18/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/manager/dedup_test.go
+++ b/manager/dedup_test.go
@@ -21,6 +21,8 @@ func TestDedup_StartStop(t *testing.T) {
 }
 
 func TestDedup_IsLeader(t *testing.T) {
+	sessionCreateRetry = 100 * time.Millisecond
+
 	// Create a template
 	tmpl, err := template.NewTemplate(&template.NewTemplateInput{
 		Contents: `template-1 {{ range service "consul" }}{{ .Node }}{{ end }}`,

--- a/template/nomad_funcs.go
+++ b/template/nomad_funcs.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	dep "github.com/hashicorp/consul-template/dependency"
@@ -73,5 +74,115 @@ func nomadServiceFunc(b *Brain, used, missing *dep.Set) func(...interface{}) ([]
 		missing.Add(query)
 
 		return nil, nil
+	}
+}
+
+// nomadVariableItemsFunc returns a given variable rooted at the
+// items map.
+func nomadVariableItemsFunc(b *Brain, used, missing *dep.Set, defaultNS string) func(string) (*dep.NomadVarItems, error) {
+	return func(s string) (*dep.NomadVarItems, error) {
+		if len(s) == 0 {
+			return nil, nil
+		}
+
+		d, err := dep.NewNVGetQuery(defaultNS, s)
+		if err != nil {
+			return nil, err
+		}
+		d.EnableBlocking()
+
+		used.Add(d)
+
+		if value, ok := b.Recall(d); ok {
+			if value == nil {
+				return nil, nil
+			}
+			return value.(*dep.NomadVarItems), nil
+		}
+
+		missing.Add(d)
+
+		return nil, nil
+	}
+}
+
+// nomadVariableExistsFunc returns true if a variable exists, false otherwise.
+func nomadVariableExistsFunc(b *Brain, used, missing *dep.Set, defaultNS string) func(string) (bool, error) {
+	return func(s string) (bool, error) {
+		if len(s) == 0 {
+			return false, nil
+		}
+
+		d, err := dep.NewNVGetQuery(defaultNS, s)
+		if err != nil {
+			return false, err
+		}
+
+		used.Add(d)
+
+		if value, ok := b.Recall(d); ok {
+			return value != nil, nil
+		}
+
+		missing.Add(d)
+
+		return false, nil
+	}
+}
+
+func nomadSafeVariablesFunc(b *Brain, used, missing *dep.Set, defaultNS string) func(...string) ([]*dep.NomadVarMeta, error) {
+	// call nomadVariablesFunc but explicitly mark that empty data set
+	// returned on monitored variable prefix is NOT safe
+	return nomadVariablesFunc(b, used, missing, defaultNS, false)
+}
+
+// nomadVariablesFunc returns or accumulates nomad variable prefix list
+// dependencies.
+func nomadVariablesFunc(b *Brain, used, missing *dep.Set, defaultNS string, emptyIsSafe bool) func(...string) ([]*dep.NomadVarMeta, error) {
+	return func(args ...string) ([]*dep.NomadVarMeta, error) {
+		if len(args) > 1 {
+			return nil, fmt.Errorf("nomadVarList takes either a single \"prefix\" parameter or none for all available variables; got: %v", args)
+		}
+
+		result := []*dep.NomadVarMeta{}
+		s := ""
+
+		if len(args) == 1 {
+			s = args[0]
+		}
+
+		d, err := dep.NewNVListQuery(defaultNS, s)
+		if err != nil {
+			return result, err
+		}
+
+		used.Add(d)
+
+		// Only return non-empty top-level keys
+		value, ok := b.Recall(d)
+		if ok {
+			result = append(result, value.([]*dep.NomadVarMeta)...)
+
+			if len(result) == 0 {
+				if emptyIsSafe {
+					// Operator used potentially unsafe nomadVariables
+					// function in the template instead of the safe version.
+					return result, nil
+				}
+			} else {
+				// non empty result is good so we just return the data
+				return result, nil
+			}
+
+			// If we reach this part of the code result is completely empty as
+			// value returned no variables. Operator selected to use
+			// safeVariables on the specific variable prefix so we will refuse
+			// to render template by marking d as missing
+		}
+
+		// b.Recall either returned an error or safeVariables entered unsafe case
+		missing.Add(d)
+
+		return result, nil
 	}
 }

--- a/watch/vault_token_test.go
+++ b/watch/vault_token_test.go
@@ -92,7 +92,7 @@ func TestVaultTokenWatcher(t *testing.T) {
 		defer watcher.Stop()
 		// tests
 		select {
-		case <-time.After(time.Millisecond):
+		case <-time.After(50 * time.Millisecond):
 			// XXX remove this timer in hashicat port
 			doneCh <- struct{}{}
 		case err := <-watcher.ErrCh():


### PR DESCRIPTION
This PR extends consul-template to support NomadVariables. It adds 4 additional functions:

- nomadVars
- nomadVarsSafe
- nomadVar
- nomadVarExists

There is a circular dependency issue with Nomad, so the tests won't pass until Nomad has released a version that contains secure variables. I'm not sure how exactly to manage this, but I need to get the PR up at least.