### PR TITLE
[NET-9900] Prep for release of v0.38.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.38.1 (June 6, 2024)
+
+IMPROVEMENTS:
+* Return expanded list for exportedServices instead of wildcard from configuration entry [[GH-1948](https://github.com/hashicorp/consul-template/pull/1948)]
+
+BUG FIXES:
+* Return the correct value for exportedServices when called multiple times with different partitions [[GH-1949](https://github.com/hashicorp/consul-template/pull/1949)]
+
 # 0.38.0 (June 3, 2024)
 
 NEW FEATURES:

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ package version
 import "fmt"
 
 const (
-	Version           = "0.38.0"
+	Version           = "0.38.1"
 	VersionPrerelease = "" // "-dev", "-beta", "-rc1", etc. (include dash)
 )
 


### PR DESCRIPTION
This release includes one bug fix and one improvement for the `exportedServices` function (see `CHANGELOG.md`)