### PR TITLE
VAULT-528 Fix issue with consul-template not rendering secrets with delete_version_after set on them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ NEW FEATURES:
 
 BUG FIXES:
 * Fetch services query not overriding opts correctly [NET-7571](https://hashicorp.atlassian.net/browse/NET-7571)
+* Consul-template now correctly renders KVv2 secrets with `delete_version_after` set [NET-3777](https://hashicorp.atlassian.net/browse/NET-3777)
 
 ## v0.36.0 (January 3, 2024)
 

--- a/dependency/vault_read.go
+++ b/dependency/vault_read.go
@@ -176,7 +176,20 @@ func (d *VaultReadQuery) readSecret(clients *ClientSet) (*api.Secret, error) {
 func deletedKVv2(s *api.Secret) bool {
 	switch md := s.Data["metadata"].(type) {
 	case map[string]interface{}:
-		return md["deletion_time"] != ""
+		deletionTime, ok := md["deletion_time"].(string)
+		if !ok {
+			// Not a string, end early
+			return false
+		}
+		t, err := time.Parse(time.RFC3339, deletionTime)
+		if err != nil {
+			// Deletion time is either empty, or not a valid string.
+			return false
+		}
+
+		// If now is 'after' the deletion time, then the secret
+		// should be deleted.
+		return time.Now().After(t)
 	}
 	return false
 }


### PR DESCRIPTION
Some background:

Initially, Vault secrets would only have `deletion_time` set on them if they'd been deleted. Since then, it has become possible to set deletion time in the future, using `delete_version_after` to indicate that a secret 'will' be deleted. As a result, the old logic to assume a secret is deleted if it has a deletion time has become naive.

Resolves https://github.com/hashicorp/consul-template/issues/1789
Resolves https://github.com/hashicorp/consul-template/issues/1778
Resolves https://discuss.hashicorp.com/t/consul-template-not-returning-vault-kv-items-with-deletion-time-set/55763