### PR TITLE
CLI support for exec env configs

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -378,6 +378,26 @@ func (cli *CLI) ParseFlags(args []string) (
 		return nil
 	}), "exec-splay", "")
 
+	flags.Var((funcBoolVar)(func(b bool) error {
+		c.Exec.Env.Pristine = config.Bool(b)
+		return nil
+	}), "exec-env-pristine", "")
+
+	flags.Var((funcVar)(func(s string) error {
+		c.Exec.Env.Custom = append(c.Exec.Env.Custom, s)
+		return nil
+	}), "exec-env-custom", "")
+
+	flags.Var((funcVar)(func(s string) error {
+		c.Exec.Env.Allowlist = append(c.Exec.Env.Allowlist, s)
+		return nil
+	}), "exec-env-allowlist", "")
+
+	flags.Var((funcVar)(func(s string) error {
+		c.Exec.Env.Denylist = append(c.Exec.Env.Denylist, s)
+		return nil
+	}), "exec-env-denylist", "")
+
 	flags.Var((funcVar)(func(s string) error {
 		sig, err := signals.Parse(s)
 		if err != nil {
@@ -772,6 +792,27 @@ Options:
 
   -exec-splay=<duration>
       Amount of time to wait before sending signals
+
+  -exec-env-pristine
+      Child process should not inherit the parent process's environment.
+
+  -exec-env-custom
+      Additional custom environment variables to inject into the child's
+      runtime. Even if pristine, allowlist, or denylist is specified, all
+      values in this option are given to the child process. Can be specified
+      multiple times.
+
+  -exec-env-allowlist
+      List of environment variables to exclusively include in the list of
+      environment variables exposed to the child process. Only those environment
+      variables matching the given patterns are exposed to the child process.
+      Wildcards are permitted. Can be specified multiple times.
+
+  -exec-env-denylist
+      List of environment variables to exclusively prohibit in the list of
+      environment variables exposed to the child process. The values in this
+      option take precedence over the values in the allowlist.
+      Wildcards are permitted. Can be specified multiple times.
 
   -kill-signal=<signal>
       Signal to listen to gracefully terminate the process

--- a/cli_test.go
+++ b/cli_test.go
@@ -352,6 +352,108 @@ func TestCLI_ParseFlags(t *testing.T) {
 			false,
 		},
 		{
+			"exec-env-pristine",
+			[]string{"-exec-env-pristine"},
+			&config.Config{
+				Exec: &config.ExecConfig{
+					Env: &config.EnvConfig{
+						Pristine: config.Bool(true),
+					},
+				},
+			},
+			false,
+		},
+		{
+			"exec-env-custom",
+			[]string{"-exec-env-custom", "SOME_ENV_VARIABLE=VALUE"},
+			&config.Config{
+				Exec: &config.ExecConfig{
+					Env: &config.EnvConfig{
+						Custom: []string{"SOME_ENV_VARIABLE=VALUE"},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"exec-env-custom-multiple",
+			[]string{
+				"-exec-env-custom", "SOME_ENV_VARIABLE=VALUE",
+				"-exec-env-custom", "ANOTHER_ENV_VARIABLE=VALUE",
+			},
+			&config.Config{
+				Exec: &config.ExecConfig{
+					Env: &config.EnvConfig{
+						Custom: []string{
+							"SOME_ENV_VARIABLE=VALUE",
+							"ANOTHER_ENV_VARIABLE=VALUE",
+						},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"exec-env-allowlist",
+			[]string{"-exec-env-allowlist", "SOME_*"},
+			&config.Config{
+				Exec: &config.ExecConfig{
+					Env: &config.EnvConfig{
+						Allowlist: []string{"SOME_*"},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"exec-env-allowlist-multiple",
+			[]string{
+				"-exec-env-allowlist", "SOME_*",
+				"-exec-env-allowlist", "ANOTHER_*",
+			},
+			&config.Config{
+				Exec: &config.ExecConfig{
+					Env: &config.EnvConfig{
+						Allowlist: []string{
+							"SOME_*",
+							"ANOTHER_*",
+						},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"exec-env-denylist",
+			[]string{"-exec-env-denylist", "VAULT_*"},
+			&config.Config{
+				Exec: &config.ExecConfig{
+					Env: &config.EnvConfig{
+						Denylist: []string{"VAULT_*"},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"exec-env-denylist-multiple",
+			[]string{
+				"-exec-env-denylist", "VAULT_*",
+				"-exec-env-denylist", "CONSUL_*",
+			},
+			&config.Config{
+				Exec: &config.ExecConfig{
+					Env: &config.EnvConfig{
+						Denylist: []string{
+							"VAULT_*",
+							"CONSUL_*",
+						},
+					},
+				},
+			},
+			false,
+		},
+		{
 			"kill-signal",
 			[]string{"-kill-signal", "SIGUSR1"},
 			&config.Config{


### PR DESCRIPTION
Add the following CLI parameters and tests for each one:

- `exec-env-pristine`
- `exec-env-custom`
- `exec-env-allowlist`
- `exec-env-denylist`

As `custom`, `denylist` and `allowlist` are presented in slices, it is possible to define the same parameter multiple times. This behaviour matches how other HashiCorp tools handle similar cases, such as:

- `consul agent` and `--node-meta<key:value>` parameter
-  `vault kv get` and `-header=<key=value>`

Fixes #1051 