### PR TITLE
option to exit with error on failed data lookup

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -104,6 +104,10 @@ type Config struct {
 
 	// BlockQueryWaitTime is amount of time in seconds to do a blocking query for
 	BlockQueryWaitTime *time.Duration `mapstructure:"block_query_wait"`
+
+	// ErrOnFailedLookup, when enabled, will trigger an error if a dependency
+	// fails to return a value.
+	ErrOnFailedLookup bool `mapstructure:"err_on_failed_lookup"`
 }
 
 // Copy returns a deep copy of the current configuration. This is useful because
@@ -168,7 +172,7 @@ func (c *Config) Copy() *Config {
 
 	o.Once = c.Once
 	o.ParseOnly = c.ParseOnly
-
+	o.ErrOnFailedLookup = c.ErrOnFailedLookup
 	o.BlockQueryWaitTime = c.BlockQueryWaitTime
 
 	if c.Nomad != nil {
@@ -260,6 +264,9 @@ func (c *Config) Merge(o *Config) *Config {
 
 	r.Once = o.Once
 	r.ParseOnly = o.ParseOnly
+	if o.ErrOnFailedLookup {
+		r.ErrOnFailedLookup = o.ErrOnFailedLookup
+	}
 
 	if o.Nomad != nil {
 		r.Nomad = r.Nomad.Merge(o.Nomad)
@@ -462,7 +469,8 @@ func (c *Config) GoString() string {
 		"Vault:%#v, "+
 		"Wait:%#v, "+
 		"Once:%#v, "+
-		"BlockQueryWaitTime:%#v"+
+		"BlockQueryWaitTime:%#v, "+
+		"ErrOnFailedLookup:%#v"+
 		"}",
 		c.Consul,
 		c.Dedup,
@@ -481,6 +489,7 @@ func (c *Config) GoString() string {
 		c.Wait,
 		c.Once,
 		TimeDurationGoString(c.BlockQueryWaitTime),
+		c.ErrOnFailedLookup,
 	)
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -171,6 +171,10 @@ log_level = "warn"
 # configuration.
 template_error_fatal = true
 
+# This will cause consul-template to exit with an error if it fails to
+# successfully fetch a value for a field.
+err_on_failed_lookup = true
+
 # This is the quiescence timers; it defines the minimum and maximum amount of
 # time to wait for the cluster to reach a consistent state before rendering a
 # template. This is useful to enable in systems that have a lot of flapping,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,7 +172,8 @@ log_level = "warn"
 template_error_fatal = true
 
 # This will cause consul-template to exit with an error if it fails to
-# successfully fetch a value for a field.
+# successfully fetch a value for a field. Note that the retry logic defined for
+# the services don't apply to this type of error.
 err_on_failed_lookup = true
 
 # This is the quiescence timers; it defines the minimum and maximum amount of

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -1404,6 +1404,7 @@ func newWatcher(c *config.Config, clients *dep.ClientSet, once bool) *watch.Watc
 		RenewVault:          clients.Vault().Token() != "" && config.BoolVal(c.Vault.RenewToken),
 		VaultAgentTokenFile: config.StringVal(c.Vault.VaultAgentTokenFile),
 		RetryFuncConsul:     watch.RetryFunc(c.Consul.Retry.RetryFunc()),
+		FailLookupErrors:    c.ErrOnFailedLookup,
 		// TODO: Add a reasonable default retry - right now this only affects
 		// "local" dependencies like reading a file from disk.
 		RetryFuncDefault: nil,

--- a/watch/dependencies_test.go
+++ b/watch/dependencies_test.go
@@ -157,3 +157,17 @@ func (d *TestDepRetry) Stop() {}
 func (d *TestDepRetry) Type() dep.Type {
 	return dep.TypeLocal
 }
+
+// TestDepBlock is a dependency that think's its blocking
+type TestDepBlock struct {
+	TestDep
+}
+
+func (d *TestDepBlock) Fetch(clients *dep.ClientSet, opts *dep.QueryOptions) (interface{}, *dep.ResponseMetadata, error) {
+	meta := &dep.ResponseMetadata{LastIndex: 100, BlockOnNil: true}
+	return nil, meta, nil
+}
+
+func (d *TestDepBlock) String() string {
+	return fmt.Sprintf("test_dep_block")
+}

--- a/watch/watcher.go
+++ b/watch/watcher.go
@@ -30,6 +30,10 @@ type Watcher struct {
 	// blockQueryWaitTime is amount of time in seconds to do a blocking query for
 	blockQueryWaitTime time.Duration
 
+	// failLookupErrors triggers error when a dependency Fetch fails to
+	// return data after the first pass.
+	failLookupErrors bool
+
 	// depViewMap is a map of Templates to Views. Templates are keyed by
 	// their string.
 	depViewMap map[string]*View
@@ -61,6 +65,10 @@ type NewWatcherInput struct {
 	// WaitTime is amount of time in seconds to do a blocking query for
 	BlockQueryWaitTime time.Duration
 
+	// FailLookupErrors triggers error when a dependency Fetch fails to
+	// return data after the first pass.
+	FailLookupErrors bool
+
 	// RenewVault indicates if this watcher should renew Vault tokens.
 	RenewVault bool
 
@@ -87,6 +95,7 @@ func NewWatcher(i *NewWatcherInput) *Watcher {
 		maxStale:           i.MaxStale,
 		once:               i.Once,
 		blockQueryWaitTime: i.BlockQueryWaitTime,
+		failLookupErrors:   i.FailLookupErrors,
 		retryFuncConsul:    i.RetryFuncConsul,
 		retryFuncDefault:   i.RetryFuncDefault,
 		retryFuncVault:     i.RetryFuncVault,
@@ -146,6 +155,7 @@ func (w *Watcher) Add(d dep.Dependency) (bool, error) {
 		Clients:            w.clients,
 		MaxStale:           w.maxStale,
 		BlockQueryWaitTime: w.blockQueryWaitTime,
+		FailLookupErrors:   w.failLookupErrors,
 		Once:               w.once,
 		RetryFunc:          retryFunc,
 	})


### PR DESCRIPTION
Works at the view/polling level, so should cover all data types. It fails on 2nd attempt as first attempt is special cased.

Fixes #1637