### PR TITLE
Fix code formatting for template package

### DIFF
--- a/template/funcs.go
+++ b/template/funcs.go
@@ -1212,13 +1212,13 @@ func splitToMap(sep1, sep2, s string) (map[string]string, error) {
 		return emptyMap, nil
 	}
 	s1 := strings.Split(s, sep1)
-	m:=make(map[string]string, len(s1))
+	m := make(map[string]string, len(s1))
 	for i := range s1 {
-		k,v,f:=strings.Cut(s1[i],sep2)
+		k, v, f := strings.Cut(s1[i], sep2)
 		if !f {
 			continue
 		}
-		m[k]=v
+		m[k] = v
 	}
 	return m, nil
 }

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1207,7 +1207,7 @@ func TestTemplate_Execute(t *testing.T) {
 				Contents: `{{ mustEnv "CT_TEST_NONEXISTENT" }}`,
 			},
 			&ExecuteInput{
-				Brain:  NewBrain(),
+				Brain: NewBrain(),
 			},
 			"",
 			true,


### PR DESCRIPTION
While working on #1676 and #1677 I struggled with minor formatting issues in the `template` package. This PR fixes those issues by formatting the code according to `go fmt`.

Other packages are ok.