### PR TITLE
Various code quality fixes/linting

### DIFF
--- a/config/convert_test.go
+++ b/config/convert_test.go
@@ -216,7 +216,7 @@ func TestFileModePresent(t *testing.T) {
 		},
 		{
 			"present",
-			FileMode(123),
+			FileMode(0644),
 			true,
 		},
 		{

--- a/config/vault.go
+++ b/config/vault.go
@@ -88,7 +88,7 @@ type VaultConfig struct {
 
 	// ClientUserAgent is the User-Agent header that will be set on the client
 	// when making requests to Vault.
-	ClientUserAgent *string `mapstructure:"client_user_agent""`
+	ClientUserAgent *string `mapstructure:"client_user_agent"`
 
 	// DefaultLeaseDuration configures the default lease duration when not explicitly
 	// set by vault

--- a/dependency/catalog_datacenters_test.go
+++ b/dependency/catalog_datacenters_test.go
@@ -122,15 +122,12 @@ func TestCatalogDatacentersQuery_Fetch(t *testing.T) {
 		dataCh := make(chan interface{}, 1)
 		errCh := make(chan error, 1)
 		go func() {
-			for {
-				data, _, err := d.Fetch(testClients, &QueryOptions{WaitIndex: qm.LastIndex})
-				if err != nil {
-					errCh <- err
-					return
-				}
-				dataCh <- data
+			data, _, err := d.Fetch(testClients, &QueryOptions{WaitIndex: qm.LastIndex})
+			if err != nil {
+				errCh <- err
 				return
 			}
+			dataCh <- data
 		}()
 
 		select {

--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -85,7 +85,7 @@ func (q *QueryOptions) Merge(o *QueryOptions) *QueryOptions {
 		return &r
 	}
 
-	if o.AllowStale != false {
+	if o.AllowStale {
 		r.AllowStale = o.AllowStale
 	}
 
@@ -105,7 +105,7 @@ func (q *QueryOptions) Merge(o *QueryOptions) *QueryOptions {
 		r.Choose = o.Choose
 	}
 
-	if o.RequireConsistent != false {
+	if o.RequireConsistent {
 		r.RequireConsistent = o.RequireConsistent
 	}
 
@@ -197,9 +197,7 @@ type ResponseMetadata struct {
 // sorts and returns the copied result.
 func deepCopyAndSortTags(tags []string) []string {
 	newTags := make([]string, 0, len(tags))
-	for _, tag := range tags {
-		newTags = append(newTags, tag)
-	}
+	newTags = append(newTags, tags...)
 	sort.Strings(newTags)
 	return newTags
 }

--- a/dependency/kv_get_test.go
+++ b/dependency/kv_get_test.go
@@ -223,15 +223,12 @@ func TestKVGetQuery_Fetch(t *testing.T) {
 		dataCh := make(chan interface{}, 1)
 		errCh := make(chan error, 1)
 		go func() {
-			for {
-				data, _, err := d.Fetch(testClients, &QueryOptions{WaitIndex: qm.LastIndex})
-				if err != nil {
-					errCh <- err
-					return
-				}
-				dataCh <- data
+			data, _, err := d.Fetch(testClients, &QueryOptions{WaitIndex: qm.LastIndex})
+			if err != nil {
+				errCh <- err
 				return
 			}
+			dataCh <- data
 		}()
 
 		testConsul.SetKVString(t, "test-kv-get/key", "new-value")

--- a/dependency/kv_keys_test.go
+++ b/dependency/kv_keys_test.go
@@ -239,15 +239,12 @@ func TestKVKeysQuery_Fetch(t *testing.T) {
 		dataCh := make(chan interface{}, 1)
 		errCh := make(chan error, 1)
 		go func() {
-			for {
-				data, _, err := d.Fetch(testClients, &QueryOptions{WaitIndex: qm.LastIndex})
-				if err != nil {
-					errCh <- err
-					return
-				}
-				dataCh <- data
+			data, _, err := d.Fetch(testClients, &QueryOptions{WaitIndex: qm.LastIndex})
+			if err != nil {
+				errCh <- err
 				return
 			}
+			dataCh <- data
 		}()
 
 		testConsul.SetKVString(t, "test-kv-keys/prefix/zebra", "value")

--- a/dependency/kv_list_test.go
+++ b/dependency/kv_list_test.go
@@ -276,15 +276,12 @@ func TestKVListQuery_Fetch(t *testing.T) {
 		dataCh := make(chan interface{}, 1)
 		errCh := make(chan error, 1)
 		go func() {
-			for {
-				data, _, err := d.Fetch(testClients, &QueryOptions{WaitIndex: qm.LastIndex})
-				if err != nil {
-					errCh <- err
-					return
-				}
-				dataCh <- data
+			data, _, err := d.Fetch(testClients, &QueryOptions{WaitIndex: qm.LastIndex})
+			if err != nil {
+				errCh <- err
 				return
 			}
+			dataCh <- data
 		}()
 
 		testConsul.SetKVString(t, "test-kv-list/prefix/foo", "new-bar")

--- a/dependency/nomad_service_test.go
+++ b/dependency/nomad_service_test.go
@@ -178,20 +178,18 @@ func TestNomadServiceQuery_Fetch(t *testing.T) {
 
 			act := actI.([]*NomadService)
 
-			if act != nil {
-				for _, s := range act {
-					// Assert the shape of the randomized fields
-					assert.Regexp(t, "^_nomad-task.+", s.ID)
-					assert.Regexp(t, ".+-.+-.+-.+-.+", s.Node)
-					assert.NotZero(t, s.Port)
-					assert.Regexp(t, ".+-.+-.+-.+-.+", s.AllocID)
+			for _, s := range act {
+				// Assert the shape of the randomized fields
+				assert.Regexp(t, "^_nomad-task.+", s.ID)
+				assert.Regexp(t, ".+-.+-.+-.+-.+", s.Node)
+				assert.NotZero(t, s.Port)
+				assert.Regexp(t, ".+-.+-.+-.+-.+", s.AllocID)
 
-					// Clear randomized fields
-					s.ID = ""
-					s.Node = ""
-					s.Port = 0
-					s.AllocID = ""
-				}
+				// Clear randomized fields
+				s.ID = ""
+				s.Node = ""
+				s.Port = 0
+				s.AllocID = ""
 			}
 
 			assert.Equal(t, tc.exp, act)

--- a/dependency/nomad_var_get_test.go
+++ b/dependency/nomad_var_get_test.go
@@ -249,15 +249,12 @@ func TestNVGetQuery_Fetch(t *testing.T) {
 		dataCh := make(chan interface{}, 1)
 		errCh := make(chan error, 1)
 		go func() {
-			for {
-				data, _, err := d.Fetch(testClients, &QueryOptions{WaitIndex: qm.LastIndex})
-				if err != nil {
-					errCh <- err
-					return
-				}
-				dataCh <- data
+			data, _, err := d.Fetch(testClients, &QueryOptions{WaitIndex: qm.LastIndex})
+			if err != nil {
+				errCh <- err
 				return
 			}
+			dataCh <- data
 		}()
 
 		_ = testNomad.CreateVariable("test-kv-get/path", nvmap{"bar": "barp", "car": "carp"}, nil)

--- a/dependency/nomad_var_list_test.go
+++ b/dependency/nomad_var_list_test.go
@@ -313,15 +313,12 @@ func TestNVListQuery_Fetch(t *testing.T) {
 		dataCh := make(chan interface{}, 1)
 		errCh := make(chan error, 1)
 		go func() {
-			for {
-				data, _, err := d.Fetch(testClients, &QueryOptions{WaitIndex: qm.LastIndex})
-				if err != nil {
-					errCh <- err
-					return
-				}
-				dataCh <- data
+			data, _, err := d.Fetch(testClients, &QueryOptions{WaitIndex: qm.LastIndex})
+			if err != nil {
+				errCh <- err
 				return
 			}
+			dataCh <- data
 		}()
 
 		_ = testNomad.CreateVariable("test-kv-list/prefix/foo", nvmap{"new-bar": "new-barp"}, nil)

--- a/dependency/vault_list_test.go
+++ b/dependency/vault_list_test.go
@@ -188,15 +188,12 @@ func TestVaultListQuery_Fetch(t *testing.T) {
 		dataCh := make(chan interface{}, 1)
 		errCh := make(chan error, 1)
 		go func() {
-			for {
-				data, _, err := d.Fetch(clients, &QueryOptions{WaitIndex: qm.LastIndex})
-				if err != nil {
-					errCh <- err
-					return
-				}
-				dataCh <- data
+			data, _, err := d.Fetch(clients, &QueryOptions{WaitIndex: qm.LastIndex})
+			if err != nil {
+				errCh <- err
 				return
 			}
+			dataCh <- data
 		}()
 
 		select {

--- a/dependency/vault_read_test.go
+++ b/dependency/vault_read_test.go
@@ -210,15 +210,12 @@ func TestVaultReadQuery_Fetch_KVv1(t *testing.T) {
 		dataCh := make(chan interface{}, 1)
 		errCh := make(chan error, 1)
 		go func() {
-			for {
-				data, _, err := d.Fetch(clients, &QueryOptions{WaitIndex: qm.LastIndex})
-				if err != nil {
-					errCh <- err
-					return
-				}
-				dataCh <- data
+			data, _, err := d.Fetch(clients, &QueryOptions{WaitIndex: qm.LastIndex})
+			if err != nil {
+				errCh <- err
 				return
 			}
+			dataCh <- data
 		}()
 
 		select {
@@ -495,15 +492,12 @@ func TestVaultReadQuery_Fetch_KVv2(t *testing.T) {
 			dataCh := make(chan interface{}, 1)
 			errCh := make(chan error, 1)
 			go func() {
-				for {
-					data, _, err := d.Fetch(clients, &QueryOptions{WaitIndex: qm.LastIndex})
-					if err != nil {
-						errCh <- err
-						return
-					}
-					dataCh <- data
+				data, _, err := d.Fetch(clients, &QueryOptions{WaitIndex: qm.LastIndex})
+				if err != nil {
+					errCh <- err
 					return
 				}
+				dataCh <- data
 			}()
 
 			select {

--- a/dependency/vault_write.go
+++ b/dependency/vault_write.go
@@ -146,12 +146,6 @@ func sha1Map(m map[string]interface{}) string {
 	return fmt.Sprintf("%.4x", h.Sum(nil))
 }
 
-func (d *VaultWriteQuery) printWarnings(warnings []string) {
-	for _, w := range warnings {
-		log.Printf("[WARN] %s: %s", d, w)
-	}
-}
-
 func (d *VaultWriteQuery) writeSecret(clients *ClientSet, opts *QueryOptions) (*api.Secret, error) {
 	log.Printf("[TRACE] %s: PUT %s", d, &url.URL{
 		Path:     "/v1/" + d.path,

--- a/dependency/vault_write_test.go
+++ b/dependency/vault_write_test.go
@@ -306,15 +306,12 @@ func TestVaultWriteQuery_Fetch(t *testing.T) {
 		dataCh := make(chan interface{}, 1)
 		errCh := make(chan error, 1)
 		go func() {
-			for {
-				data, _, err := d.Fetch(clients, &QueryOptions{WaitIndex: qm.LastIndex})
-				if err != nil {
-					errCh <- err
-					return
-				}
-				dataCh <- data
+			data, _, err := d.Fetch(clients, &QueryOptions{WaitIndex: qm.LastIndex})
+			if err != nil {
+				errCh <- err
 				return
 			}
+			dataCh <- data
 		}()
 
 		select {

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -944,7 +944,7 @@ func (r *Runner) init(clients *dep.ClientSet) error {
 	dep.SetVaultLeaseRenewalThreshold(*r.config.Vault.LeaseRenewalThreshold)
 
 	// Create the watcher
-	r.watcher = newWatcher(r.config, clients, r.config.Once)
+	r.watcher = newWatcher(r.config, clients)
 
 	numTemplates := len(*r.config.Templates)
 	templates := make([]*template.Template, 0, numTemplates)
@@ -1398,7 +1398,7 @@ func NewClientSet(c *config.Config) (*dep.ClientSet, error) {
 }
 
 // newWatcher creates a new watcher.
-func newWatcher(c *config.Config, clients *dep.ClientSet, once bool) *watch.Watcher {
+func newWatcher(c *config.Config, clients *dep.ClientSet) *watch.Watcher {
 	log.Printf("[INFO] (runner) creating watcher")
 
 	return watch.NewWatcher(&watch.NewWatcherInput{


### PR DESCRIPTION
Minor fixes, including:

- Use a more descriptive `FileMode` in tests and in octal format to match `os.Filemode`
- Fix tag in `ClientUserAgent` field for `VaultConfig`
- Omit comparison to bool constants
- Remove unconditionally terminated loops from various tests
- Remove unused `printWarnings()` method from `VaultWriteQuery`
- Remove `once` parameter from `newWatcher()` as it's reachable through `config` parameter as well

Figured it would make sense to put it all into a single PR rather than multiple (almost) one-line changes :)