### PR TITLE
respect reload/kill configured signals

### DIFF
--- a/child/child.go
+++ b/child/child.go
@@ -211,7 +211,15 @@ func (c *Child) Signal(s os.Signal) error {
 	c.logger.Printf("[INFO] (child) receiving signal %q", s.String())
 	c.RLock()
 	defer c.RUnlock()
-	return c.signal(s)
+	switch s {
+	case c.reloadSignal:
+		return c.reload()
+	case c.killSignal:
+		c.kill(true)
+		return nil
+	default:
+		return c.signal(s)
+	}
 }
 
 // Reload sends the reload signal to the child process and does not wait for a


### PR DESCRIPTION
In cases it would just send the signal instead of matching against configured signals for special behavior.

Fixes #1671