### PR TITLE
fix: renew token of vault k8s auth method

### DIFF
--- a/dependency/vault_token_test.go
+++ b/dependency/vault_token_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/vault/api"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewVaultTokenQuery(t *testing.T) {
@@ -34,6 +35,7 @@ func TestNewVaultTokenQuery(t *testing.T) {
 						LeaseDuration: 1,
 					},
 				},
+				initialToken: "my-token",
 			},
 			false,
 		},
@@ -74,5 +76,24 @@ func TestVaultTokenQuery_String(t *testing.T) {
 			}
 			assert.Equal(t, tc.exp, d.String())
 		})
+	}
+}
+
+func TestTewVaultSecretsOverrideRenewer(t *testing.T) {
+	const token = "expected_token"
+
+	parent, err := NewVaultTokenQuery(VaultTokenRefreshCurrent)
+	require.NoError(t, err)
+
+	vaultTokenSecretsOverride := newVaultSecretsOverrideRenewer(parent, token)
+
+	secret, vaultSecret := vaultTokenSecretsOverride.secrets()
+
+	if assert.NotNil(t, secret) && assert.NotNil(t, secret.Auth) {
+		assert.Equal(t, token, secret.Auth.ClientToken)
+	}
+
+	if assert.NotNil(t, vaultSecret) && assert.NotNil(t, vaultSecret.Auth) {
+		assert.Equal(t, token, vaultSecret.Auth.ClientToken)
 	}
 }


### PR DESCRIPTION
**Description**
Run vault token renewer when k8s auth method is used.

**References**
The part of the fix to: https://github.com/hashicorp/envconsul/issues/309

Relates to:
- https://github.com/hashicorp/consul-template/pull/1580
- https://github.com/hashicorp/envconsul/pull/281
- https://github.com/hashicorp/envconsul/pull/332 (envconsul part of this fix)

**Local testing**
1. Configured vault in microk8s:
    ```bash
    vault auth enable kubernetes
    
    vault write auth/kubernetes/config \
          token_reviewer_jwt="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
          kubernetes_host=https://${KUBERNETES_PORT_443_TCP_ADDR}:443 \
          kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
    
    vault write auth/kubernetes/role/vault \
         bound_service_account_names=vault \
         bound_service_account_namespaces=vault \
         ttl=10m
    ```
1. Created secret `secret/passwords` and configured default policy to _read_ `secret/*`.
1. Port-forward vault:
   ```bash
   kubectl port-forward svc/vault 8200:8200 -n vault
   ```
1. Configured envconsul:
    ```hcl
    log_level = "trace"
    
    vault {
      address = "http://localhost:8200"
      renew_token = true
    
      k8s_auth_role_name = "vault"
      k8s_service_account_token = "<JWT_FROM_SERVICE_ACCOUNT>"
      k8s_service_mount_path = "kubernetes"
    }
    
    secret {
      no_prefix = true
      path      = "secret/passwords"
    }
    ```
1. Run envconsul and checked logs:
    ```
    2023-05-18T08:25:22.357+0300 [DEBUG] envconsul: (watcher) adding vault.token
    2023-05-18T08:25:22.357+0300 [TRACE] envconsul: (watcher) vault.token starting
    2023-05-18T08:25:22.357+0300 [TRACE] envconsul: (view) vault.token starting fetch
    2023-05-18T08:25:22.358+0300 [TRACE] envconsul: vault.token: starting renewer
    2023-05-18T08:25:22.361+0300 [TRACE] envconsul: vault.token: successfully renewed
    2023-05-18T08:32:30.667+0300 [TRACE] envconsul: vault.token: successfully renewed
    2023-05-18T08:39:38.937+0300 [TRACE] envconsul: vault.token: successfully renewed
    2023-05-18T08:46:47.233+0300 [TRACE] envconsul: vault.token: successfully renewed
    2023-05-18T08:53:55.529+0300 [TRACE] envconsul: vault.token: successfully renewed
    ```
    > Considering token TTL = 10m, everything works as expected.