### PR TITLE
Replace uses of the word "sane"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -482,7 +482,7 @@ BUG FIXES:
 
 BREAKING CHANGES:
 
-  * Retry now has a sane maximum default. Previous versions of Consul Template
+  * Retry now has a reasonable maximum default. Previous versions of Consul Template
       would retry indefinitely, potentially allowing the time between retries to
       reach days, months, or years due to the exponential nature. Users wishing
       to use the old behavior should set `max_backoff = 0` in their

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -482,7 +482,7 @@ BUG FIXES:
 
 BREAKING CHANGES:
 
-  * Retry now has a reasonable maximum default. Previous versions of Consul Template
+  * Retry now has a maximum default. Previous versions of Consul Template
       would retry indefinitely, potentially allowing the time between retries to
       reach days, months, or years due to the exponential nature. Users wishing
       to use the old behavior should set `max_backoff = 0` in their

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	// saneViewLimit is the number of views that we consider "sane" before we
+	// reasonableViewLimit is the number of views that we consider reasonable before we
 	// warn the user that they might be DDoSing their Consul cluster.
-	saneViewLimit = 128
+	reasonableViewLimit = 128
 )
 
 // Runner responsible rendering Templates and invoking Commands.
@@ -276,7 +276,7 @@ func (r *Runner) Start() {
 
 	for {
 		// Warn the user if they are watching too many dependencies.
-		if r.watcher.Size() > saneViewLimit {
+		if r.watcher.Size() > reasonableViewLimit {
 			log.Printf("[WARN] (runner) watching %d dependencies - watching this "+
 				"many dependencies could DDoS your servers", r.watcher.Size())
 		} else {

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	// reasonableViewLimit is the number of views that we consider reasonable before we
+	// viewLimit is the number of views that we consider reasonable before we
 	// warn the user that they might be DDoSing their Consul cluster.
-	reasonableViewLimit = 128
+	viewLimit = 128
 )
 
 // Runner responsible rendering Templates and invoking Commands.
@@ -276,7 +276,7 @@ func (r *Runner) Start() {
 
 	for {
 		// Warn the user if they are watching too many dependencies.
-		if r.watcher.Size() > reasonableViewLimit {
+		if r.watcher.Size() > viewLimit {
 			log.Printf("[WARN] (runner) watching %d dependencies - watching this "+
 				"many dependencies could DDoS your servers", r.watcher.Size())
 		} else {


### PR DESCRIPTION
Switching to more inclusive language by replacing "sane" with "reasonable".