### PR TITLE
chore: remove explicit math/rand seed

### DIFF
--- a/child/child.go
+++ b/child/child.go
@@ -19,12 +19,6 @@ import (
 	"github.com/hashicorp/consul-template/signals"
 )
 
-func init() {
-	// Seed the default rand Source with current time to produce better random
-	// numbers used with splay
-	rand.Seed(time.Now().UnixNano())
-}
-
 var (
 	// ErrMissingCommand is the error returned when no command is specified
 	// to run.


### PR DESCRIPTION
Go version was updated to 1.20 in #1783 and with that `math/rand` no longer requires an explicit seed for the random number generator. See https://github.com/golang/go/issues/54880 for more information. This PR removes that call.

Related to lint settings being worked on at #1774.