### PR TITLE
Pre Release Updates for 0.37.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.37.5 (April 30, 2024)
+IMPROVEMENTS:
+* Formatting changes [GH-1901]https://github.com/hashicorp/consul-template/pull/1901
+* Use lifespan instead of duration when calculating TTL for PKI certificate renewal [GH-1865]https://github.com/hashicorp/consul-template/pull/1865
+* PKI Certificate renewal time can be configured using the VaultLeaseRenewal threshold value [GH-1908]https://github.com/hashicorp/consul-template/pull/1908
+
+BUG FIXES:
+* Fix linters [GH-1902]https://github.com/hashicorp/consul-template/pull/1902
+
+
 # 0.37.4 (March 27, 2024)
 IMPROVEMENTS:
 * Add a `ServerErrCh` to the runner that that will surface server errors back to the caller. [GH-1897](https://github.com/hashicorp/consul-template/pull/1897)

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ package version
 import "fmt"
 
 const (
-	Version           = "0.37.4"
+	Version           = "0.37.5"
 	VersionPrerelease = "" // "-dev", "-beta", "-rc1", etc. (include dash)
 )
 


### PR DESCRIPTION
We need to update the consul-template version so that it can be used to fix a Vault Issue : https://hashicorp.atlassian.net/browse/VAULT-16121 that does not regenerate pki certificates at the correct cadence.