### PR TITLE
[NET-9084] - change peering fetch test to assert blocking query behavior.

### DIFF
--- a/dependency/consul_peering_test.go
+++ b/dependency/consul_peering_test.go
@@ -119,7 +119,7 @@ func TestListPeeringsQuery_Fetch(t *testing.T) {
 		// create another peer
 		err = testClients.createConsulPeerings(tenancy)
 		require.NoError(t, err)
-		
+
 		select {
 		case err := <-errCh:
 			if err != ErrStopped {

--- a/dependency/consul_peering_test.go
+++ b/dependency/consul_peering_test.go
@@ -119,8 +119,7 @@ func TestListPeeringsQuery_Fetch(t *testing.T) {
 		// create another peer
 		err = testClients.createConsulPeerings(tenancy)
 		require.NoError(t, err)
-		time.Sleep(200 * time.Millisecond)
-
+		
 		select {
 		case err := <-errCh:
 			if err != ErrStopped {

--- a/dependency/consul_peering_test.go
+++ b/dependency/consul_peering_test.go
@@ -1,8 +1,13 @@
 package dependency
 
 import (
+	"context"
 	"fmt"
+	"github.com/hashicorp/consul-template/test"
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/require"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -59,47 +64,75 @@ func TestListPeeringsQuery(t *testing.T) {
 }
 
 func TestListPeeringsQuery_Fetch(t *testing.T) {
-	cases := []struct {
-		name string
-		i    string
-		exp  []string
-	}{
-		{
-			"all",
-			"",
-			// the peering generated has random IDs,
-			// we can't assert on the full response,
-			// we can assert on the peering names though.
-			[]string{
-				"bar",
-				"foo",
-			},
-		},
+	// the peering generated has random IDs,
+	// we can't assert on the full response,
+	// we can assert on the peering names though.
+	expectedPeerNames := []string{
+		"bar",
+		"foo",
 	}
 
-	for i, tc := range cases {
-		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
-			p, err := NewListPeeringQuery(tc.i)
+	p, err := NewListPeeringQuery("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, meta, err := p.Fetch(testClients, nil)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	peerNames := make([]string, 0)
+	for _, peering := range res.([]*Peering) {
+		peerNames = append(peerNames, peering.Name)
+	}
+	assert.Equal(t, expectedPeerNames, peerNames)
+
+	client := testClients.Consul()
+	th, err := test.NewTenancyHelper(client)
+	require.NoError(t, err)
+	if th.IsConsulEnterprise() {
+		// set up blocking query with last index
+		dataCh := make(chan interface{}, 1)
+		errCh := make(chan error, 1)
+		go func() {
+			data, _, err := p.Fetch(testClients, &QueryOptions{WaitIndex: meta.LastIndex})
 			if err != nil {
+				errCh <- err
+				return
+			}
+			dataCh <- data
+		}()
+
+		tenancy := th.Tenancy("default.baz")
+		ap := &api.Partition{Name: tenancy.Partition}
+		partition, _, err := client.Partitions().Create(context.Background(), ap, nil)
+		defer func() {
+			_, _ = client.Partitions().Delete(context.Background(), partition.Name, nil)
+		}()
+		require.NoError(t, err)
+		generateReq := api.PeeringGenerateTokenRequest{PeerName: "baz", Partition: tenancy.Partition}
+		_, _, err = client.Peerings().GenerateToken(context.Background(), generateReq, &api.WriteOptions{})
+		require.NoError(t, err)
+		defer func() {
+			_, _ = client.Peerings().Delete(context.Background(), generateReq.PeerName, nil)
+		}()
+
+		// create another peer
+		err = testClients.createConsulPeerings(tenancy)
+		require.NoError(t, err)
+		time.Sleep(200 * time.Millisecond)
+
+		select {
+		case err := <-errCh:
+			if err != ErrStopped {
 				t.Fatal(err)
 			}
-
-			res, _, err := p.Fetch(testClients, nil)
-			if err != nil {
-				t.Fatal(err)
+		case <-time.After(1 * time.Minute):
+			t.Errorf("did not stop")
+		case val := <-dataCh:
+			if val != nil {
+				require.Equal(t, 3, len(val.([]*Peering)))
 			}
-
-			if res == nil {
-				t.Fatalf("expected non-nil result")
-			}
-
-			peerNames := make([]string, 0)
-			for _, peering := range res.([]*Peering) {
-				peerNames = append(peerNames, peering.Name)
-			}
-
-			assert.Equal(t, tc.exp, peerNames)
-		})
+		}
 	}
 }
 


### PR DESCRIPTION
changed the `TestListPeeringsQuery_Fetch` test so that it also:
- creates a blocking query
- creates a new peer
- asserts that the blocking query detects the new peer.