### PR TITLE
Update to use CRT prepare workflow

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -33,146 +33,17 @@ event "build" {
   }
 }
 
-event "upload-dev" {
+event "prepare" {
   depends = ["build"]
-  action "upload-dev" {
+  action "prepare" {
     organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "upload-dev"
-    depends = ["build"]
+    repository   = "crt-workflows-common"
+    workflow     = "prepare"
+    depends      = ["build"]
   }
 
   notification {
     on = "fail"
-  }
-}
-
-event "security-scan-binaries" {
-  depends = ["upload-dev"]
-  action "security-scan-binaries" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "security-scan-binaries"
-    config = "security-scan.hcl"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "security-scan-containers" {
-  depends = ["security-scan-binaries"]
-  action "security-scan-containers" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "security-scan-containers"
-    config = "security-scan.hcl"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "notarize-darwin-amd64" {
-  depends = ["security-scan-containers"]
-  action "notarize-darwin-amd64" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "notarize-darwin-amd64"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "notarize-windows-386" {
-  depends = ["notarize-darwin-amd64"]
-  action "notarize-windows-386" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "notarize-windows-386"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "notarize-windows-amd64" {
-  depends = ["notarize-windows-386"]
-  action "notarize-windows-amd64" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "notarize-windows-amd64"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "sign" {
-  depends = ["notarize-windows-amd64"]
-  action "sign" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "sign"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "sign-linux-rpms" {
-  depends = ["sign"]
-  action "sign-linux-rpms" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "sign-linux-rpms"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "verify" {
-  depends = ["sign-linux-rpms"]
-  action "verify" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "verify"
-  }
-
-  notification {
-    on = "always"
-  }
-}
-
-event "promote-dev-docker" {
-  depends = ["verify"]
-  action "promote-dev-docker" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "promote-dev-docker"
-    depends = ["verify"]
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "fossa-scan" {
-  depends = ["promote-dev-docker"]
-  action "fossa-scan" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "fossa-scan"
   }
 }
 

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -15,7 +15,6 @@ project "consul-template" {
     release_branches = [
       "main",
       "release/**",
-      "crt-move-to-prepare-workflow",
     ]
   }
 }

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -15,6 +15,7 @@ project "consul-template" {
     release_branches = [
       "main",
       "release/**",
+      "crt-move-to-prepare-workflow",
     ]
   }
 }


### PR DESCRIPTION
This update, moves consul-template to use the prepare workflow. This workflow encapsulates several previous workflows, running jobs in parallel to reduce the artifact processing time. See [here](https://hashicorp.atlassian.net/wiki/spaces/RELENG/pages/2489712686/Dec+7th+2022+-+Introducing+the+new+Prepare+workflow) for more info .

See successful prepare run here - https://github.com/hashicorp/crt-workflows-common/actions/runs/6420465781