### PR TITLE
Create ServerErrCh to surface server errors back to caller.

### DIFF
--- a/manager/runner.go
+++ b/manager/runner.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/consul-template/template"
 	"github.com/hashicorp/consul-template/watch"
 
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
 )
 
 const (
@@ -37,6 +37,10 @@ type Runner struct {
 	// ErrCh and DoneCh are channels where errors and finish notifications occur.
 	ErrCh  chan error
 	DoneCh chan struct{}
+
+	// ServerCh is a channel to surface error responses from the server up the calling stack
+	// and will only hold a maximum of one error at a time
+	ServerCh chan error
 
 	// config is the Config that created this Runner. It is used internally to
 	// construct other objects and pass data.
@@ -199,6 +203,7 @@ func NewRunner(config *config.Config, dry bool) (*Runner, error) {
 	runner := &Runner{
 		ErrCh:         make(chan error),
 		DoneCh:        make(chan struct{}),
+		ServerCh:      make(chan error),
 		config:        config,
 		dry:           dry,
 		inStream:      os.Stdin,
@@ -434,11 +439,20 @@ func (r *Runner) Start() {
 			log.Printf("[ERR] (runner) watcher reported error: %s", err)
 			r.ErrCh <- err
 			return
-
+		case err := <-r.watcher.ServerCh():
+			// If we got a server error we push the error up the stack
+			log.Printf("[ERR] (runner) sending server error back to caller")
+			// Drain the error channel if anything already exists
+			select {
+			case <-r.ServerCh:
+				continue
+			default:
+			}
+			r.ServerCh <- err
+			goto OUTER
 		case err := <-r.vaultTokenWatcher.ErrCh():
 			// Push the error back up the stack
 			log.Printf("[ERR] (runner): %s", err)
-			r.ErrCh <- err
 			return
 
 		case tmpl := <-r.quiescenceCh:

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -203,7 +203,7 @@ func NewRunner(config *config.Config, dry bool) (*Runner, error) {
 	runner := &Runner{
 		ErrCh:         make(chan error),
 		DoneCh:        make(chan struct{}),
-		ServerErrCh:   make(chan error),
+		ServerErrCh:   make(chan error, 1),
 		config:        config,
 		dry:           dry,
 		inStream:      os.Stdin,

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -453,6 +453,7 @@ func (r *Runner) Start() {
 		case err := <-r.vaultTokenWatcher.ErrCh():
 			// Push the error back up the stack
 			log.Printf("[ERR] (runner): %s", err)
+			r.ErrCh <- err
 			return
 
 		case tmpl := <-r.quiescenceCh:

--- a/watch/view_test.go
+++ b/watch/view_test.go
@@ -127,7 +127,7 @@ func TestPoll_once(t *testing.T) {
 	case err := <-errCh:
 		t.Errorf("error while polling: %s", err)
 	case err := <-serverErrCh:
-		t.Errorf("server error while polling : %s", err)
+		t.Errorf("server error while polling: %s", err)
 	case <-view.stopCh:
 		t.Errorf("poll received premature stop")
 	case <-time.After(20 * time.Millisecond):

--- a/watch/view_test.go
+++ b/watch/view_test.go
@@ -20,8 +20,9 @@ func TestPoll_returnsViewCh(t *testing.T) {
 
 	viewCh := make(chan *View)
 	errCh := make(chan error)
+	serverErrCh := make(chan error)
 
-	go view.poll(viewCh, errCh)
+	go view.poll(viewCh, errCh, serverErrCh)
 	defer view.stop()
 
 	select {
@@ -44,8 +45,9 @@ func TestPoll_returnsErrCh(t *testing.T) {
 
 	viewCh := make(chan *View)
 	errCh := make(chan error)
+	serverErrCh := make(chan error)
 
-	go view.poll(viewCh, errCh)
+	go view.poll(viewCh, errCh, serverErrCh)
 	defer view.stop()
 
 	select {
@@ -53,9 +55,16 @@ func TestPoll_returnsErrCh(t *testing.T) {
 		t.Errorf("expected no data, but got %+v", data)
 	case err := <-errCh:
 		expected := "failed to contact server"
+		select {
+		case <-serverErrCh:
+			t.Errorf("sent server error, expected lookup error")
+		default:
+
+		}
 		if err.Error() != expected {
 			t.Errorf("expected %q to be %q", err.Error(), expected)
 		}
+
 	case <-view.stopCh:
 		t.Errorf("poll received premature stop")
 	}
@@ -71,8 +80,9 @@ func TestPoll_stopsViewStopCh(t *testing.T) {
 
 	viewCh := make(chan *View)
 	errCh := make(chan error)
+	serverErrCh := make(chan error)
 
-	go view.poll(viewCh, errCh)
+	go view.poll(viewCh, errCh, serverErrCh)
 	view.stop()
 
 	select {
@@ -80,6 +90,8 @@ func TestPoll_stopsViewStopCh(t *testing.T) {
 		t.Errorf("expected no data, but received view data")
 	case err := <-errCh:
 		t.Errorf("error while polling: %s", err)
+	case err := <-serverErrCh:
+		t.Errorf("server error while polling : %s", err)
 	case <-time.After(20 * time.Millisecond):
 		// No data was received, test passes
 	}
@@ -95,8 +107,9 @@ func TestPoll_once(t *testing.T) {
 
 	viewCh := make(chan *View)
 	errCh := make(chan error)
+	serverErrCh := make(chan error)
 
-	go view.poll(viewCh, errCh)
+	go view.poll(viewCh, errCh, serverErrCh)
 	defer view.stop()
 
 	select {
@@ -113,6 +126,8 @@ func TestPoll_once(t *testing.T) {
 		t.Errorf("expected no data (should have stopped), but received view data")
 	case err := <-errCh:
 		t.Errorf("error while polling: %s", err)
+	case err := <-serverErrCh:
+		t.Errorf("server error while polling : %s", err)
 	case <-view.stopCh:
 		t.Errorf("poll received premature stop")
 	case <-time.After(20 * time.Millisecond):
@@ -133,8 +148,9 @@ func TestPoll_retries(t *testing.T) {
 
 	viewCh := make(chan *View)
 	errCh := make(chan error)
+	serverErrCh := make(chan error)
 
-	go view.poll(viewCh, errCh)
+	go view.poll(viewCh, errCh, serverErrCh)
 	defer view.stop()
 
 	select {
@@ -142,6 +158,9 @@ func TestPoll_retries(t *testing.T) {
 		t.Errorf("should not have gotten data yet")
 	case <-time.After(100 * time.Millisecond):
 	}
+
+	// need to receive error to avoid timeout
+	<-serverErrCh
 
 	select {
 	case <-viewCh:
@@ -291,14 +310,17 @@ func TestStop_stopsPolling(t *testing.T) {
 
 	viewCh := make(chan *View)
 	errCh := make(chan error)
+	serverErrCh := make(chan error)
 
-	go view.poll(viewCh, errCh)
+	go view.poll(viewCh, errCh, serverErrCh)
 	view.stop()
 
 	select {
 	case v := <-viewCh:
 		t.Errorf("got unexpected view: %#v", v)
 	case err := <-errCh:
+		t.Error(err)
+	case err := <-serverErrCh:
 		t.Error(err)
 	case <-view.stopCh:
 		// Successfully stopped

--- a/watch/watcher.go
+++ b/watch/watcher.go
@@ -30,8 +30,8 @@ type Watcher struct {
 	// errCh is the chan where any errors will be published.
 	errCh chan error
 
-	// serverCh is the chan where response errors from the server will be published
-	serverCh chan error
+	// serverErrCh is the chan where response errors from the server will be published
+	serverErrCh chan error
 
 	// blockQueryWaitTime is amount of time in seconds to do a blocking query for
 	blockQueryWaitTime time.Duration
@@ -98,7 +98,7 @@ func NewWatcher(i *NewWatcherInput) *Watcher {
 		depViewMap:         make(map[string]*View),
 		dataCh:             make(chan *View, dataBufferSize),
 		errCh:              make(chan error),
-		serverCh:           make(chan error),
+		serverErrCh:        make(chan error),
 		maxStale:           i.MaxStale,
 		once:               i.Once,
 		blockQueryWaitTime: i.BlockQueryWaitTime,
@@ -125,13 +125,13 @@ func (w *Watcher) ErrCh() <-chan error {
 	return w.errCh
 }
 
-// ServerCh returns a read-only channel of errors returned by the server
+// ServerErrCh returns a read-only channel of errors returned by the server
 // as a response to each consul-template instance
-func (w *Watcher) ServerCh() <-chan error {
+func (w *Watcher) ServerErrCh() <-chan error {
 	if w == nil {
 		return nil
 	}
-	return w.serverCh
+	return w.serverErrCh
 }
 
 // Add adds the given dependency to the list of monitored dependencies
@@ -182,7 +182,7 @@ func (w *Watcher) Add(d dep.Dependency) (bool, error) {
 	log.Printf("[TRACE] (watcher) %s starting", d)
 
 	w.depViewMap[d.String()] = v
-	go v.poll(w.dataCh, w.errCh, w.serverCh)
+	go v.poll(w.dataCh, w.errCh, w.serverErrCh)
 
 	return true, nil
 }

--- a/watch/watcher.go
+++ b/watch/watcher.go
@@ -126,7 +126,7 @@ func (w *Watcher) ErrCh() <-chan error {
 }
 
 // ServerCh returns a read-only channel of errors returned by the server
-// as a response to each Consul instance
+// as a response to each consul-template instance
 func (w *Watcher) ServerCh() <-chan error {
 	if w == nil {
 		return nil

--- a/watch/watcher.go
+++ b/watch/watcher.go
@@ -30,6 +30,9 @@ type Watcher struct {
 	// errCh is the chan where any errors will be published.
 	errCh chan error
 
+	// serverCh is the chan where response errors from the server will be published
+	serverCh chan error
+
 	// blockQueryWaitTime is amount of time in seconds to do a blocking query for
 	blockQueryWaitTime time.Duration
 
@@ -95,6 +98,7 @@ func NewWatcher(i *NewWatcherInput) *Watcher {
 		depViewMap:         make(map[string]*View),
 		dataCh:             make(chan *View, dataBufferSize),
 		errCh:              make(chan error),
+		serverCh:           make(chan error),
 		maxStale:           i.MaxStale,
 		once:               i.Once,
 		blockQueryWaitTime: i.BlockQueryWaitTime,
@@ -119,6 +123,15 @@ func (w *Watcher) ErrCh() <-chan error {
 		return nil
 	}
 	return w.errCh
+}
+
+// ServerCh returns a read-only channel of errors returned by the server
+// as a response to each Consul instance
+func (w *Watcher) ServerCh() <-chan error {
+	if w == nil {
+		return nil
+	}
+	return w.serverCh
 }
 
 // Add adds the given dependency to the list of monitored dependencies
@@ -169,7 +182,7 @@ func (w *Watcher) Add(d dep.Dependency) (bool, error) {
 	log.Printf("[TRACE] (watcher) %s starting", d)
 
 	w.depViewMap[d.String()] = v
-	go v.poll(w.dataCh, w.errCh)
+	go v.poll(w.dataCh, w.errCh, w.serverCh)
 
 	return true, nil
 }


### PR DESCRIPTION
Creates a channel, ServerErrCh that will surface server errors back to the caller. This channel will hold a maximum of one error at a time. 

The purpose of this, is to allow Vault Agent and Vault Proxy to re-authenticate if the error message from the server indicates that the token is an "invalid token". More information on this initiative here: https://hermes.hashicorp.services/document/1yTtWJEvyoYLPkYRQ3lxs6dHmqAVyC177BMEBEXuu8fE?draft=false