### PR TITLE
fix: user set in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,6 @@ COPY ./dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/
 COPY ./.release/docker-entrypoint.sh /bin/
 ENTRYPOINT ["/bin/docker-entrypoint.sh"]
 
-USER ${NAME}:${NAME}
+USER ${BIN_NAME}:${BIN_NAME}
 CMD /bin/$BIN_NAME
 


### PR DESCRIPTION
my organization is currently auditing whether any docker images we run are currently using the root user. From dockerhub it looks like this line expands out to `USER :` since the env var names don't match. (see https://hub.docker.com/layers/hashicorp/consul-template/0.29/images/sha256-32f8ffb8db51809d93488527d63f97d267e2a10c0cbe96dfa5cbc408266211ab?context=explore) This would fix this so that your images are run as the user you create earlier in the dockerfile.