### PR TITLE
fix goroutine leak on fetch sleep

### DIFF
--- a/dependency/vault_read.go
+++ b/dependency/vault_read.go
@@ -61,7 +61,12 @@ func (d *VaultReadQuery) Fetch(clients *ClientSet, opts *QueryOptions,
 	}
 	select {
 	case dur := <-d.sleepCh:
-		time.Sleep(dur)
+		select {
+		case <-time.After(dur):
+			break
+		case <-d.stopCh:
+			return nil, nil, ErrStopped
+		}
 	default:
 	}
 


### PR DESCRIPTION
**Main problem:** Fetch goroutine in some cases ends with sleep and freezes all allocated objects in its runtime context, even if _cancelChannel_ was triggered.

This bug appears in vault agent and causes memory leak. It can not be fully cured with configuration, but setting specific configuration values can reduce its severity.

**Reproduction of the most severe case:** 
* Set big _DefaultLeaseTtl_ in vault config (default value of 768h is ok, this value need to be big enough)
* Vault agent config field _exit_after_auth_ must be **false**
* Set _TokenTtl_ in agent auth engine to small value (like 10s)
* For template section in agent config: some number of big non-leased secrets need to be used (like kv-v1 without _ttl_ key)

**Observed behavior:** Every time, when agent renews its token we will see growth of new allocated memory. This growth proportional to the size of the non-leased secrets and their quantity in vault agent template config section.