### PR TITLE
chore: refactor deprecated Vault calls

### DIFF
--- a/dependency/vault_common.go
+++ b/dependency/vault_common.go
@@ -81,8 +81,9 @@ func renewSecret(clients *ClientSet, d renewer) error {
 	log.Printf("[TRACE] %s: starting renewer", d)
 
 	secret, vaultSecret := d.secrets()
-	renewer, err := clients.Vault().NewRenewer(&api.RenewerInput{
-		Secret: vaultSecret,
+	renewer, err := clients.Vault().NewLifetimeWatcher(&api.LifetimeWatcherInput{
+		Secret:        vaultSecret,
+		RenewBehavior: api.RenewBehaviorErrorOnErrors,
 	})
 	if err != nil {
 		return err
@@ -303,8 +304,7 @@ func isKVv2(client *api.Client, path string) (string, bool, error) {
 	client.SetOutputCurlString(false)
 	defer client.SetOutputCurlString(currentOutputCurlString)
 
-	r := client.NewRequest("GET", "/v1/sys/internal/ui/mounts/"+path)
-	resp, err := client.RawRequest(r)
+	resp, err := client.Logical().ReadRaw("sys/internal/ui/mounts/" + path)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/dependency/vault_pki.go
+++ b/dependency/vault_pki.go
@@ -212,10 +212,6 @@ func (d *VaultPKIQuery) fetchPEMs(clients *ClientSet) ([]byte, error) {
 	return pems.Bytes(), nil
 }
 
-func (d *VaultPKIQuery) stopChan() chan struct{} {
-	return d.stopCh
-}
-
 // CanShare returns if this dependency is shareable.
 func (d *VaultPKIQuery) CanShare() bool {
 	return false

--- a/dependency/vault_read.go
+++ b/dependency/vault_read.go
@@ -82,7 +82,7 @@ func (d *VaultReadQuery) Fetch(clients *ClientSet, opts *QueryOptions,
 		}
 	}
 
-	err := d.fetchSecret(clients, opts)
+	err := d.fetchSecret(clients)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, d.String())
 	}
@@ -96,10 +96,8 @@ func (d *VaultReadQuery) Fetch(clients *ClientSet, opts *QueryOptions,
 	return respWithMetadata(d.secret)
 }
 
-func (d *VaultReadQuery) fetchSecret(clients *ClientSet, opts *QueryOptions,
-) error {
-	opts = opts.Merge(&QueryOptions{})
-	vaultSecret, err := d.readSecret(clients, opts)
+func (d *VaultReadQuery) fetchSecret(clients *ClientSet) error {
+	vaultSecret, err := d.readSecret(clients)
 	if err == nil {
 		printVaultWarnings(d, vaultSecret.Warnings)
 		d.vaultSecret = vaultSecret
@@ -140,7 +138,7 @@ func (d *VaultReadQuery) Type() Type {
 	return TypeVault
 }
 
-func (d *VaultReadQuery) readSecret(clients *ClientSet, opts *QueryOptions) (*api.Secret, error) {
+func (d *VaultReadQuery) readSecret(clients *ClientSet) (*api.Secret, error) {
 	vaultClient := clients.Vault()
 
 	// Check whether this secret refers to a KV v2 entry if we haven't yet.

--- a/dependency/vault_write_test.go
+++ b/dependency/vault_write_test.go
@@ -100,7 +100,7 @@ func TestVaultWriteSecretKV_Fetch(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		act, err := rq.readSecret(clients, nil)
+		act, err := rq.readSecret(clients)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -134,7 +134,7 @@ func TestVaultWriteSecretKV_Fetch(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		act, err := rq.readSecret(clients, nil)
+		act, err := rq.readSecret(clients)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -166,7 +166,7 @@ func TestVaultWriteSecretKV_Fetch(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		act, err := rq.readSecret(clients, nil)
+		act, err := rq.readSecret(clients)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Minor refactor for Vault related functionality in the `dependency` package:

- Use Vault `NewLifetimeWatcher()` instead of `NewWatcher()` as it is deprecated ([see API client reference here](https://github.com/hashicorp/vault/blob/api/v1.9.2/api/lifetime_watcher.go#L185C6-L187)). For compatibility purposes, `RenewBehaviour` is the same as with the previous functionality.
- Use Vault `ReadRaw()` instead of `RawRequest()` as it is deprecated ([see API client reference here](https://github.com/hashicorp/vault/blob/api/v1.9.2/api/client.go#L1279-L1288)).
- For `VaultReadQuery` dependency, remove `opts` from being passed further down to other functions as it is and won't be used. Query parameters (like `version`) for Vault read calls are stored in a separate `queryValues` field. Other dependencies which implement the same `Fetch()` interface (like `FileQuery`) won't pass it further either if the parameter is not needed.
- Remove unused `stopChan()` function from `VaultPKIQuery`.