### PR TITLE
Remove unnecessary type conversions from various places

### DIFF
--- a/config/convert_test.go
+++ b/config/convert_test.go
@@ -602,7 +602,7 @@ func TestTimeDurationVal(t *testing.T) {
 		{
 			"present",
 			TimeDuration(10 * time.Second),
-			time.Duration(10 * time.Second),
+			10 * time.Second,
 		},
 	}
 

--- a/manager/runner_test.go
+++ b/manager/runner_test.go
@@ -694,7 +694,7 @@ func TestRunner_Start(t *testing.T) {
 		c := config.DefaultConfig().Merge(&config.Config{
 			Exec: &config.ExecConfig{
 				Command:     []string{`sleep 30`},
-				KillTimeout: config.TimeDuration(time.Duration(10 * time.Second)),
+				KillTimeout: config.TimeDuration(10 * time.Second),
 			},
 			Templates: &config.TemplateConfigs{
 				&config.TemplateConfig{
@@ -975,8 +975,8 @@ func TestRunner_Start(t *testing.T) {
 				}
 			}
 			exp := "foo"
-			if exp != string(act) {
-				t.Errorf("\nexp: %#v\nact: %#v", exp, string(act))
+			if exp != act {
+				t.Errorf("\nexp: %#v\nact: %#v", exp, act)
 			}
 			expOut := "> \nfoo"
 			if expOut != o.String() {

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -972,7 +972,7 @@ func loop(ifaces ...interface{}) (<-chan int64, error) {
 		switch v.Kind() {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32,
 			reflect.Int64:
-			return int64(v.Int()), nil
+			return v.Int(), nil
 		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32,
 			reflect.Uint64:
 			return int64(v.Uint()), nil


### PR DESCRIPTION
In detail:

- `config/convert_test.go`: `time.Second` & others are already represented (internally) by an `int64` so type conversion after multiplication is not needed
- `manager/runner_test.go`: Same as above + `act` is defined as a string from the start, no need for conversion
- `template/funcs.go`: Upon reflection `v.Int()` already returns an `int64`