### PR TITLE
Make setpgid configurable for exec commands

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -350,6 +350,11 @@ func (cli *CLI) ParseFlags(args []string) (
 		return nil
 	}), "exec", "")
 
+	flags.Var((funcBoolVar)(func(b bool) error {
+		c.Exec.Setpgid = config.Bool(b)
+		return nil
+	}), "exec-setpgid", "")
+
 	flags.Var((funcVar)(func(s string) error {
 		sig, err := signals.Parse(s)
 		if err != nil {
@@ -780,6 +785,10 @@ Options:
       Enable exec mode to run as a supervisor-like process - the given command
       will receive all signals provided to the parent process and will receive a
       signal when templates change
+
+  -exec-setpgid
+	  Enable to send reload and kill signal to children of the child process or not.
+	  If unset, will try to detect the appropriate setting for the flag by examining the command.
 
   -exec-kill-signal=<signal>
       Signal to send when gracefully killing the process

--- a/cli_test.go
+++ b/cli_test.go
@@ -307,6 +307,17 @@ func TestCLI_ParseFlags(t *testing.T) {
 				Exec: &config.ExecConfig{
 					Enabled: config.Bool(true),
 					Command: []string{"command"},
+					Setpgid: nil,
+				},
+			},
+			false,
+		},
+		{
+			"exec-setpgid",
+			[]string{"-exec-setpgid=0"},
+			&config.Config{
+				Exec: &config.ExecConfig{
+					Setpgid: config.Bool(false),
 				},
 			},
 			false,

--- a/config/exec.go
+++ b/config/exec.go
@@ -38,6 +38,9 @@ type ExecConfig struct {
 	// Enabled controls if this exec is enabled.
 	Enabled *bool `mapstructure:"enabled"`
 
+	// Setpgid controls if the ReloadSignal and the KillSignal are propagated to the children of the child processes.
+	Setpgid *bool `mapstructure:"setpgid"`
+
 	// EnvConfig is the environmental customizations.
 	Env *EnvConfig `mapstructure:"env"`
 
@@ -89,6 +92,8 @@ func (c *ExecConfig) Copy() *ExecConfig {
 
 	o.Enabled = c.Enabled
 
+	o.Setpgid = c.Setpgid
+
 	if c.Env != nil {
 		o.Env = c.Env.Copy()
 	}
@@ -130,6 +135,10 @@ func (c *ExecConfig) Merge(o *ExecConfig) *ExecConfig {
 
 	if o.Enabled != nil {
 		r.Enabled = o.Enabled
+	}
+
+	if o.Setpgid != nil {
+		r.Setpgid = o.Setpgid
 	}
 
 	if o.Env != nil {
@@ -204,6 +213,7 @@ func (c *ExecConfig) GoString() string {
 	return fmt.Sprintf("&ExecConfig{"+
 		"Command:%s, "+
 		"Enabled:%s, "+
+		"Setpgid:%s, "+
 		"Env:%#v, "+
 		"KillSignal:%s, "+
 		"KillTimeout:%s, "+
@@ -213,6 +223,7 @@ func (c *ExecConfig) GoString() string {
 		"}",
 		c.Command,
 		BoolGoString(c.Enabled),
+		BoolGoString(c.Setpgid),
 		c.Env,
 		SignalGoString(c.KillSignal),
 		TimeDurationGoString(c.KillTimeout),


### PR DESCRIPTION
#1494 added the setpgid setting to ensure signals are propagated to all processes and not just the subshell. However, this might not always be desirable.

For instance, servers like uWSGI run workers in subprocesses and wait for workers to finish processing active requests for a while before restarting them to support graceful reloading. consul-template sending the reload signal to all processes, sends singals to these worker processes in uWSGI as well which can interfere with graceful reloads.

Currently, we are working around this by using the array form of the command which does not set the pgid on the child process. But I feel it might be useful to make this option configurable as well.

If the flag is unset, the existing behavior is retained.