### PR TITLE
use lifespan instead of duration for calculating when cert should be rotate

### DIFF
--- a/dependency/vault_pki.go
+++ b/dependency/vault_pki.go
@@ -40,7 +40,6 @@ type VaultPKIQuery struct {
 
 // NewVaultReadQuery creates a new datacenter dependency.
 func NewVaultPKIQuery(urlpath, filepath string, data map[string]interface{}) (*VaultPKIQuery, error) {
-	fmt.Println(filepath)
 	urlpath = strings.TrimSpace(urlpath)
 	urlpath = strings.Trim(urlpath, "/")
 	if urlpath == "" {
@@ -139,7 +138,6 @@ func goodFor(cert *x509.Certificate) (time.Duration, bool) {
 		return 0, false
 	}
 
-	fmt.Println("sleeping for ", sleepFor.Seconds())
 	return sleepFor, true
 }
 


### PR DESCRIPTION
closes #1612

The current logic for determining how long a certificate rotates depends on the duration (`time the certificate expires` - `the current time`) which seems to have weird corner cases that cause the certificate to be renewed at much later than 86-93% of the ttl which was originally intended. This updates the code to determine a `rotationTime` (i.e. the time that is NotBefore + 86-93% of the lifespan of the certificate) and sleeps until the `rotationTime` occurs.

Once this is merged, I can follow with a fix for https://github.com/hashicorp/consul-template/issues/1646