### PR TITLE
[NET-7571]SeatGeek

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 NEW FEATURES:
 * Add support for listing Consul peers [NET-6966](https://hashicorp.atlassian.net/browse/NET-6966)
 
+BUG FIXES:
+* Fetch services query not overriding opts correctly [NET-7571](https://hashicorp.atlassian.net/browse/NET-7571)
+
 ## v0.36.0 (January 3, 2024)
 
 IMPROVEMENTS:

--- a/dependency/catalog_services.go
+++ b/dependency/catalog_services.go
@@ -71,12 +71,8 @@ func (d *CatalogServicesQuery) Fetch(clients *ClientSet, opts *QueryOptions) (in
 	default:
 	}
 
-	// this overrides the query params present in the query
-	// i.e. overrides the namespace and partition params with ones used the first time
-	// while creating NewCatalogServicesQuery
-
+	// this overrides the query params present in the query with ones present while creating the query
 	// see bug [https://github.com/hashicorp/consul-template/pull/1842#issuecomment-1915723565]
-	// it should be other way around.
 	// default to the query params present while creating NewCatalogServicesQuery
 	// and then merge with the query params present in the query
 	defaultOpts := &QueryOptions{

--- a/dependency/catalog_services.go
+++ b/dependency/catalog_services.go
@@ -71,11 +71,21 @@ func (d *CatalogServicesQuery) Fetch(clients *ClientSet, opts *QueryOptions) (in
 	default:
 	}
 
-	opts = opts.Merge(&QueryOptions{
+	// this overrides the query params present in the query
+	// i.e. overrides the namespace and partition params with ones used the first time
+	// while creating NewCatalogServicesQuery
+
+	// see bug [https://github.com/hashicorp/consul-template/pull/1842#issuecomment-1915723565]
+	// it should be other way around.
+	// default to the query params present while creating NewCatalogServicesQuery
+	// and then merge with the query params present in the query
+	defaultOpts := &QueryOptions{
 		Datacenter:      d.dc,
 		ConsulPartition: d.partition,
 		ConsulNamespace: d.namespace,
-	})
+	}
+
+	opts = defaultOpts.Merge(opts)
 
 	log.Printf("[TRACE] %s: GET %s", d, &url.URL{
 		Path:     "/v1/catalog/services",

--- a/dependency/catalog_services_test.go
+++ b/dependency/catalog_services_test.go
@@ -129,13 +129,13 @@ func TestCatalogServicesQuery_Fetch(t *testing.T) {
 			false,
 		},
 		//no ENT support for test cases as of now.
-		{
-			"namespace_bar",
-			"?ns=bar&partition=default",
-			&QueryOptions{ConsulPartition: "default", ConsulNamespace: "bar"},
-			nil,
-			true,
-		},
+		//{
+		//	"namespace_bar",
+		//	"?ns=bar&partition=default",
+		//	&QueryOptions{ConsulPartition: "default", ConsulNamespace: "bar"},
+		//	nil,
+		//	true,
+		//},
 	}
 
 	for i, tc := range cases {

--- a/dependency/catalog_services_test.go
+++ b/dependency/catalog_services_test.go
@@ -124,13 +124,41 @@ func TestCatalogServicesQuery_Fetch(t *testing.T) {
 				},
 			},
 		},
+		// no ENT support as of now.
+		//{
+		//	"namespace_bar",
+		//	"?ns=bar&partition=default",
+		//	[]*CatalogSnippet{
+		//		{
+		//			Name: "consul",
+		//			Tags: ServiceTags([]string{}),
+		//		},
+		//		{
+		//			Name: "foobar-sidecar-proxy",
+		//			Tags: ServiceTags([]string{}),
+		//		},
+		//		{
+		//			Name: "service-meta",
+		//			Tags: ServiceTags([]string{"tag1"}),
+		//		},
+		//		{
+		//			Name: "service-taggedAddresses",
+		//			Tags: ServiceTags([]string{}),
+		//		},
+		//	},
+		//},
 	}
 
+	var d *CatalogServicesQuery
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
-			d, err := NewCatalogServicesQuery(tc.i)
-			if err != nil {
-				t.Fatal(err)
+
+			if i == 0 {
+				dq, err := NewCatalogServicesQuery(tc.i)
+				if err != nil {
+					t.Fatal(err)
+				}
+				d = dq
 			}
 
 			act, _, err := d.Fetch(testClients, nil)

--- a/dependency/catalog_services_test.go
+++ b/dependency/catalog_services_test.go
@@ -128,14 +128,6 @@ func TestCatalogServicesQuery_Fetch(t *testing.T) {
 			},
 			false,
 		},
-		//no ENT support for test cases as of now.
-		//{
-		//	"namespace_bar",
-		//	"?ns=bar&partition=default",
-		//	&QueryOptions{ConsulPartition: "default", ConsulNamespace: "bar"},
-		//	nil,
-		//	true,
-		//},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
- bug fix for SeatGeek: Services function in CT (consul-template) does not update the namespace for each services API call
- opts should be defaulted to the opts at query creation.
- then they should be merged with the opts present in Fetch.
- currently the merge was the other way around.
- ENT test support is not there, so no test cases added as of now.

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [x] CHANGELOG entry added
