### PR TITLE
add mustEnv function

### DIFF
--- a/docs/templating-language.md
+++ b/docs/templating-language.md
@@ -47,6 +47,7 @@ provides the following functions:
   - [containsNone](#containsnone)
   - [containsNotAll](#containsnotall)
   - [env](#env)
+  - [mustEnv](#mustEnv)
   - [envOrDefault](#envOrDefault)
   - [executeTemplate](#executetemplate)
   - [explode](#explode)
@@ -60,7 +61,7 @@ provides the following functions:
   - [trimSpace](#trimspace)
   - [trim](#trim)
   - [trimPrefix](#trimprefix)
-  - [trimSuffix](#trimsuffix)  
+  - [trimSuffix](#trimsuffix)
   - [parseBool](#parsebool)
   - [parseFloat](#parsefloat)
   - [parseInt](#parseint)
@@ -1138,6 +1139,14 @@ Reads the given environment variable and if it does not exist or is blank use a 
 
 ```golang
 {{ or (env "CLUSTER_ID") "12345" }}
+```
+
+### `mustEnv`
+
+Reads the given environment variable accessible to the current process. If the variable is not defined or is empty the substitution will fail with error.
+
+```golang
+{{ mustEnv "CLUSTER_ID" }}
 ```
 
 ### `envOrDefault`

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -84,6 +84,31 @@ func envFunc(env []string) func(string) (string, error) {
 	}
 }
 
+// mustEnvFunc returns a function which checks the value of an environment variable
+// and returns an error if environment variable value is empty.
+// Invokers can specify their own environment, which takes precedences over any
+// real environment variables.
+func mustEnvFunc(env []string) func(string) (string, error) {
+	return func(s string) (string, error) {
+		val := ""
+		for _, e := range env {
+			split := strings.SplitN(e, "=", 2)
+			k, v := split[0], split[1]
+			if k == s {
+				val = v
+				break
+			}
+		}
+		if val == "" {
+			val = os.Getenv(s)
+		}
+		if val == "" {
+			return "", fmt.Errorf("required environment variable %s is empty", s)
+		}
+		return val, nil
+	}
+}
+
 // envWithDefaultFunc returns a function which checks the value of an environment variable.
 // Invokers can specify their own environment, which takes precedences over any
 // real environment variables.

--- a/template/template.go
+++ b/template/template.go
@@ -317,6 +317,7 @@ func funcMap(i *funcMapInput) template.FuncMap {
 		"containsNone":          containsSomeFunc(true, false),
 		"containsNotAll":        containsSomeFunc(false, true),
 		"env":                   envFunc(i.env),
+		"mustEnv":               mustEnvFunc(i.env),
 		"envOrDefault":          envWithDefaultFunc(i.env),
 		"executeTemplate":       executeTemplateFunc(i.newTmpl),
 		"explode":               explode,

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1184,6 +1184,34 @@ func TestTemplate_Execute(t *testing.T) {
 			false,
 		},
 		{
+			"helper_mustEnv",
+			&NewTemplateInput{
+				Contents: `{{ mustEnv "CT_TEST" }}`,
+			},
+			&ExecuteInput{
+				Brain: func() *Brain {
+					// Cheat and use the brain callback here to set the env.
+					if err := os.Setenv("CT_TEST", "1"); err != nil {
+						t.Fatal(err)
+					}
+					return NewBrain()
+				}(),
+			},
+			"1",
+			false,
+		},
+		{
+			"helper_mustEnv_negative",
+			&NewTemplateInput{
+				Contents: `{{ mustEnv "CT_TEST_NONEXISTENT" }}`,
+			},
+			&ExecuteInput{
+				Brain:  NewBrain(),
+			},
+			"",
+			true,
+		},
+		{
 			"helper_env__override",
 			&NewTemplateInput{
 				Contents: `{{ env "CT_TEST" }}`,


### PR DESCRIPTION
## Background
It is important to fail early and not try to deploy a config with wrong data. But when populating values using `env` function a typo in variable name will lead to an empty value instead of an error, like when trying to access nonexistent vault key with `error_on_missing_key` enabled.

This PR addresses it with adding extra `mustEnv` command that fails if environment variable does not exist or is empty.

```
$ cat env.tmpl
URL={{mustEnv "ENV"}}:12312

$ ENV=test ~/go/bin/consul-template -once -template=env.tmpl -dry
>
URL=test:12312

$ ~/go/bin/consul-template -once -template=env.tmpl -dry
2022-10-20T18:21:52.794+0700 [ERR] (cli) env.tmpl: execute: template: :1:6: executing "" at <mustEnv "ENV">: error calling mustEnv: required environment variable ENV is empty
```