### PR TITLE
[NET-1484] Support for namespaces, partitions in consul endpoints

### DIFF
--- a/dependency/catalog_node_test.go
+++ b/dependency/catalog_node_test.go
@@ -25,7 +25,7 @@ func TestNewCatalogNodeQuery(t *testing.T) {
 		},
 		{
 			"invalid query param (unsupported key)",
-			"key?unsupported=foo",
+			"node?unsupported=foo",
 			nil,
 			true,
 		},

--- a/dependency/catalog_node_test.go
+++ b/dependency/catalog_node_test.go
@@ -24,6 +24,12 @@ func TestNewCatalogNodeQuery(t *testing.T) {
 			false,
 		},
 		{
+			"invalid query param (unsupported key)",
+			"key?unsupported=foo",
+			nil,
+			true,
+		},
+		{
 			"bad",
 			"!4d",
 			nil,
@@ -32,6 +38,12 @@ func TestNewCatalogNodeQuery(t *testing.T) {
 		{
 			"dc_only",
 			"@dc1",
+			nil,
+			true,
+		},
+		{
+			"query_only",
+			"?ns=foo",
 			nil,
 			true,
 		},
@@ -49,6 +61,17 @@ func TestNewCatalogNodeQuery(t *testing.T) {
 			&CatalogNodeQuery{
 				name: "node",
 				dc:   "dc1",
+			},
+			false,
+		},
+		{
+			"every_option",
+			"node?ns=foo&partition=bar@dc1",
+			&CatalogNodeQuery{
+				name:      "node",
+				dc:        "dc1",
+				namespace: "foo",
+				partition: "bar",
 			},
 			false,
 		},

--- a/dependency/catalog_nodes_test.go
+++ b/dependency/catalog_nodes_test.go
@@ -24,6 +24,12 @@ func TestNewCatalogNodesQuery(t *testing.T) {
 			false,
 		},
 		{
+			"invalid query param (unsupported key)",
+			"key?unsupported=foo",
+			nil,
+			true,
+		},
+		{
 			"node",
 			"node",
 			nil,
@@ -34,6 +40,41 @@ func TestNewCatalogNodesQuery(t *testing.T) {
 			"@dc1",
 			&CatalogNodesQuery{
 				dc: "dc1",
+			},
+			false,
+		},
+		{
+			"namespace",
+			"?ns=foo",
+			&CatalogNodesQuery{
+				namespace: "foo",
+			},
+			false,
+		},
+		{
+			"partition",
+			"?partition=foo",
+			&CatalogNodesQuery{
+				partition: "foo",
+			},
+			false,
+		},
+		{
+			"namespace_and_partition",
+			"?ns=foo&partition=bar",
+			&CatalogNodesQuery{
+				namespace: "foo",
+				partition: "bar",
+			},
+			false,
+		},
+		{
+			"namespace_and_partition_and_near",
+			"?ns=foo&partition=bar~node1",
+			&CatalogNodesQuery{
+				namespace: "foo",
+				partition: "bar",
+				near:      "node1",
 			},
 			false,
 		},
@@ -51,6 +92,26 @@ func TestNewCatalogNodesQuery(t *testing.T) {
 			&CatalogNodesQuery{
 				dc:   "dc1",
 				near: "node1",
+			},
+			false,
+		},
+		{
+			"query_near",
+			"?ns=foo~node1",
+			&CatalogNodesQuery{
+				namespace: "foo",
+				near:      "node1",
+			},
+			false,
+		},
+		{
+			"every_option",
+			"?ns=foo&partition=bar@dc1~node1",
+			&CatalogNodesQuery{
+				dc:        "dc1",
+				near:      "node1",
+				partition: "bar",
+				namespace: "foo",
 			},
 			false,
 		},

--- a/dependency/catalog_service.go
+++ b/dependency/catalog_service.go
@@ -18,7 +18,7 @@ var (
 	_ Dependency = (*CatalogServiceQuery)(nil)
 
 	// CatalogServiceQueryRe is the regular expression to use.
-	CatalogServiceQueryRe = regexp.MustCompile(`\A` + tagRe + serviceNameRe + dcRe + nearRe + `\z`)
+	CatalogServiceQueryRe = regexp.MustCompile(`\A` + tagRe + serviceNameRe + queryRe + dcRe + nearRe + `\z`)
 )
 
 func init() {

--- a/dependency/catalog_service_test.go
+++ b/dependency/catalog_service_test.go
@@ -30,6 +30,18 @@ func TestNewCatalogServiceQuery(t *testing.T) {
 			true,
 		},
 		{
+			"query_only",
+			"?ns=foo",
+			nil,
+			true,
+		},
+		{
+			"invalid query param (unsupported key)",
+			"name?unsupported=foo",
+			nil,
+			true,
+		},
+		{
 			"near_only",
 			"~near",
 			nil,
@@ -59,12 +71,31 @@ func TestNewCatalogServiceQuery(t *testing.T) {
 			false,
 		},
 		{
+			"name_query",
+			"name?ns=foo",
+			&CatalogServiceQuery{
+				name:      "name",
+				namespace: "foo",
+			},
+			false,
+		},
+		{
 			"name_dc_near",
 			"name@dc1~near",
 			&CatalogServiceQuery{
 				dc:   "dc1",
 				name: "name",
 				near: "near",
+			},
+			false,
+		},
+		{
+			"name_query_near",
+			"name?ns=foo~near",
+			&CatalogServiceQuery{
+				name:      "name",
+				near:      "near",
+				namespace: "foo",
 			},
 			false,
 		},
@@ -107,13 +138,15 @@ func TestNewCatalogServiceQuery(t *testing.T) {
 			false,
 		},
 		{
-			"tag_name_dc_near",
-			"tag.name@dc~near",
+			"every_option",
+			"tag.name?ns=foo&partition=bar@dc~near",
 			&CatalogServiceQuery{
-				dc:   "dc",
-				name: "name",
-				near: "near",
-				tag:  "tag",
+				dc:        "dc",
+				name:      "name",
+				near:      "near",
+				tag:       "tag",
+				namespace: "foo",
+				partition: "bar",
 			},
 			false,
 		},

--- a/dependency/catalog_services_test.go
+++ b/dependency/catalog_services_test.go
@@ -24,6 +24,12 @@ func TestNewCatalogServicesQuery(t *testing.T) {
 			false,
 		},
 		{
+			"invalid query param (unsupported key)",
+			"?unsupported=foo",
+			nil,
+			true,
+		},
+		{
 			"node",
 			"node",
 			nil,
@@ -34,6 +40,41 @@ func TestNewCatalogServicesQuery(t *testing.T) {
 			"@dc1",
 			&CatalogServicesQuery{
 				dc: "dc1",
+			},
+			false,
+		},
+		{
+			"namespace",
+			"?ns=foo",
+			&CatalogServicesQuery{
+				namespace: "foo",
+			},
+			false,
+		},
+		{
+			"partition",
+			"?partition=foo",
+			&CatalogServicesQuery{
+				partition: "foo",
+			},
+			false,
+		},
+		{
+			"partition_and_namespace",
+			"?ns=foo&partition=bar",
+			&CatalogServicesQuery{
+				namespace: "foo",
+				partition: "bar",
+			},
+			false,
+		},
+		{
+			"partition_and_namespace_and_dc",
+			"?ns=foo&partition=bar@dc1",
+			&CatalogServicesQuery{
+				namespace: "foo",
+				partition: "bar",
+				dc:        "dc1",
 			},
 			false,
 		},

--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -23,7 +23,7 @@ const (
 	queryRe        = `(\?(?P<query>[[:word:]\-\_\=\&]+))?`
 	nodeNameRe     = `(?P<name>[[:word:]\.\-\_]+)`
 	nearRe         = `(~(?P<near>[[:word:]\.\-\_]+))?`
-	prefixRe       = `/?(?P<prefix>[^@]+)`
+	prefixRe       = `/?(?P<prefix>[^@\?]+)`
 	tagRe          = `((?P<tag>[[:word:]=:\.\-\_]+)\.)?`
 	regionRe       = `(@(?P<region>[[:word:]\.\-\_]+))?`
 	nvPathRe       = `/?(?P<path>[^@]+)`

--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -4,6 +4,7 @@
 package dependency
 
 import (
+	"fmt"
 	"net/url"
 	"regexp"
 	"sort"
@@ -148,6 +149,34 @@ func (q *QueryOptions) ToConsulOpts() *consulapi.QueryOptions {
 		WaitIndex:         q.WaitIndex,
 		WaitTime:          q.WaitTime,
 	}
+}
+
+// GetConsulQueryOpts parses optional consul query params into key pairs.
+// supports namespace, peer and partition params
+func GetConsulQueryOpts(queryMap map[string]string, endpointLabel string) (url.Values, error) {
+	queryParams := url.Values{}
+
+	if queryRaw := queryMap["query"]; queryRaw != "" {
+		var err error
+		queryParams, err = url.ParseQuery(queryRaw)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"%s: invalid query: %q: %s", endpointLabel, queryRaw, err)
+		}
+		// Validate keys.
+		for key := range queryParams {
+			switch key {
+			case QueryNamespace,
+				QueryPeer,
+				QueryPartition:
+			default:
+				return nil,
+					fmt.Errorf("%s: invalid query parameter key %q in query %q: supported keys: %s,%s,%s", endpointLabel, key, queryRaw, QueryNamespace, QueryPeer, QueryPartition)
+			}
+		}
+	}
+
+	return queryParams, nil
 }
 
 func (q *QueryOptions) ToNomadOpts() *nomadapi.QueryOptions {

--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	dcRe           = `(@(?P<dc>[[:word:]\.\-\_]+))?`
-	keyRe          = `/?(?P<key>[^@]+)`
+	keyRe          = `/?(?P<key>[^@\?]+)`
 	filterRe       = `(\|(?P<filter>[[:word:]\,]+))?`
 	serviceNameRe  = `(?P<name>[[:word:]\-\_]+)`
 	queryRe        = `(\?(?P<query>[[:word:]\-\_\=\&]+))?`

--- a/dependency/health_service.go
+++ b/dependency/health_service.go
@@ -117,26 +117,9 @@ func healthServiceQuery(s string, connect bool) (*HealthServiceQuery, error) {
 		filters = []string{HealthPassing}
 	}
 
-	// Parse optional query into key pairs.
-	queryParams := url.Values{}
-	if queryRaw := m["query"]; queryRaw != "" {
-		var err error
-		queryParams, err = url.ParseQuery(queryRaw)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"health.service: invalid query: %q: %s", queryRaw, err)
-		}
-		// Validate keys.
-		for key := range queryParams {
-			switch key {
-			case QueryNamespace,
-				QueryPeer,
-				QueryPartition:
-			default:
-				return nil,
-					fmt.Errorf("health.service: invalid query parameter key %q in query %q: supported keys: %s,%s,%s", key, queryRaw, QueryNamespace, QueryPeer, QueryPartition)
-			}
-		}
+	queryParams, err := GetConsulQueryOpts(m, "health.service")
+	if err != nil {
+		return nil, err
 	}
 
 	return &HealthServiceQuery{

--- a/dependency/kv_get.go
+++ b/dependency/kv_get.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"regexp"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/pkg/errors"
 )
 
@@ -39,7 +38,6 @@ func NewKVGetQuery(s string) (*KVGetQuery, error) {
 	}
 
 	m := regexpMatch(KVGetQueryRe, s)
-	spew.Dump(m["key"])
 	queryParams, err := GetConsulQueryOpts(m, "kv.get")
 	if err != nil {
 		return nil, err

--- a/dependency/kv_get_test.go
+++ b/dependency/kv_get_test.go
@@ -32,6 +32,18 @@ func TestNewKVGetQuery(t *testing.T) {
 			true,
 		},
 		{
+			"query_only",
+			"?ns=foo",
+			nil,
+			true,
+		},
+		{
+			"invalid query param (unsupported key)",
+			"key?unsupported=foo",
+			nil,
+			true,
+		},
+		{
 			"key",
 			"key",
 			&KVGetQuery{
@@ -45,6 +57,55 @@ func TestNewKVGetQuery(t *testing.T) {
 			&KVGetQuery{
 				key: "key",
 				dc:  "dc1",
+			},
+			false,
+		},
+		{
+			"partition",
+			"key?partition=foo",
+			&KVGetQuery{
+				key:       "key",
+				partition: "foo",
+			},
+			false,
+		},
+		{
+			"namespace",
+			"key?ns=foo",
+			&KVGetQuery{
+				key:       "key",
+				namespace: "foo",
+			},
+			false,
+		},
+		{
+			"namespace_and_partition",
+			"key?ns=foo&partition=bar",
+			&KVGetQuery{
+				key:       "key",
+				namespace: "foo",
+				partition: "bar",
+			},
+			false,
+		},
+		{
+			"namespace_and_partition_and_dc",
+			"key?ns=foo&partition=bar@dc1",
+			&KVGetQuery{
+				key:       "key",
+				namespace: "foo",
+				partition: "bar",
+				dc:        "dc1",
+			},
+			false,
+		},
+		{
+			"empty_query",
+			"key?ns=&partition=",
+			&KVGetQuery{
+				key:       "key",
+				namespace: "",
+				partition: "",
 			},
 			false,
 		},

--- a/dependency/kv_keys_test.go
+++ b/dependency/kv_keys_test.go
@@ -31,6 +31,18 @@ func TestNewKVKeysQuery(t *testing.T) {
 			true,
 		},
 		{
+			"query_only",
+			"?ns=foo",
+			nil,
+			true,
+		},
+		{
+			"invalid query param (unsupported key)",
+			"prefix?unsupported=foo",
+			nil,
+			true,
+		},
+		{
 			"prefix",
 			"prefix",
 			&KVKeysQuery{
@@ -44,6 +56,55 @@ func TestNewKVKeysQuery(t *testing.T) {
 			&KVKeysQuery{
 				prefix: "prefix",
 				dc:     "dc1",
+			},
+			false,
+		},
+		{
+			"partition",
+			"prefix?partition=foo",
+			&KVKeysQuery{
+				prefix:    "prefix",
+				partition: "foo",
+			},
+			false,
+		},
+		{
+			"namespace",
+			"prefix?ns=foo",
+			&KVKeysQuery{
+				prefix:    "prefix",
+				namespace: "foo",
+			},
+			false,
+		},
+		{
+			"namespace_and_partition",
+			"prefix?ns=foo&partition=bar",
+			&KVKeysQuery{
+				prefix:    "prefix",
+				namespace: "foo",
+				partition: "bar",
+			},
+			false,
+		},
+		{
+			"namespace_and_partition_and_dc",
+			"prefix?ns=foo&partition=bar@dc1",
+			&KVKeysQuery{
+				prefix:    "prefix",
+				namespace: "foo",
+				partition: "bar",
+				dc:        "dc1",
+			},
+			false,
+		},
+		{
+			"empty_query",
+			"prefix?ns=&partition=",
+			&KVKeysQuery{
+				prefix:    "prefix",
+				namespace: "",
+				partition: "",
 			},
 			false,
 		},

--- a/dependency/kv_list_test.go
+++ b/dependency/kv_list_test.go
@@ -31,6 +31,18 @@ func TestNewKVListQuery(t *testing.T) {
 			true,
 		},
 		{
+			"query_only",
+			"?ns=foo",
+			nil,
+			true,
+		},
+		{
+			"invalid query param (unsupported key)",
+			"prefix?unsupported=foo",
+			nil,
+			true,
+		},
+		{
 			"prefix",
 			"prefix",
 			&KVListQuery{
@@ -44,6 +56,55 @@ func TestNewKVListQuery(t *testing.T) {
 			&KVListQuery{
 				prefix: "prefix",
 				dc:     "dc1",
+			},
+			false,
+		},
+		{
+			"partition",
+			"prefix?partition=foo",
+			&KVListQuery{
+				prefix:    "prefix",
+				partition: "foo",
+			},
+			false,
+		},
+		{
+			"namespace",
+			"prefix?ns=foo",
+			&KVListQuery{
+				prefix:    "prefix",
+				namespace: "foo",
+			},
+			false,
+		},
+		{
+			"namespace_and_partition",
+			"prefix?ns=foo&partition=bar",
+			&KVListQuery{
+				prefix:    "prefix",
+				namespace: "foo",
+				partition: "bar",
+			},
+			false,
+		},
+		{
+			"namespace_and_partition_and_dc",
+			"prefix?ns=foo&partition=bar@dc1",
+			&KVListQuery{
+				prefix:    "prefix",
+				namespace: "foo",
+				partition: "bar",
+				dc:        "dc1",
+			},
+			false,
+		},
+		{
+			"empty_query",
+			"prefix?ns=&partition=",
+			&KVListQuery{
+				prefix:    "prefix",
+				namespace: "",
+				partition: "",
 			},
 			false,
 		},

--- a/docs/templating-language.md
+++ b/docs/templating-language.md
@@ -261,7 +261,13 @@ exist, Consul Template will block rendering until the key is present. To avoid
 blocking, use [`keyOrDefault`](#keyordefault) or [`keyExists`](#keyexists).
 
 ```golang
-{{ key "<PATH>@<DATACENTER>" }}
+{{ key "<PATH>?<QUERY>@<DATACENTER>" }}
+```
+
+The `<QUERY>` attribute is optional; if omitted, the `default` Consul namespace, `default` partition will be queried. `<QUERY>` can be used to set the Consul [namespace](https://developer.hashicorp.com/consul/api-docs/health#ns-2) or partition. `<QUERY>` accepts a url query-parameter format, e.g.:
+
+```golang
+{{ service "key?ns=namespace-name&partition=partition-name" }}
 ```
 
 The `<DATACENTER>` attribute is optional; if omitted, the local datacenter is

--- a/docs/templating-language.md
+++ b/docs/templating-language.md
@@ -399,10 +399,18 @@ To learn how [`safeLs`](#safels) was born see [CT-1131](https://github.com/hashi
 Query [Consul][consul] for a node in the catalog.
 
 ```golang
-{{node "<NAME>@<DATACENTER>"}}
+{{node "<NAME>?<QUERY>@<DATACENTER>"}}
 ```
 
 The `<NAME>` attribute is optional; if omitted, the local agent node is used.
+
+The `<QUERY>` attribute is optional; if omitted, the `default` Consul namespace, `default` partition will be queried. `<QUERY>` can be used to set the Consul [namespace](https://developer.hashicorp.com/consul/api-docs/health#ns-2) or partition. `<QUERY>` accepts a url query-parameter format, e.g.:
+
+```golang
+{{ with node "node?ns=default&partition=default" }}
+  {{ .Node.Address }}
+{{ end }}
+```
 
 The `<DATACENTER>` attribute is optional; if omitted, the local datacenter is
 used.
@@ -441,7 +449,13 @@ To access map data such as `TaggedAddresses` or `Meta`, use
 Query [Consul][consul] for all nodes in the catalog.
 
 ```golang
-{{ nodes "@<DATACENTER>~<NEAR>" }}
+{{ nodes "?<QUERY>@<DATACENTER>~<NEAR>" }}
+```
+The `<QUERY>` attribute is optional; if omitted, the `default` Consul namespace, `default` partition will be queried. `<QUERY>` can be used to set the Consul [namespace](https://developer.hashicorp.com/consul/api-docs/health#ns-2) or partition. `<QUERY>` accepts a url query-parameter format, e.g.:
+
+```golang
+{{ range nodes "?ns=namespace&partition=partition" }}
+{{ .Address }}{{ end }}
 ```
 
 The `<DATACENTER>` attribute is optional; if omitted, the local datacenter is
@@ -777,7 +791,15 @@ argument instead.
 Query [Consul][consul] for all services in the catalog.
 
 ```golang
-{{ services "@<DATACENTER>" }}
+{{ services "?<QUERY>@<DATACENTER>" }}
+```
+
+The `<QUERY>` attribute is optional; if omitted, the `default` Consul namespace, `default` partition will be queried. `<QUERY>` can be used to set the Consul [namespace](https://developer.hashicorp.com/consul/api-docs/health#ns-2) or partition. `<QUERY>` accepts a url query-parameter format, e.g.:
+
+```golang
+{{ range services "?ns=default&partition=default" }}
+  {{ .Name }}
+{{ end }}
 ```
 
 The `<DATACENTER>` attribute is optional; if omitted, the local datacenter is

--- a/docs/templating-language.md
+++ b/docs/templating-language.md
@@ -267,7 +267,7 @@ blocking, use [`keyOrDefault`](#keyordefault) or [`keyExists`](#keyexists).
 The `<QUERY>` attribute is optional; if omitted, the `default` Consul namespace, `default` partition will be queried. `<QUERY>` can be used to set the Consul [namespace](https://developer.hashicorp.com/consul/api-docs/health#ns-2) or partition. `<QUERY>` accepts a url query-parameter format, e.g.:
 
 ```golang
-{{ service "key?ns=namespace-name&partition=partition-name" }}
+{{ key "key?ns=namespace-name&partition=partition-name" }}
 ```
 
 The `<DATACENTER>` attribute is optional; if omitted, the local datacenter is
@@ -348,7 +348,15 @@ instead.
 Query [Consul][consul] for all top-level kv pairs at the given key path.
 
 ```golang
-{{ ls "<PATH>@<DATACENTER>" }}
+{{ ls "<PATH>?<QUERY>@<DATACENTER>" }}
+```
+
+The `<QUERY>` attribute is optional; if omitted, the `default` Consul namespace, `default` partition will be queried. `<QUERY>` can be used to set the Consul [namespace](https://developer.hashicorp.com/consul/api-docs/health#ns-2) or partition. `<QUERY>` accepts a url query-parameter format, e.g.:
+
+```golang
+{{ range ls "service/redis?ns=namespace-name&partition=partition-name" }}
+  {{ .Key }}:{{ .Value }}
+{{ end }}
 ```
 
 The `<DATACENTER>` attribute is optional; if omitted, the local datacenter is
@@ -358,7 +366,8 @@ For example:
 
 ```golang
 {{ range ls "service/redis" }}
-{{ .Key }}:{{ .Value }}{{ end }}
+  {{ .Key }}:{{ .Value }}
+{{ end }}
 ```
 
 renders


### PR DESCRIPTION
## TODO 

- [x] KV list endpoint 
- [x] KV keys endpoint 
- [x] KV get endpoint 
- [x] Catalog node endpoint
- [x] Catalog nodes endpoint 
- [x] catalog service endpoint 
- [x] catalog services endpoint 
- [x] Docs 

## How to test 
Note: ensure you have consul running 
### previous behavior is preserved 
- insert into kv in default namespace and partition 
```
consul kv put "hashi/test" "default"
```
- create a file `in.tpl`  insert the following to retrieve that key 
```
{{ key "hashi/test" }}
```
- ensure it can still read the key
```
consul-template -template "in.tpl:out.txt" -once
```
- verify: your `out.tpl` file should have:
```
default
```

### specify namespace/partition 
- create a new consul namespace/partition (sorry these names aren't too creative :D) 
```
consul partition create -name "partition"
consul namespace create -name "partition-ns" -partition "partition"
```
- store kv in the new partition/namespace created above
```
consul kv put -partition "partition" -namespace "partition-ns" "hashi/test" "part
ition"
```
- update your `in.tpl` to include namespace and partition
```
{{ key "hashi/test?partition=partition&ns=partition-ns" }}
```
- verify: your `out.tpl` file should have:
```
partition
```
