### PR TITLE
Update deprecated ioutil calls

### DIFF
--- a/child/child_test.go
+++ b/child/child_test.go
@@ -2,7 +2,7 @@ package child
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"reflect"
@@ -22,14 +22,14 @@ import (
 const fileWaitSleepDelay = 50 * time.Millisecond
 
 func TestMain(m *testing.M) {
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 	os.Exit(m.Run())
 }
 
 func testChild(t *testing.T) *Child {
 	c, err := New(&NewInput{
-		Stdout:       ioutil.Discard,
-		Stderr:       ioutil.Discard,
+		Stdout:       io.Discard,
+		Stderr:       io.Discard,
 		Command:      "echo",
 		Args:         []string{"hello", "world"},
 		ReloadSignal: os.Interrupt,

--- a/cli.go
+++ b/cli.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/signal"
@@ -213,7 +212,7 @@ func (cli *CLI) ParseFlags(args []string) (
 
 	// Parse the flags and options
 	flags := flag.NewFlagSet(version.Name, flag.ContinueOnError)
-	flags.SetOutput(ioutil.Discard)
+	flags.SetOutput(io.Discard)
 	flags.Usage = func() {}
 
 	flags.Var((funcVar)(func(s string) error {

--- a/cli_test.go
+++ b/cli_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -17,7 +16,7 @@ import (
 )
 
 func TestCLI_ParseFlags(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -850,7 +849,7 @@ func TestCLI_Run(t *testing.T) {
 	}
 
 	t.Run("once", func(t *testing.T) {
-		f, err := ioutil.TempFile("", "")
+		f, err := os.CreateTemp("", "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -859,7 +858,7 @@ func TestCLI_Run(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		dest, err := ioutil.TempFile("", "")
+		dest, err := os.CreateTemp("", "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -887,7 +886,7 @@ func TestCLI_Run(t *testing.T) {
 			if status != ExitCodeOK {
 				t.Errorf("\nexp: %#v\nact: %#v", ExitCodeOK, status)
 			}
-			b, err := ioutil.ReadFile(dest.Name())
+			b, err := os.ReadFile(dest.Name())
 			if err != nil {
 				t.Errorf("\nerror reading file: %s\nout: %s", err, out.String())
 			}
@@ -901,7 +900,7 @@ func TestCLI_Run(t *testing.T) {
 	})
 
 	t.Run("reload", func(t *testing.T) {
-		f, err := ioutil.TempFile("", "")
+		f, err := os.CreateTemp("", "")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -369,7 +368,7 @@ func TestConfig(c *Config) *Config {
 // FromFile reads the configuration file at the given path and returns a new
 // Config struct with the data populated.
 func FromFile(path string) (*Config, error) {
-	c, err := ioutil.ReadFile(path)
+	c, err := os.ReadFile(path)
 	if err != nil {
 		return nil, errors.Wrap(err, "from file: "+path)
 	}
@@ -398,7 +397,7 @@ func FromPath(path string) (*Config, error) {
 	// Recursively parse directories, single load files
 	if stat.Mode().IsDir() {
 		// Ensure the given filepath has at least one config file
-		_, err := ioutil.ReadDir(path)
+		_, err := os.ReadDir(path)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed listing dir: "+path)
 		}
@@ -638,7 +637,7 @@ func stringFromEnv(list []string, def string) *string {
 
 func stringFromFile(list []string, def string) *string {
 	for _, s := range list {
-		c, err := ioutil.ReadFile(s)
+		c, err := os.ReadFile(s)
 		if err == nil {
 			return String(strings.TrimSpace(string(c)))
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strconv"
@@ -19,13 +18,13 @@ func TestMain(m *testing.M) {
 	os.Unsetenv("VAULT_ADDR")
 	os.Unsetenv("VAULT_TOKEN")
 	os.Unsetenv("VAULT_DEV_ROOT_TOKEN_ID")
-	homePath, _ = ioutil.TempDir("", "")
+	homePath, _ = os.MkdirTemp("", "")
 
 	os.Exit(m.Run())
 }
 
 func testFile(t *testing.T, contents string) (path string, remove func()) {
-	testFile, err := ioutil.TempFile("", "test.")
+	testFile, err := os.CreateTemp("", "test.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2331,24 +2330,24 @@ func TestConfig_Merge(t *testing.T) {
 }
 
 func TestFromPath(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.Remove(f.Name())
 
-	emptyDir, err := ioutil.TempDir(os.TempDir(), "")
+	emptyDir, err := os.MkdirTemp(os.TempDir(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(emptyDir)
 
-	configDir, err := ioutil.TempDir(os.TempDir(), "")
+	configDir, err := os.MkdirTemp(os.TempDir(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(configDir)
-	cf1, err := ioutil.TempFile(configDir, "")
+	cf1, err := os.CreateTemp(configDir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2357,10 +2356,10 @@ func TestFromPath(t *testing.T) {
 			address = "1.2.3.4"
 		}
 	`)
-	if err = ioutil.WriteFile(cf1.Name(), d, 0o644); err != nil {
+	if err = os.WriteFile(cf1.Name(), d, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	cf2, err := ioutil.TempFile(configDir, "")
+	cf2, err := os.CreateTemp(configDir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2369,7 +2368,7 @@ func TestFromPath(t *testing.T) {
 			token = "token"
 		}
 	`)
-	if err := ioutil.WriteFile(cf2.Name(), d, 0o644); err != nil {
+	if err := os.WriteFile(cf2.Name(), d, 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -3,7 +3,7 @@ package dependency
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -32,7 +32,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 	nomadFuture := runTestNomad()
 	runTestVault()
 	tb := &test.TestingTB{}
@@ -159,8 +159,8 @@ func runTestConsul(tb testutil.TestingTB) {
 	consul, err := testutil.NewTestServerConfigT(tb,
 		func(c *testutil.TestServerConfig) {
 			c.LogLevel = "warn"
-			c.Stdout = ioutil.Discard
-			c.Stderr = ioutil.Discard
+			c.Stdout = io.Discard
+			c.Stderr = io.Discard
 		})
 	if err != nil {
 		Fatalf("failed to start consul server: %v", err)
@@ -184,8 +184,8 @@ func runTestNomad() <-chan error {
 		"-network-speed=100",
 		"-log-level=error", // We're just discarding it anyway
 	)
-	cmd.Stdout = ioutil.Discard
-	cmd.Stderr = ioutil.Discard
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
 
 	if err := cmd.Start(); err != nil {
 		Fatalf("nomad failed to start: %v", err)
@@ -328,8 +328,8 @@ func runTestVault() {
 		"-dev-no-store-token",
 	}
 	cmd := exec.Command("vault", args...)
-	cmd.Stdout = ioutil.Discard
-	cmd.Stderr = ioutil.Discard
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
 
 	if err := cmd.Start(); err != nil {
 		Fatalf("vault failed to start: %v", err)

--- a/dependency/file.go
+++ b/dependency/file.go
@@ -2,7 +2,6 @@ package dependency
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -57,7 +56,7 @@ func (d *FileQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interface{}, 
 
 		log.Printf("[TRACE] %s: reported change", d)
 
-		data, err := ioutil.ReadFile(d.path)
+		data, err := os.ReadFile(d.path)
 		if err != nil {
 			return "", nil, errors.Wrap(err, d.String())
 		}

--- a/dependency/file_test.go
+++ b/dependency/file_test.go
@@ -2,7 +2,6 @@ package dependency
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -54,7 +53,7 @@ func TestNewFileQuery(t *testing.T) {
 }
 
 func TestFileQuery_Fetch(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,7 +99,7 @@ func TestFileQuery_Fetch(t *testing.T) {
 	}
 
 	t.Run("stops", func(t *testing.T) {
-		f, err := ioutil.TempFile("", "")
+		f, err := os.CreateTemp("", "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -145,7 +144,7 @@ func TestFileQuery_Fetch(t *testing.T) {
 		return err
 	}
 	t.Run("fires_changes", func(t *testing.T) {
-		f, err := ioutil.TempFile("", "")
+		f, err := os.CreateTemp("", "")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/dependency/vault_agent_token_test.go
+++ b/dependency/vault_agent_token_test.go
@@ -1,7 +1,6 @@
 package dependency
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -15,7 +14,7 @@ func TestVaultAgentTokenQuery_Fetch(t *testing.T) {
 	// other tests if run in parallel
 
 	// Set up the Vault token file.
-	tokenFile, err := ioutil.TempFile("", "token1")
+	tokenFile, err := os.CreateTemp("", "token1")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/logging/logfile_test.go
+++ b/logging/logfile_test.go
@@ -1,7 +1,7 @@
 package logging
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -14,12 +14,12 @@ import (
 )
 
 func TestLogFileFilter(t *testing.T) {
-	filt, err := newLogFilter(ioutil.Discard, logutils.LogLevel("INFO"))
+	filt, err := newLogFilter(io.Discard, logutils.LogLevel("INFO"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	tempDir, err := ioutil.TempDir("", "")
+	tempDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,7 +59,7 @@ func TestLogFileFilter(t *testing.T) {
 }
 
 func TestLogFileNoFilter(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "")
+	tempDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,7 +102,7 @@ func TestLogFile_Rotation_MaxDuration(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	tempDir, err := ioutil.TempDir("", "")
+	tempDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +120,7 @@ func TestLogFile_Rotation_MaxDuration(t *testing.T) {
 }
 
 func TestLogFile_openNew(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "")
+	tempDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,13 +137,13 @@ func TestLogFile_openNew(t *testing.T) {
 	_, err = logFile.Write([]byte(msg))
 	require.NoError(t, err)
 
-	content, err := ioutil.ReadFile(logFile.FileInfo.Name())
+	content, err := os.ReadFile(logFile.FileInfo.Name())
 	require.NoError(t, err)
 	require.Contains(t, string(content), msg)
 }
 
 func TestLogFile_Rotation_MaxBytes(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "")
+	tempDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +160,7 @@ func TestLogFile_Rotation_MaxBytes(t *testing.T) {
 }
 
 func TestLogFile_PruneFiles(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "")
+	tempDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -180,17 +180,17 @@ func TestLogFile_PruneFiles(t *testing.T) {
 	sort.Strings(logFiles)
 	require.Len(t, logFiles, 2)
 
-	content, err := ioutil.ReadFile(filepath.Join(tempDir, logFiles[0]))
+	content, err := os.ReadFile(filepath.Join(tempDir, logFiles[0]))
 	require.NoError(t, err)
 	require.Contains(t, string(content), "Second File")
 
-	content, err = ioutil.ReadFile(filepath.Join(tempDir, logFiles[1]))
+	content, err = os.ReadFile(filepath.Join(tempDir, logFiles[1]))
 	require.NoError(t, err)
 	require.Contains(t, string(content), "Third File")
 }
 
 func TestLogFile_PruneFiles_Disabled(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "")
+	tempDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,7 +209,7 @@ func TestLogFile_PruneFiles_Disabled(t *testing.T) {
 }
 
 func TestLogFile_FileRotation_Disabled(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "")
+	tempDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -3,7 +3,6 @@ package logging
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"path/filepath"
 	"strings"
@@ -138,7 +137,7 @@ func newWriter(config *Config) (io.Writer, error) {
 // we use.
 func newLogFilter(out io.Writer, logLevel logutils.LogLevel) (*logutils.LevelFilter, error) {
 	if out == nil {
-		out = ioutil.Discard
+		out = io.Discard
 	}
 
 	logFilter := &logutils.LevelFilter{

--- a/logging/syslog_test.go
+++ b/logging/syslog_test.go
@@ -1,7 +1,7 @@
 package logging
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"runtime"
 	"testing"
@@ -27,7 +27,7 @@ func TestSyslogFilter(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	filt, err := newLogFilter(ioutil.Discard, logutils.LogLevel("INFO"))
+	filt, err := newLogFilter(io.Discard, logutils.LogLevel("INFO"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"testing"
@@ -22,14 +22,14 @@ func TestMain(m *testing.M) {
 	consul, err := testutil.NewTestServerConfigT(tb,
 		func(c *testutil.TestServerConfig) {
 			c.LogLevel = "warn"
-			c.Stdout = ioutil.Discard
-			c.Stderr = ioutil.Discard
+			c.Stdout = io.Discard
+			c.Stderr = io.Discard
 		})
 	if err != nil {
 		log.Fatal(fmt.Errorf("failed to start consul server: %v", err))
 	}
 	testConsul = consul
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 
 	clients := dep.NewClientSet()
 	if err := clients.CreateConsulClient(&dep.CreateConsulClientInput{

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -2,7 +2,7 @@ package manager
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"testing"
@@ -20,13 +20,13 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 	tb := &test.TestingTB{}
 	consul, err := testutil.NewTestServerConfigT(tb,
 		func(c *testutil.TestServerConfig) {
 			c.LogLevel = "warn"
-			c.Stdout = ioutil.Discard
-			c.Stderr = ioutil.Discard
+			c.Stdout = io.Discard
+			c.Stderr = io.Discard
 		})
 	if err != nil {
 		log.Fatal(fmt.Errorf("failed to start consul server: %v", err))

--- a/manager/runner_test.go
+++ b/manager/runner_test.go
@@ -3,7 +3,6 @@ package manager
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -388,7 +387,7 @@ func TestRunner_Run(t *testing.T) {
 			"no_command_if_same_template",
 			func(t *testing.T, r *Runner) {
 				r.dry = false
-				if err := ioutil.WriteFile("/tmp/ct-no_command_if_same_template", []byte("hello"), 0o644); err != nil {
+				if err := os.WriteFile("/tmp/ct-no_command_if_same_template", []byte("hello"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -500,13 +499,13 @@ func TestRunner_Run(t *testing.T) {
 
 func TestRunner_Start(t *testing.T) {
 	t.Run("store_pid", func(t *testing.T) {
-		pid, err := ioutil.TempFile("", "")
+		pid, err := os.CreateTemp("", "")
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer os.Remove(pid.Name())
 
-		out, err := ioutil.TempFile("", "")
+		out, err := os.CreateTemp("", "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -535,7 +534,7 @@ func TestRunner_Start(t *testing.T) {
 		case err := <-r.ErrCh:
 			t.Fatal(err)
 		case <-r.renderedCh:
-			c, err := ioutil.ReadFile(pid.Name())
+			c, err := os.ReadFile(pid.Name())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -548,7 +547,7 @@ func TestRunner_Start(t *testing.T) {
 	})
 
 	t.Run("run_no_deps", func(t *testing.T) {
-		out, err := ioutil.TempFile("", "")
+		out, err := os.CreateTemp("", "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -576,7 +575,7 @@ func TestRunner_Start(t *testing.T) {
 		case err := <-r.ErrCh:
 			t.Fatal(err)
 		case <-r.renderedCh:
-			act, err := ioutil.ReadFile(out.Name())
+			act, err := os.ReadFile(out.Name())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -592,7 +591,7 @@ func TestRunner_Start(t *testing.T) {
 	t.Run("single_dependency", func(t *testing.T) {
 		testConsul.SetKVString(t, "single-dep-foo", "bar")
 
-		out, err := ioutil.TempFile("", "")
+		out, err := os.CreateTemp("", "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -623,7 +622,7 @@ func TestRunner_Start(t *testing.T) {
 		case err := <-r.ErrCh:
 			t.Fatal(err)
 		case <-r.renderedCh:
-			act, err := ioutil.ReadFile(out.Name())
+			act, err := os.ReadFile(out.Name())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -640,7 +639,7 @@ func TestRunner_Start(t *testing.T) {
 		testConsul.SetKVString(t, "multipass-foo", "multipass-bar")
 		testConsul.SetKVString(t, "multipass-bar", "zip")
 
-		out, err := ioutil.TempFile("", "")
+		out, err := os.CreateTemp("", "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -671,7 +670,7 @@ func TestRunner_Start(t *testing.T) {
 		case err := <-r.ErrCh:
 			t.Fatal(err)
 		case <-r.renderedCh:
-			act, err := ioutil.ReadFile(out.Name())
+			act, err := os.ReadFile(out.Name())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -685,7 +684,7 @@ func TestRunner_Start(t *testing.T) {
 	})
 
 	t.Run("exec", func(t *testing.T) {
-		out, err := ioutil.TempFile("", "")
+		out, err := os.CreateTemp("", "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -740,7 +739,7 @@ func TestRunner_Start(t *testing.T) {
 	})
 
 	t.Run("exec_once", func(t *testing.T) {
-		out, err := ioutil.TempFile("", "")
+		out, err := os.CreateTemp("", "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -798,11 +797,11 @@ func TestRunner_Start(t *testing.T) {
 	t.Run("exec-wait", func(t *testing.T) {
 		testConsul.SetKVString(t, "exec-wait-foo", "foo")
 
-		firstOut, err := ioutil.TempFile("", "foo")
+		firstOut, err := os.CreateTemp("", "foo")
 		if err != nil {
 			t.Fatal(err)
 		}
-		os.Remove(firstOut.Name())       // remove ioutil created file
+		os.Remove(firstOut.Name())       // remove os created file
 		defer os.Remove(firstOut.Name()) // remove template created file
 
 		c := config.DefaultConfig().Merge(&config.Config{
@@ -867,12 +866,12 @@ func TestRunner_Start(t *testing.T) {
 		testConsul.SetKVString(t, "multi-exec-wait-foo", "bar")
 		testConsul.SetKVString(t, "multi-exec-wait-bar", "bat")
 
-		firstOut, err := ioutil.TempFile("", "foo")
+		firstOut, err := os.CreateTemp("", "foo")
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer os.Remove(firstOut.Name())
-		secondOut, err := ioutil.TempFile("", "bar")
+		secondOut, err := os.CreateTemp("", "bar")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -993,7 +992,7 @@ func TestRunner_Start(t *testing.T) {
 	})
 
 	t.Run("parse_only", func(t *testing.T) {
-		out, err := ioutil.TempFile("", "")
+		out, err := os.CreateTemp("", "")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -60,7 +59,7 @@ type RenderResult struct {
 // Render atomically renders a file contents to disk, returning a result of
 // whether it would have rendered and actually did render.
 func Render(i *RenderInput) (*RenderResult, error) {
-	existing, err := ioutil.ReadFile(i.Path)
+	existing, err := os.ReadFile(i.Path)
 	fileExists := !os.IsNotExist(err)
 	if err != nil && fileExists {
 		return nil, errors.Wrap(err, "failed reading file")
@@ -147,7 +146,7 @@ func AtomicWrite(path string, createDestDirs bool, contents []byte, perms os.Fil
 		}
 	}
 
-	f, err := ioutil.TempFile(parent, "")
+	f, err := os.CreateTemp(parent, "")
 	if err != nil {
 		return err
 	}

--- a/renderer/renderer_test.go
+++ b/renderer/renderer_test.go
@@ -3,7 +3,6 @@ package renderer
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -15,12 +14,12 @@ func TestAtomicWrite(t *testing.T) {
 	t.Run("parent_folder_missing", func(t *testing.T) {
 		// Create a TempDir and a TempFile in that TempDir, then remove them to
 		// "simulate" a non-existent folder
-		outDir, err := ioutil.TempDir("", "")
+		outDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Error(err)
 		}
 		defer os.RemoveAll(outDir)
-		outFile, err := ioutil.TempFile(outDir, "")
+		outFile, err := os.CreateTemp(outDir, "")
 		if err != nil {
 			t.Error(err)
 		}
@@ -38,12 +37,12 @@ func TestAtomicWrite(t *testing.T) {
 	})
 
 	t.Run("retains_permissions", func(t *testing.T) {
-		outDir, err := ioutil.TempDir("", "")
+		outDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Error(err)
 		}
 		defer os.RemoveAll(outDir)
-		outFile, err := ioutil.TempFile(outDir, "")
+		outFile, err := os.CreateTemp(outDir, "")
 		if err != nil {
 			t.Error(err)
 		}
@@ -65,7 +64,7 @@ func TestAtomicWrite(t *testing.T) {
 	})
 
 	t.Run("non_existent", func(t *testing.T) {
-		outDir, err := ioutil.TempDir("", "")
+		outDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Error(err)
 		}
@@ -84,7 +83,7 @@ func TestAtomicWrite(t *testing.T) {
 	})
 
 	t.Run("non_existent_no_create", func(t *testing.T) {
-		outDir, err := ioutil.TempDir("", "")
+		outDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Error(err)
 		}
@@ -99,12 +98,12 @@ func TestAtomicWrite(t *testing.T) {
 	})
 
 	t.Run("backup", func(t *testing.T) {
-		outDir, err := ioutil.TempDir("", "")
+		outDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Error(err)
 		}
 		defer os.RemoveAll(outDir)
-		outFile, err := ioutil.TempFile(outDir, "")
+		outFile, err := os.CreateTemp(outDir, "")
 		if err != nil {
 			t.Error(err)
 		}
@@ -119,7 +118,7 @@ func TestAtomicWrite(t *testing.T) {
 			t.Error(err)
 		}
 
-		f, err := ioutil.ReadFile(outFile.Name() + ".bak")
+		f, err := os.ReadFile(outFile.Name() + ".bak")
 		if err != nil {
 			t.Error(err)
 		}
@@ -137,12 +136,12 @@ func TestAtomicWrite(t *testing.T) {
 	})
 
 	t.Run("backup_not_exists", func(t *testing.T) {
-		outDir, err := ioutil.TempDir("", "")
+		outDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Error(err)
 		}
 		defer os.RemoveAll(outDir)
-		outFile, err := ioutil.TempFile(outDir, "")
+		outFile, err := os.CreateTemp(outDir, "")
 		if err != nil {
 			t.Error(err)
 		}
@@ -165,12 +164,12 @@ func TestAtomicWrite(t *testing.T) {
 	})
 
 	t.Run("backup_backup", func(t *testing.T) {
-		outDir, err := ioutil.TempDir("", "")
+		outDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Error(err)
 		}
 		defer os.RemoveAll(outDir)
-		outFile, err := ioutil.TempFile(outDir, "")
+		outFile, err := os.CreateTemp(outDir, "")
 		if err != nil {
 			t.Error(err)
 		}
@@ -179,7 +178,7 @@ func TestAtomicWrite(t *testing.T) {
 		}
 
 		contains := func(filename, content string) {
-			f, err := ioutil.ReadFile(filename + ".bak")
+			f, err := os.ReadFile(filename + ".bak")
 			if err != nil {
 				t.Error(err)
 			}
@@ -204,12 +203,12 @@ func TestAtomicWrite(t *testing.T) {
 
 func TestRender(t *testing.T) {
 	t.Run("file-exists-same-content", func(t *testing.T) {
-		outDir, err := ioutil.TempDir("", "")
+		outDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Error(err)
 		}
 		defer os.RemoveAll(outDir)
-		outFile, err := ioutil.TempFile(outDir, "")
+		outFile, err := os.CreateTemp(outDir, "")
 		if err != nil {
 			t.Error(err)
 		}
@@ -237,12 +236,12 @@ func TestRender(t *testing.T) {
 		}
 	})
 	t.Run("file-exists-diff-content", func(t *testing.T) {
-		outDir, err := ioutil.TempDir("", "")
+		outDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Error(err)
 		}
 		defer os.RemoveAll(outDir)
-		outFile, err := ioutil.TempFile(outDir, "")
+		outFile, err := os.CreateTemp(outDir, "")
 		if err != nil {
 			t.Error(err)
 		}
@@ -271,7 +270,7 @@ func TestRender(t *testing.T) {
 		}
 	})
 	t.Run("file-no-exists", func(t *testing.T) {
-		outDir, err := ioutil.TempDir("", "")
+		outDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Error(err)
 		}
@@ -294,7 +293,7 @@ func TestRender(t *testing.T) {
 		}
 	})
 	t.Run("empty-file-no-exists", func(t *testing.T) {
-		outDir, err := ioutil.TempDir("", "")
+		outDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Error(err)
 		}
@@ -357,13 +356,13 @@ func TestRender_Chown(t *testing.T) {
 	}
 
 	t.Run("sets-file-ownership-when-file-exists-same-content", func(t *testing.T) {
-		outDir, err := ioutil.TempDir("", "")
+		outDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Error(err)
 		}
 		defer os.RemoveAll(outDir)
 
-		outFile, err := ioutil.TempFile(outDir, "")
+		outFile, err := os.CreateTemp(outDir, "")
 		if err != nil {
 			t.Error(err)
 		}
@@ -402,12 +401,12 @@ func TestRender_Chown(t *testing.T) {
 	})
 
 	t.Run("sets-file-ownership-when-file-exists-diff-content", func(t *testing.T) {
-		outDir, err := ioutil.TempDir("", "")
+		outDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Error(err)
 		}
 		defer os.RemoveAll(outDir)
-		outFile, err := ioutil.TempFile(outDir, "")
+		outFile, err := os.CreateTemp(outDir, "")
 		if err != nil {
 			t.Error(err)
 		}
@@ -446,7 +445,7 @@ func TestRender_Chown(t *testing.T) {
 		}
 	})
 	t.Run("sets-file-ownership-when-file-no-exists", func(t *testing.T) {
-		outDir, err := ioutil.TempDir("", "")
+		outDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Error(err)
 		}
@@ -479,7 +478,7 @@ func TestRender_Chown(t *testing.T) {
 		}
 	})
 	t.Run("sets-file-ownership-when-empty-file-no-exists", func(t *testing.T) {
-		outDir, err := ioutil.TempDir("", "")
+		outDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Error(err)
 		}
@@ -513,12 +512,12 @@ func TestRender_Chown(t *testing.T) {
 	})
 
 	t.Run("should-be-noop-when-missing-user", func(t *testing.T) {
-		outDir, err := ioutil.TempDir("", "")
+		outDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Error(err)
 		}
 		defer os.RemoveAll(outDir)
-		outFile, err := ioutil.TempFile(outDir, "")
+		outFile, err := os.CreateTemp(outDir, "")
 		if err != nil {
 			t.Error(err)
 		}
@@ -562,12 +561,12 @@ func TestRender_Chown(t *testing.T) {
 	})
 
 	t.Run("should-be-noop-when-missing-group", func(t *testing.T) {
-		outDir, err := ioutil.TempDir("", "")
+		outDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Error(err)
 		}
 		defer os.RemoveAll(outDir)
-		outFile, err := ioutil.TempFile(outDir, "")
+		outFile, err := os.CreateTemp(outDir, "")
 		if err != nil {
 			t.Error(err)
 		}
@@ -612,12 +611,12 @@ func TestRender_Chown(t *testing.T) {
 	})
 
 	t.Run("should-be-noop-when-user-and-group-are-both-empty", func(t *testing.T) {
-		outDir, err := ioutil.TempDir("", "")
+		outDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Error(err)
 		}
 		defer os.RemoveAll(outDir)
-		outFile, err := ioutil.TempFile(outDir, "")
+		outFile, err := os.CreateTemp(outDir, "")
 		if err != nil {
 			t.Error(err)
 		}
@@ -662,12 +661,12 @@ func TestRender_Chown(t *testing.T) {
 		}
 	})
 	t.Run("should-be-noop-user-only-second-pass", func(t *testing.T) {
-		outDir, err := ioutil.TempDir("", "")
+		outDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Error(err)
 		}
 		defer os.RemoveAll(outDir)
-		outFile, err := ioutil.TempFile(outDir, "")
+		outFile, err := os.CreateTemp(outDir, "")
 		if err != nil {
 			t.Error(err)
 		}
@@ -711,12 +710,12 @@ func TestRender_Chown(t *testing.T) {
 		}
 	})
 	t.Run("should-be-noop-group-only-second-pass", func(t *testing.T) {
-		outDir, err := ioutil.TempDir("", "")
+		outDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Error(err)
 		}
 		defer os.RemoveAll(outDir)
-		outFile, err := ioutil.TempFile(outDir, "")
+		outFile, err := os.CreateTemp(outDir, "")
 		if err != nil {
 			t.Error(err)
 		}

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -8,7 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"os/user"
@@ -1314,7 +1314,7 @@ func toTOML(m map[string]interface{}) (string, error) {
 	if err := enc.Encode(m); err != nil {
 		return "", errors.Wrap(err, "toTOML")
 	}
-	result, err := ioutil.ReadAll(buf)
+	result, err := io.ReadAll(buf)
 	if err != nil {
 		return "", errors.Wrap(err, "toTOML")
 	}

--- a/template/template.go
+++ b/template/template.go
@@ -5,7 +5,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"text/template"
 
@@ -134,7 +134,7 @@ func NewTemplate(i *NewTemplateInput) (*Template, error) {
 	t.config = i.Config
 
 	if i.Source != "" {
-		contents, err := ioutil.ReadFile(i.Source)
+		contents, err := os.ReadFile(i.Source)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to read template")
 		}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -3,7 +3,6 @@ package template
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"reflect"
@@ -20,7 +19,7 @@ import (
 )
 
 func TestNewTemplate(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +130,7 @@ func TestNewTemplate(t *testing.T) {
 func TestTemplate_Execute(t *testing.T) {
 	now = func() time.Time { return time.Unix(0, 0).UTC() }
 
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2500,7 +2499,7 @@ func Test_writeToFile(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			outDir, err := ioutil.TempDir("", "")
+			outDir, err := os.MkdirTemp("", "")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2508,7 +2507,7 @@ func Test_writeToFile(t *testing.T) {
 
 			var outputFilePath string
 			if tc.filePath == "" {
-				outputFile, err := ioutil.TempFile(outDir, "")
+				outputFile, err := os.CreateTemp(outDir, "")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -2540,7 +2539,7 @@ func Test_writeToFile(t *testing.T) {
 
 			// Compare generated file content with the expectation.
 			// The function should generate an empty string to the output.
-			_generatedFileContent, err := ioutil.ReadFile(outputFilePath)
+			_generatedFileContent, err := os.ReadFile(outputFilePath)
 			generatedFileContent := string(_generatedFileContent)
 			if err != nil {
 				t.Fatal(err)

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
@@ -17,7 +16,7 @@ import (
 func CreateTempfile(tb testing.TB, b []byte) *os.File {
 	tb.Helper()
 
-	f, err := ioutil.TempFile(os.TempDir(), "")
+	f, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(tb, err)
 
 	tb.Cleanup(func() {
@@ -54,7 +53,7 @@ func WaitForContents(t *testing.T, d time.Duration, p, c string) {
 			default:
 			}
 
-			actual, err := ioutil.ReadFile(p)
+			actual, err := os.ReadFile(p)
 			if err != nil && !os.IsNotExist(err) {
 				errCh <- err
 				return

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -2,7 +2,7 @@ package watch
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 
 // sub-main so I can use defer
 func main(m *testing.M) int {
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 	testVault = newTestVault()
 	defer func() { testVault.Stop() }()
 
@@ -70,8 +70,8 @@ func newTestVault() *vaultServer {
 		"-dev-no-store-token",
 	}
 	cmd := exec.Command("vault", args...)
-	cmd.Stdout = ioutil.Discard
-	cmd.Stderr = ioutil.Discard
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
 
 	if err := cmd.Start(); err != nil {
 		panic("vault failed to start: " + err.Error())
@@ -188,8 +188,8 @@ func runVaultAgent(clients *dep.ClientSet, role_id string) string {
 		"agent", "-exit-after-auth", "-config=" + vaconf,
 	}
 	cmd := exec.Command("vault", args...)
-	cmd.Stdout = ioutil.Discard
-	cmd.Stderr = ioutil.Discard
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
 
 	if err := cmd.Run(); err != nil {
 		panic("vault agent failed to run: " + err.Error())


### PR DESCRIPTION
The `ioutil` package has been deprecated since Go 1.16 and this project uses 1.19. This PR updates the code to use equivalent functions from the `io` and `os` packages.

Fixes #1675 