### PR TITLE
Add missing err check to Vault read test

### DIFF
--- a/dependency/vault_read_test.go
+++ b/dependency/vault_read_test.go
@@ -585,6 +585,9 @@ func TestVaultReadQuery_Fetch_NonSecrets(t *testing.T) {
 		map[string]interface{}{
 			"policy": `path "auth/approle/role/my-approle/role-id" { capabilities = ["read"] }`,
 		})
+	if err != nil {
+		t.Fatal(err)
+	}
 	secret, err := vc.Auth().Token().Create(&api.TokenCreateRequest{
 		Policies: []string{"operator"},
 	})


### PR DESCRIPTION
A Vault related test in `dependency/vault_read_test.go` creates an `operator` policy for creating restricted tokens later on. The call is missing an `err` check and this PR fixes that.