### PR TITLE
use vault agent token when wrap_ttl is set

### DIFF
--- a/dependency/client_set.go
+++ b/dependency/client_set.go
@@ -3,12 +3,10 @@ package dependency
 import (
 	"context"
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -349,33 +347,8 @@ func (c *ClientSet) CreateVaultClient(i *CreateVaultClientInput) error {
 		}
 	}
 
-	token, _ := unwrapTTL(i.Token) // error expected, returned for testing
-
-	// Needs to be above Unwrap call below.
-	if token != "" {
-		client.SetToken(token)
-	}
-
-	// Check if we are unwrapping
-	if i.UnwrapToken {
-		secret, err := client.Logical().Unwrap(token)
-		if err != nil {
-			return fmt.Errorf("client set: vault unwrap: %s", err)
-		}
-
-		if secret == nil {
-			return fmt.Errorf("client set: vault unwrap: no secret")
-		}
-
-		if secret.Auth == nil {
-			return fmt.Errorf("client set: vault unwrap: no secret auth")
-		}
-
-		if secret.Auth.ClientToken == "" {
-			return fmt.Errorf("client set: vault unwrap: no token returned")
-		}
-
-		client.SetToken(secret.Auth.ClientToken)
+	if err := VaultSetToken(client, i.Token, i.UnwrapToken); err != nil {
+		return err
 	}
 
 	// Save the data on ourselves
@@ -387,20 +360,6 @@ func (c *ClientSet) CreateVaultClient(i *CreateVaultClientInput) error {
 	c.Unlock()
 
 	return nil
-}
-
-// If vault agent specifies wrap_ttl for the token it is returned as
-// a SecretWrapInfo struct marshalled into JSON instead of the normal raw
-// token. This checks for that and pulls out the token if it is the case.
-//
-// An error is expected most of the time (when it is a normal token) but
-// we return it to help testing/debugging.
-func unwrapTTL(token string) (string, error) {
-	var wrapinfo vaultapi.SecretWrapInfo
-	if err := json.Unmarshal([]byte(token), &wrapinfo); err != nil {
-		return strings.TrimSpace(token), err
-	}
-	return wrapinfo.Token, nil
 }
 
 // CreateNomadClient creates a new Nomad API client from the given input.

--- a/dependency/client_set.go
+++ b/dependency/client_set.go
@@ -348,7 +348,7 @@ func (c *ClientSet) CreateVaultClient(i *CreateVaultClientInput) error {
 	}
 
 	if err := VaultSetToken(client, i.Token, i.UnwrapToken); err != nil {
-		return err
+		return fmt.Errorf("client set: %w", err)
 	}
 
 	// Save the data on ourselves

--- a/dependency/client_set.go
+++ b/dependency/client_set.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -397,7 +398,7 @@ func (c *ClientSet) CreateVaultClient(i *CreateVaultClientInput) error {
 func unwrapTTL(token string) (string, error) {
 	var wrapinfo vaultapi.SecretWrapInfo
 	if err := json.Unmarshal([]byte(token), &wrapinfo); err != nil {
-		return token, err
+		return strings.TrimSpace(token), err
 	}
 	return wrapinfo.Token, nil
 }

--- a/dependency/client_set_test.go
+++ b/dependency/client_set_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/hashicorp/consul-template/test"
 	"github.com/hashicorp/vault/api"
-	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -43,27 +42,6 @@ func TestClientSet_unwrapVaultToken(t *testing.T) {
 
 	if _, err := vault.Auth().Token().LookupSelf(); err != nil {
 		t.Fatal(err)
-	}
-}
-
-// When vault-agent uses the wrap_ttl option it writes a json blob instead of
-// a raw token. This verifies it will extract the token from that when needed.
-func TestVaultAgentWrapTTL(t *testing.T) {
-	wrapinfo := vaultapi.SecretWrapInfo{
-		Token: "btoken",
-	}
-	b, _ := json.Marshal(wrapinfo)
-	testcases := []struct{ in, out string }{
-		{in: "", out: ""},
-		{in: "atoken", out: "atoken"},
-		{in: string(b), out: "btoken"},
-	}
-	for _, tc := range testcases {
-		token, err := unwrapTTL(tc.in)
-		if token != tc.out {
-			t.Errorf("unwrapTTL, wanted: '%v', got: '%v', err: '%v'",
-				tc.out, token, err)
-		}
 	}
 }
 

--- a/dependency/vault_agent_token.go
+++ b/dependency/vault_agent_token.go
@@ -59,7 +59,7 @@ func (d *VaultAgentTokenQuery) Fetch(clients *ClientSet, opts *QueryOptions) (in
 		d.stat = r.stat
 		err = VaultSetToken(clients.Vault(), string(token), d.unwrap)
 		if err != nil {
-			log.Printf("[INFO] token not unwrapped")
+			log.Printf("[INFO] token not unwrapped (%s)", err.Error())
 		}
 	}
 

--- a/dependency/vault_agent_token.go
+++ b/dependency/vault_agent_token.go
@@ -59,7 +59,7 @@ func (d *VaultAgentTokenQuery) Fetch(clients *ClientSet, opts *QueryOptions) (in
 		d.stat = r.stat
 		err = VaultSetToken(clients.Vault(), string(token), d.unwrap)
 		if err != nil {
-			log.Printf("[INFO] token not unwrapped (%s)", err.Error())
+			log.Printf("[INFO] unwrap skipped (%s)", err.Error())
 		}
 	}
 

--- a/dependency/vault_agent_token.go
+++ b/dependency/vault_agent_token.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -50,13 +49,14 @@ func (d *VaultAgentTokenQuery) Fetch(clients *ClientSet, opts *QueryOptions) (in
 
 		log.Printf("[TRACE] %s: reported change", d)
 
-		token, err := ioutil.ReadFile(d.path)
+		raw_token, err := ioutil.ReadFile(d.path)
 		if err != nil {
 			return "", nil, errors.Wrap(err, d.String())
 		}
+		token, _ := unwrapTTL(string(raw_token))
 
 		d.stat = r.stat
-		clients.Vault().SetToken(strings.TrimSpace(string(token)))
+		clients.Vault().SetToken(token)
 	}
 
 	return respWithMetadata("")

--- a/dependency/vault_agent_token.go
+++ b/dependency/vault_agent_token.go
@@ -57,8 +57,9 @@ func (d *VaultAgentTokenQuery) Fetch(clients *ClientSet, opts *QueryOptions) (in
 		}
 
 		d.stat = r.stat
-		if err := VaultSetToken(clients.Vault(), string(token), d.unwrap); err != nil {
-			return "", nil, errors.Wrap(err, d.String())
+		err = VaultSetToken(clients.Vault(), string(token), d.unwrap)
+		if err != nil {
+			log.Printf("[INFO] token not unwrapped")
 		}
 	}
 

--- a/dependency/vault_agent_token_test.go
+++ b/dependency/vault_agent_token_test.go
@@ -27,7 +27,7 @@ func TestVaultAgentTokenQuery_Fetch(t *testing.T) {
 	defer os.Remove(tokenFile.Name())
 	renderer.AtomicWrite(tokenFile.Name(), false, []byte("token"), 0o644, false)
 
-	d, err := NewVaultAgentTokenQuery(tokenFile.Name())
+	d, err := NewVaultAgentTokenQuery(tokenFile.Name(), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +53,7 @@ func TestVaultAgentTokenQuery_Fetch(t *testing.T) {
 
 func TestVaultAgentTokenQuery_Fetch_missingFile(t *testing.T) {
 	// Use a non-existant token file path.
-	d, err := NewVaultAgentTokenQuery("/tmp/invalid-file")
+	d, err := NewVaultAgentTokenQuery("/tmp/invalid-file", false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/dependency/vault_common.go
+++ b/dependency/vault_common.go
@@ -395,13 +395,13 @@ func VaultSetToken(client setTokener, token string, unwrap bool) error {
 		secret, err := client.Logical().Unwrap(token)
 		switch {
 		case err != nil:
-			return fmt.Errorf("client set: vault unwrap: %s", err)
+			return fmt.Errorf("vault token not wrapped")
 		case secret == nil:
-			return fmt.Errorf("client set: vault unwrap: no secret")
+			return fmt.Errorf("vault unwrap: no secret")
 		case secret.Auth == nil:
-			return fmt.Errorf("client set: vault unwrap: no secret auth")
+			return fmt.Errorf("vault unwrap: no secret auth")
 		case secret.Auth.ClientToken == "":
-			return fmt.Errorf("client set: vault unwrap: no token returned")
+			return fmt.Errorf("vault unwrap: no token returned")
 		}
 		client.SetToken(secret.Auth.ClientToken)
 	}

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -1388,6 +1388,7 @@ func newWatcher(c *config.Config, clients *dep.ClientSet, once bool) (*watch.Wat
 		BlockQueryWaitTime:  config.TimeDurationVal(c.BlockQueryWaitTime),
 		RenewVault:          clients.Vault().Token() != "" && config.BoolVal(c.Vault.RenewToken),
 		VaultAgentTokenFile: config.StringVal(c.Vault.VaultAgentTokenFile),
+		VaultTokenUnwrap:    config.BoolVal(c.Vault.UnwrapToken),
 		RetryFuncConsul:     watch.RetryFunc(c.Consul.Retry.RetryFunc()),
 		// TODO: Add a sane default retry - right now this only affects "local"
 		// dependencies like reading a file from disk.

--- a/watch/watcher.go
+++ b/watch/watcher.go
@@ -70,6 +70,9 @@ type NewWatcherInput struct {
 	// VaultAgentTokenFile is the path to Vault Agent token file
 	VaultAgentTokenFile string
 
+	// Does the Vault token need to be unwrapped?
+	VaultTokenUnwrap bool
+
 	// RetryFuncs specify the different ways to retry based on the upstream.
 	RetryFuncConsul  RetryFunc
 	RetryFuncDefault RetryFunc
@@ -105,7 +108,7 @@ func NewWatcher(i *NewWatcherInput) (*Watcher, error) {
 	}
 
 	if len(i.VaultAgentTokenFile) > 0 {
-		vag, err := dep.NewVaultAgentTokenQuery(i.VaultAgentTokenFile)
+		vag, err := dep.NewVaultAgentTokenQuery(i.VaultAgentTokenFile, i.VaultTokenUnwrap)
 		if err != nil {
 			return nil, errors.Wrap(err, "watcher")
 		}


### PR DESCRIPTION
If vault agent specifies wrap_ttl for the token it is returned as
a SecretWarpInfo struct marshalled into JSON instead of the normal raw
token. This checks for that and pulls out the token if it is the case.
Plus tests.

Fixes #1498