### PR TITLE
Remove outdated instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,13 +434,6 @@ $ make dev
 This will compile the `consul-template` binary into `bin/consul-template` as
 well as your `$GOPATH` and run the test suite.
 
-If you want to compile a specific binary, set `XC_OS` and `XC_ARCH` or run the
-following to generate all binaries:
-
-```shell
-$ make build
-```
-
 If you want to run the tests, first install [consul](https://www.consul.io/docs/install/index.html), [nomad](https://learn.hashicorp.com/tutorials/nomad/get-started-install) and [vault](https://www.vaultproject.io/docs/install/) locally, then:
 
 ```shell


### PR DESCRIPTION
`make build` was removed a couple of version back from the makefile so this instructions are incorrect