### PR TITLE
chore(lint): gosimple

### DIFF
--- a/config/convert.go
+++ b/config/convert.go
@@ -36,10 +36,7 @@ func BoolGoString(b *bool) string {
 // BoolPresent returns a boolean indicating if the pointer is nil, or if the
 // pointer is pointing to the zero value..
 func BoolPresent(b *bool) bool {
-	if b == nil {
-		return false
-	}
-	return true
+	return b != nil
 }
 
 // FileMode returns a pointer to the given os.FileMode.
@@ -201,7 +198,7 @@ func TimeDurationGoString(t *time.Duration) string {
 	if t == nil {
 		return "(*time.Duration)(nil)"
 	}
-	return fmt.Sprintf("%s", t)
+	return t.String()
 }
 
 // TimeDurationPresent returns a boolean indicating if the pointer is nil, or if the pointer is pointing to the zero value..

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -1276,10 +1276,8 @@ func (q *quiescence) tick() {
 	if q.timer == nil {
 		q.timer = time.NewTimer(q.min)
 		go func() {
-			select {
-			case <-q.timer.C:
-				q.ch <- q.template
-			}
+			<-q.timer.C
+			q.ch <- q.template
 		}()
 
 		q.deadline = now.Add(q.max)

--- a/manager/runner_test.go
+++ b/manager/runner_test.go
@@ -1046,7 +1046,7 @@ func TestRunner_quiescence(t *testing.T) {
 		q.tick()
 		select {
 		case <-ch:
-			dur := time.Now().Sub(start)
+			dur := time.Since(start)
 			if dur < q.min || dur > 2*q.min {
 				t.Fatalf("bad duration %9.6f", dur.Seconds())
 			}
@@ -1072,7 +1072,7 @@ func TestRunner_quiescence(t *testing.T) {
 		q.tick()
 		select {
 		case <-ch:
-			dur := time.Now().Sub(start)
+			dur := time.Since(start)
 			if dur < q.min || dur > 2*q.min {
 				t.Fatalf("bad duration %9.6f", dur.Seconds())
 			}
@@ -1092,7 +1092,7 @@ func TestRunner_quiescence(t *testing.T) {
 		// cut off at the max time.
 		fired := false
 		start := time.Now()
-		for !fired && time.Now().Sub(start) < 2*q.max {
+		for !fired && time.Since(start) < 2*q.max {
 			q.tick()
 			time.Sleep(q.min / 2)
 			select {

--- a/watch/dependencies_test.go
+++ b/watch/dependencies_test.go
@@ -172,5 +172,5 @@ func (d *TestDepBlock) Fetch(clients *dep.ClientSet, opts *dep.QueryOptions) (in
 }
 
 func (d *TestDepBlock) String() string {
-	return fmt.Sprintf("test_dep_block")
+	return "test_dep_block"
 }


### PR DESCRIPTION
Lint fixes as per the `gosimple` linter:

- `S1025: should use String() instead of fmt.Sprintf`
- `S1000: should use a simple channel send/receive instead of 'select' with a single case`
- `S1039: unnecessary use of fmt.Sprintf`
- `S1008: should use 'return b != nil' instead of 'if b == nil { return false }; return true`
- `S1012: should use 'time.Since' instead of 'time.Now().Sub'`