### PR TITLE
Fix 'toTitle' function for a better support for word boundaries and unicode punctuation

### DIFF
--- a/template/funcs.go
+++ b/template/funcs.go
@@ -28,6 +28,8 @@ import (
 	socktmpl "github.com/hashicorp/go-sockaddr/template"
 	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -1290,7 +1292,7 @@ func toUnescapedJSONPretty(m map[string]interface{}) (string, error) {
 
 // toTitle converts the given string (usually by a pipe) to titlecase.
 func toTitle(s string) (string, error) {
-	return strings.Title(s), nil
+	return cases.Title(language.Und, cases.NoLower).String(s), nil
 }
 
 // toUpper converts the given string (usually by a pipe) to uppercase.

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1790,6 +1790,17 @@ func TestTemplate_Execute(t *testing.T) {
 			false,
 		},
 		{
+			"helper_toTitle_unicode",
+			&NewTemplateInput{
+				Contents: `{{ "this is a sentence\u2026and another sentence\u2026with a \xf0\x9f\x9a\x80rocket" | toTitle }}`,
+			},
+			&ExecuteInput{
+				Brain: NewBrain(),
+			},
+			"This Is A Sentence\u2026And Another Sentence\u2026With A \xf0\x9f\x9a\x80Rocket",
+			false,
+		},
+		{
 			"helper_toTOML",
 			&NewTemplateInput{
 				Contents: `{{ "{\"foo\":\"bar\"}" | parseJSON | toTOML }}`,


### PR DESCRIPTION
- Use `golang.org/x/text/cases` package in the `toTitle` function. Previous method `strings.Title` has been deprecated since Go 1.18. 

- Add a test to title case a sentence with unicode punctuation and a rocket emoji 🚀 

Fixes #1677