### PR TITLE
Deprecate set-output commands in GH Actions 'build' workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         # looking for just the number, eg. 1.18.3
         run: |
           echo "Building with Go $(go env GOVERSION | tr -d 'go')"
-          echo "::set-output name=go-version::$(go env GOVERSION | tr -d 'go')"
+          echo "go-version=$(go env GOVERSION | tr -d 'go')" >> "$GITHUB_OUTPUT"
 
   get-product-version:
     runs-on: ubuntu-latest
@@ -42,7 +42,7 @@ jobs:
         id: get-product-version
         run: |
           make version
-          echo "::set-output name=product-version::$(make version)"
+          echo "product-version=$(make version)" >> "$GITHUB_OUTPUT"
 
   generate-metadata-file:
     needs: get-product-version


### PR DESCRIPTION
Replace `set-output` commands in GH Actions workflows by setting outputs to temporary environment variables read by the Actions runners.

More information available in [this Github blog post](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) and [environment files documentation](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files).

Fixes #1748. 