### PR TITLE
also pass down max conns per host to consul and nomad http transports

### DIFF
--- a/dependency/client_set.go
+++ b/dependency/client_set.go
@@ -81,6 +81,7 @@ type CreateConsulClientInput struct {
 	TransportIdleConnTimeout     time.Duration
 	TransportMaxIdleConns        int
 	TransportMaxIdleConnsPerHost int
+	TransportMaxConnsPerHost     int
 	TransportTLSHandshakeTimeout time.Duration
 }
 
@@ -138,6 +139,7 @@ type CreateNomadClientInput struct {
 	TransportIdleConnTimeout     time.Duration
 	TransportMaxIdleConns        int
 	TransportMaxIdleConnsPerHost int
+	TransportMaxConnsPerHost     int
 	TransportTLSHandshakeTimeout time.Duration
 }
 
@@ -184,6 +186,7 @@ func (c *ClientSet) CreateConsulClient(i *CreateConsulClientInput) error {
 		MaxIdleConns:        i.TransportMaxIdleConns,
 		IdleConnTimeout:     i.TransportIdleConnTimeout,
 		MaxIdleConnsPerHost: i.TransportMaxIdleConnsPerHost,
+		MaxConnsPerHost:     i.TransportMaxConnsPerHost,
 		TLSHandshakeTimeout: i.TransportTLSHandshakeTimeout,
 	}
 
@@ -416,6 +419,7 @@ func (c *ClientSet) CreateNomadClient(i *CreateNomadClientInput) error {
 		MaxIdleConns:        i.TransportMaxIdleConns,
 		IdleConnTimeout:     i.TransportIdleConnTimeout,
 		MaxIdleConnsPerHost: i.TransportMaxIdleConnsPerHost,
+		MaxConnsPerHost:     i.TransportMaxConnsPerHost,
 		TLSHandshakeTimeout: i.TransportTLSHandshakeTimeout,
 	}
 

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -1372,6 +1372,7 @@ func NewClientSet(c *config.Config) (*dep.ClientSet, error) {
 		TransportIdleConnTimeout:     config.TimeDurationVal(c.Consul.Transport.IdleConnTimeout),
 		TransportMaxIdleConns:        config.IntVal(c.Consul.Transport.MaxIdleConns),
 		TransportMaxIdleConnsPerHost: config.IntVal(c.Consul.Transport.MaxIdleConnsPerHost),
+		TransportMaxConnsPerHost:     config.IntVal(c.Consul.Transport.MaxConnsPerHost),
 		TransportTLSHandshakeTimeout: config.TimeDurationVal(c.Consul.Transport.TLSHandshakeTimeout),
 	}); err != nil {
 		return nil, fmt.Errorf("runner: %s", err)
@@ -1428,6 +1429,7 @@ func NewClientSet(c *config.Config) (*dep.ClientSet, error) {
 		TransportIdleConnTimeout:     config.TimeDurationVal(c.Nomad.Transport.IdleConnTimeout),
 		TransportMaxIdleConns:        config.IntVal(c.Nomad.Transport.MaxIdleConns),
 		TransportMaxIdleConnsPerHost: config.IntVal(c.Nomad.Transport.MaxIdleConnsPerHost),
+		TransportMaxConnsPerHost:     config.IntVal(c.Nomad.Transport.MaxConnsPerHost),
 		TransportTLSHandshakeTimeout: config.TimeDurationVal(c.Nomad.Transport.TLSHandshakeTimeout),
 	}); err != nil {
 		return nil, fmt.Errorf("runner: %s", err)


### PR DESCRIPTION
following up https://github.com/hashicorp/consul-template/pull/1858 and https://github.com/hashicorp/consul-template/issues/1840 this change also makes use of the max_conns_per_host param for nomad and consul clients to make it consistent and to prevent dosing there

cc @ccapurso 