### PR TITLE
Log info on child return zero

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -116,13 +116,20 @@ func (cli *CLI) Run(args []string) int {
 	for {
 		select {
 		case err := <-runner.ErrCh:
-			// Check if the runner's error returned a specific exit status, and return
-			// that value. If no value was given, return a generic exit status.
+			// Check if the runner's error returned a specific exit status, and
+			// return that value.
+			// If no value was given, return a generic exit status.
 			code := ExitCodeRunnerError
 			if typed, ok := err.(manager.ErrExitable); ok {
 				code = typed.ExitStatus()
 			}
-			return logError(err, code)
+			switch code {
+			case 0:
+				log.Printf("[INFO] (cli) %s", err)
+				return ExitCodeOK
+			default:
+				return logError(err, code)
+			}
 		case <-runner.DoneCh:
 			return ExitCodeOK
 		case <-service_os.Shutdown_Channel():

--- a/manager/errors.go
+++ b/manager/errors.go
@@ -24,7 +24,7 @@ func NewErrChildDied(c int) *ErrChildDied {
 
 // Error implements the error interface.
 func (e *ErrChildDied) Error() string {
-	return fmt.Sprintf("child process died with exit code %d", e.code)
+	return fmt.Sprintf("child process exited with code %d", e.code)
 }
 
 // ExitStatus implements the ErrExitable interface.

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -244,7 +244,7 @@ func (r *Runner) Start() {
 			log.Printf("[INFO] (runner) waiting for child process to exit")
 			select {
 			case c := <-childExitCh:
-				log.Printf("[INFO] (runner) child process died")
+				log.Printf("[INFO] (runner) child process exited")
 				r.ErrCh <- NewErrChildDied(c)
 				return
 			case <-r.DoneCh:
@@ -348,7 +348,7 @@ func (r *Runner) Start() {
 					log.Printf("[INFO] (runner) waiting for child process to exit")
 					select {
 					case c := <-childExitCh:
-						log.Printf("[INFO] (runner) child process died")
+						log.Printf("[INFO] (runner) child process exited")
 						r.ErrCh <- NewErrChildDied(c)
 						return
 					case <-r.DoneCh:
@@ -410,7 +410,7 @@ func (r *Runner) Start() {
 			delete(r.quiescenceMap, tmpl.ID())
 
 		case c := <-childExitCh:
-			log.Printf("[INFO] (runner) child process died")
+			log.Printf("[INFO] (runner) child process exited")
 			r.ErrCh <- NewErrChildDied(c)
 			return
 


### PR DESCRIPTION
Consul-template exits with the code of the child process exit, but it still logs it as an error when it isn't. This changes it to log that at INFO level instead.

Fixes #1282