### PR TITLE
[NET-9610] Prep for release of v0.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.38.0 (June 3, 2024)
+
+NEW FEATURES:
+* Add support for listing Consul partitions [[GH-1940](https://github.com/hashicorp/consul-template/pull/1940)]
+* Add support for listing exported services in a Consul partition [[GH-1940](https://github.com/hashicorp/consul-template/pull/1940)]
+* Add support for grouping Consul services by port [[GH-1939](https://github.com/hashicorp/consul-template/pull/1939)]
+
 # 0.37.6 (May 6, 2024)
 BUG FIXES:
 * Fix shimkv2 concatenation [GH-1921]https://github.com/hashicorp/consul-template/pull/1921/

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ package version
 import "fmt"
 
 const (
-	Version           = "0.37.6"
+	Version           = "0.38.0"
 	VersionPrerelease = "" // "-dev", "-beta", "-rc1", etc. (include dash)
 )
 


### PR DESCRIPTION
This release adds functionality in a backwards-compatible manner:
- `byPort` function for grouping Consul services by port
- `partitions` function for listing Consul partitions in the local datacenter
- `exportedServices` function for listing services exported from a given partition