### PR TITLE
Add function for HMAC SHA256

### DIFF
--- a/docs/templating-language.md
+++ b/docs/templating-language.md
@@ -1489,10 +1489,10 @@ Takes a string input as an argument, and returns the hex-encoded md5 hash of the
 
 ### `hmacSHA256Hex`
 
-Takes a secret and a message as string inputs. Returns a hex-encoded HMAC SHA256 hash of the given parameters.
+Takes a key and a message as string inputs. Returns a hex-encoded HMAC-SHA256 hash with the given parameters.
 
 ```golang
-{{ hmacSHA256Hex "somemessage" "somesecret" }}
+{{ hmacSHA256Hex "somemessage" "somekey" }}
 ```
 
 Or with a pipe function

--- a/docs/templating-language.md
+++ b/docs/templating-language.md
@@ -74,6 +74,7 @@ provides the following functions:
   - [replaceAll](#replaceall)
   - [sha256Hex](#sha256hex)
   - [md5sum](#md5sum)
+  - [hmacSHA256Hex](#hmacSHA256hex)
   - [split](#split)
   - [splitToMap](#splitToMap)
   - [timestamp](#timestamp)
@@ -1484,6 +1485,20 @@ Takes a string input as an argument, and returns the hex-encoded md5 hash of the
 
 ```golang
 {{ "myString" | md5sum }}
+```
+
+### `hmacSHA256Hex`
+
+Takes a secret and a message as string inputs. Returns a hex-encoded HMAC SHA256 hash of the given parameters.
+
+```golang
+{{ hmacSHA256Hex "somemessage" "somesecret" }}
+```
+
+Or with a pipe function
+
+```golang
+{{ "somesecret" | hmacSHA256Hex "somemessage" }}
 ```
 
 ### `split`

--- a/docs/templating-language.md
+++ b/docs/templating-language.md
@@ -1498,7 +1498,7 @@ Takes a key and a message as string inputs. Returns a hex-encoded HMAC-SHA256 ha
 Or with a pipe function
 
 ```golang
-{{ "somesecret" | hmacSHA256Hex "somemessage" }}
+{{ "somekey" | hmacSHA256Hex "somemessage" }}
 ```
 
 ### `split`

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -5,6 +5,7 @@ package template
 
 import (
 	"bytes"
+	"crypto/hmac"
 	"crypto/md5"
 	"crypto/sha256"
 	"encoding/base64"
@@ -1718,6 +1719,13 @@ func sha256Hex(item string) (string, error) {
 // md5sum returns the md5 hash of a string
 func md5sum(item string) (string, error) {
 	return fmt.Sprintf("%x", md5.Sum([]byte(item))), nil
+}
+
+// hmacSHA256Hex returns the HMAC SHA256 hex of a string
+func hmacSHA256Hex(message, secret string) (string, error) {
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write([]byte(message))
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // writeToFile writes the content to a file with permissions, username (or UID), group name (or GID),

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -1721,9 +1721,10 @@ func md5sum(item string) (string, error) {
 	return fmt.Sprintf("%x", md5.Sum([]byte(item))), nil
 }
 
-// hmacSHA256Hex returns the HMAC SHA256 hex of a string
-func hmacSHA256Hex(message, secret string) (string, error) {
-	h := hmac.New(sha256.New, []byte(secret))
+// hmacSHA256Hex returns the HMAC-SHA256 hash in hexadecimal format of the
+// given message by using the provided key
+func hmacSHA256Hex(message, key string) (string, error) {
+	h := hmac.New(sha256.New, []byte(key))
 	h.Write([]byte(message))
 	return hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/template/funcs_test.go
+++ b/template/funcs_test.go
@@ -272,7 +272,7 @@ func Test_md5sum(t *testing.T) {
 func Test_hmacSHA256Hex(t *testing.T) {
 	type args struct {
 		message string
-		secret  string
+		key     string
 	}
 	tests := []struct {
 		name    string
@@ -284,7 +284,7 @@ func Test_hmacSHA256Hex(t *testing.T) {
 			name: "Should return the proper string",
 			args: args{
 				message: "bladibla",
-				secret:  "foobar",
+				key:     "foobar",
 			},
 			want:    "82cd4c36fa45a1936e93d005ea2fd008350339bb9246a3ba0c8dfecb9d77155b",
 			wantErr: false,
@@ -292,7 +292,7 @@ func Test_hmacSHA256Hex(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := hmacSHA256Hex(tt.args.message, tt.args.secret)
+			got, err := hmacSHA256Hex(tt.args.message, tt.args.key)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("hmacSHA256Hex() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/template/funcs_test.go
+++ b/template/funcs_test.go
@@ -268,3 +268,38 @@ func Test_md5sum(t *testing.T) {
 		})
 	}
 }
+
+func Test_hmacSHA256Hex(t *testing.T) {
+	type args struct {
+		message string
+		secret  string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Should return the proper string",
+			args: args{
+				message: "bladibla",
+				secret:  "foobar",
+			},
+			want:    "82cd4c36fa45a1936e93d005ea2fd008350339bb9246a3ba0c8dfecb9d77155b",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := hmacSHA256Hex(tt.args.message, tt.args.secret)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("hmacSHA256Hex() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("hmacSHA256Hex() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/template/template.go
+++ b/template/template.go
@@ -390,6 +390,7 @@ func funcMap(i *funcMapInput) template.FuncMap {
 		"replaceAll":            replaceAll,
 		"sha256Hex":             sha256Hex,
 		"md5sum":                md5sum,
+		"hmacSHA256Hex":         hmacSHA256Hex,
 		"timestamp":             timestamp,
 		"toLower":               toLower,
 		"toJSON":                toJSON,

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -255,6 +255,15 @@ func TestTemplate_Execute(t *testing.T) {
 			false,
 		},
 		{
+			"func_hmacSHA256Hex",
+			&NewTemplateInput{
+				Contents: `{{ hmacSHA256Hex "somemessage" "somesecret" }}`,
+			},
+			nil,
+			"64e071cca0eb27a3b12d70efc15c18a52a91d84cf4e91a5943195f1015bf7c34",
+			false,
+		},
+		{
 			"func_datacenters",
 			&NewTemplateInput{
 				Contents: `{{ datacenters }}`,

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -257,10 +257,10 @@ func TestTemplate_Execute(t *testing.T) {
 		{
 			"func_hmacSHA256Hex",
 			&NewTemplateInput{
-				Contents: `{{ hmacSHA256Hex "somemessage" "somesecret" }}`,
+				Contents: `{{ hmacSHA256Hex "somemessage" "somekey" }}`,
 			},
 			nil,
-			"64e071cca0eb27a3b12d70efc15c18a52a91d84cf4e91a5943195f1015bf7c34",
+			"6116e95f2827172aa6ef8b22b883f6a77e966aefc129c6b8228ebd0aac74e98d",
 			false,
 		},
 		{


### PR DESCRIPTION
Useful for cases where data in Consul has to be rendered into HMAC SHA256 hashes, where the shared key is stored in Vault. Example snippet:

```
{{ range ls "foo" }}
{{ $msg := .Value -}}
{{ with secret "secret/foo" }}{{ .Data.data.bar | hmacSHA256Hex $msg }}{{ end -}}
{{ end }}
```

Fixes #1701.