### PR TITLE
feat(build): add public.ecr.aws tag image build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,6 +246,7 @@ jobs:
           arch: ${{ matrix.arch }}
           tags: |
             docker.io/hashicorp/${{ env.repo }}:${{ env.version }}
+            public.ecr.aws/hashicorp/${{ env.repo }}:${{ env.version }}
           # dev_tags are tags that get automatically pushed whenever successful
           # builds make it to the stable channel. The intention is for these tags
           # to be used for early testing of new code prior to official releases


### PR DESCRIPTION
## what
- add public.ecr.aws tag image build

## why
- Allow aws specific image to avoid docker rate limiting
- Prevent having to create my own custom container in ecr
- Create ecr pull through cache rules

## references
- Closes https://github.com/hashicorp/consul-template/issues/1732