### PR TITLE
use internal signal implementation for force kill

### DIFF
--- a/child/child.go
+++ b/child/child.go
@@ -352,7 +352,7 @@ func (c *Child) start() error {
 			c.stopLock.Lock()
 			defer c.stopLock.Unlock()
 			if c.cmd != nil && c.cmd.Process != nil {
-				c.cmd.Process.Kill()
+				c.signal(os.Kill)
 			}
 
 			return fmt.Errorf(
@@ -433,7 +433,7 @@ func (c *Child) kill(immediately bool) {
 	var exited bool
 	defer func() {
 		if !exited {
-			c.cmd.Process.Kill()
+			c.signal(os.Kill)
 		}
 		c.cmd = nil
 	}()


### PR DESCRIPTION
Force killing was using the builtin Process.Kill() command that signals the process with os.Kill but doesn't take into account if Setpgid has been set so doesn't kill any subprocesses (if the command was run as a shell string that uses Setpgid to be sure signals propogate to any spawned sub-processes).

This changes it to use the internal signal method which checks Setpgid and uses the process group id to kill all processes in the group.

--

Note that I wasn't able to come up with a good test that runs a subshell in a subshell. If anyone has a good idea for testing this please let me know.

Fixes #1666