### PR TITLE
config default tweaks based on cts research

### DIFF
--- a/config/transport.go
+++ b/config/transport.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"runtime"
 	"time"
 
 	"github.com/hashicorp/consul-template/dependency"
@@ -19,19 +18,19 @@ const (
 
 	// DefaultIdleConnTimeout is the default connection timeout for idle
 	// connections.
-	DefaultIdleConnTimeout = 90 * time.Second
+	DefaultIdleConnTimeout = 5 * time.Second
 
 	// DefaultMaxIdleConns is the default number of maximum idle connections.
-	DefaultMaxIdleConns = 100
+	DefaultMaxIdleConns = 0
+
+	// DefaultMaxIdleConnsPerHost is the default number of idle connections to use
+	// per host.
+	DefaultMaxIdleConnsPerHost = 100
 
 	// DefaultTLSHandshakeTimeout is the amount of time to negotiate the TLS
 	// handshake.
 	DefaultTLSHandshakeTimeout = 10 * time.Second
 )
-
-// DefaultMaxIdleConnsPerHost is the default number of idle connections to use
-// per host.
-var DefaultMaxIdleConnsPerHost = runtime.GOMAXPROCS(0) + 1
 
 // TransportConfig is the configuration to tune low-level APIs for the
 // interactions on the wire.


### PR DESCRIPTION
See this ticket for some details...
https://github.com/hashicorp/consul-terraform-sync/pull/164

Summary: http.MaxIdleConnsPerHost was default to a very low value that caused TCP connections to not be reused across dependency monitoring. Only ~1 connections were being reused from the initial set of hcat requests to Consul, and the remaining dependencies required establishing a new connection.

Fixes #1603