### PR TITLE
Fix incorrect quoting in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOTAGS ?=
 # Get the project metadata
 OWNER := "hashicorp"
 NAME := "consul-template"
-PROJECT := $(shell go list -m | awk '/${NAME}/ {print $0}' )
+PROJECT := $(shell go list -m | awk "/${NAME}/ {print $0}" )
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD || echo release)
 VERSION := $(shell awk -F\" '/^[ \t]+Version/ { print $$2; exit }' "${CURRENT_DIR}/version/version.go")
 PRERELEASE := $(shell awk -F\" '/^[ \t]+VersionPrerelease/ { print $$2; exit }' "${CURRENT_DIR}/version/version.go")


### PR DESCRIPTION
When updating the Makefile for Go Workspaces, I accidentally single quoted where I needed double quotes causing the version hash to not print in the version output properly.