### PR TITLE
Fix bitsize in parseFloat function

### DIFF
--- a/template/funcs.go
+++ b/template/funcs.go
@@ -1052,13 +1052,13 @@ func parseBool(s string) (bool, error) {
 	return result, nil
 }
 
-// parseFloat parses a string into a base 10 float
+// parseFloat parses a string into a floating-point number with 64-bit precision
 func parseFloat(s string) (float64, error) {
 	if s == "" {
 		return 0.0, nil
 	}
 
-	result, err := strconv.ParseFloat(s, 10)
+	result, err := strconv.ParseFloat(s, 64)
 	if err != nil {
 		return 0, errors.Wrap(err, "parseFloat")
 	}


### PR DESCRIPTION
`parseFloat` function calls [strconv.ParseFloat](https://pkg.go.dev/strconv#ParseFloat) with an invalid bitsize parameter. This parameter should either be `32` (for 32-bit precision) or `64` (for 64-bit precision). The result is always of type `float64`.

Not a user-impacting change, since the [internal implementation of `strconv.ParseFloat`](https://cs.opensource.google/go/go/+/refs/tags/go1.19.3:src/strconv/atof.go;l=695) defaults to bitsize of `64` if the given bitsize is anything else than `32`. 