### PR TITLE
isChownNeeded bad when only user/group (!both) set

### DIFF
--- a/renderer/file_ownership.go
+++ b/renderer/file_ownership.go
@@ -37,6 +37,14 @@ func isChownNeeded(path string, uid, gid int) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+
+	switch {
+	case uid == -1:
+		currUid = -1
+	case gid == -1:
+		currGid = -1
+	}
+
 	return uid != currUid || gid != currGid, nil
 }
 


### PR DESCRIPTION
isChownNeeded returned the wrong result if either (exclusive) user or group were set but not the other. It uses a guard value but only compares both at the start and doesn't take this into account on the final comparison which compares both against the current values.

IE. it always returns true in these cases as the guard value is never going to be the same as an real file value.

Fixes #1651