### PR TITLE
feat: Add support for systemd notify

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,6 +85,7 @@ linters-settings:
           - github.com/pkg/errors
           - github.com/stretchr/testify/assert
           - github.com/stretchr/testify/require
+          - github.com/coreos/go-systemd
 
 run:
   timeout: 10m

--- a/cli.go
+++ b/cli.go
@@ -198,14 +198,12 @@ func (cli *CLI) Run(args []string) int {
 			case *config.KillSignal:
 				fmt.Fprintf(cli.errStream, "Cleaning up...\n")
 				runner.StopImmediately()
-				cancel() // Cancel the context to stop the readyCh goroutine
 				return ExitCodeInterrupt
 			default:
 				// Propagate the signal to the child process
 				runner.Signal(s)
 			}
 		case <-cli.stopCh:
-			cancel() // Cancel the context to stop the readyCh goroutine
 			return ExitCodeOK
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
+	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/fatih/color v1.17.0 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.3 // indirect
 	github.com/google/uuid v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/cenkalti/backoff/v3 v3.2.2/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4r
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
+github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
+github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -50,6 +52,7 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.2 h1:onZX1rnHT3Wv6cqNgYyFOOlgVKJrksuCMCRvJStbMYw=
 github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -310,14 +310,15 @@ func (r *Runner) Start() {
 
 		if r.allTemplatesRendered() {
 			log.Printf("[DEBUG] (runner) all templates rendered")
-			// Enable quiescence for all templates if we have specified wait
-			// intervals.
 
+			// Send a signal to systemd that we are ready.
 			_, err := daemon.SdNotify(false, daemon.SdNotifyReady)
 			if err != nil {
 				log.Printf("[WARN] (runner) failed to signal readiness to systemd: %v", err)
 			}
 
+			// Enable quiescence for all templates if we have specified wait
+			// intervals.
 		NEXT_Q:
 			for _, t := range r.templates {
 				if _, ok := r.quiescenceMap[t.ID()]; ok {

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -23,7 +23,6 @@ import (
 	"github.com/hashicorp/consul-template/template"
 	"github.com/hashicorp/consul-template/watch"
 
-	"github.com/coreos/go-systemd/v22/daemon"
 	"github.com/hashicorp/go-multierror"
 )
 
@@ -133,6 +132,12 @@ type Runner struct {
 	// Runner config. This prevents risk of data races when reading config for
 	// other elements started by the Runner, like template functions.
 	finalConfigCopy config.Config
+
+	// readyCh is a channel used to signal readiness to the systemd init system.
+	// When a struct{} is sent on this channel, it triggers a notification to systemd
+	// that the application is ready. This helps in managing application state and
+	// integration with systemd's readiness protocol.
+	readyCh chan struct{}
 }
 
 // RenderEvent captures the time and events that occurred for a template
@@ -311,10 +316,11 @@ func (r *Runner) Start() {
 		if r.allTemplatesRendered() {
 			log.Printf("[DEBUG] (runner) all templates rendered")
 
-			// Send a signal to systemd that we are ready.
-			_, err := daemon.SdNotify(false, daemon.SdNotifyReady)
-			if err != nil {
-				log.Printf("[WARN] (runner) failed to signal readiness to systemd: %v", err)
+			// If the readyCh channel is not nil, send an empty struct to signal readiness.
+			// This will notify the systemd init system that the application is ready to
+			// handle requests. This mechanism integrates with systemd's readiness protocol.
+			if r.readyCh != nil {
+				r.readyCh <- struct{}{}
 			}
 
 			// Enable quiescence for all templates if we have specified wait
@@ -728,6 +734,13 @@ func (r *Runner) Run() error {
 	}
 
 	return nil
+}
+
+// SetReadyChannel sets the readyCh channel which is used to signal readiness to the systemd init system.
+// The channel should be a struct{} channel, and when an empty struct is sent on this channel,
+// it will trigger a notification to systemd that the application is ready.
+func (r *Runner) SetReadyChannel(ch chan struct{}) {
+	r.readyCh = ch
 }
 
 type templateRunCtx struct {

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/consul-template/template"
 	"github.com/hashicorp/consul-template/watch"
 
+	"github.com/coreos/go-systemd/v22/daemon"
 	"github.com/hashicorp/go-multierror"
 )
 
@@ -311,6 +312,12 @@ func (r *Runner) Start() {
 			log.Printf("[DEBUG] (runner) all templates rendered")
 			// Enable quiescence for all templates if we have specified wait
 			// intervals.
+
+			_, err := daemon.SdNotify(false, daemon.SdNotifyReady)
+			if err != nil {
+				log.Printf("[WARN] (runner) failed to signal readiness to systemd: %v", err)
+			}
+
 		NEXT_Q:
 			for _, t := range r.templates {
 				if _, ok := r.quiescenceMap[t.ID()]; ok {


### PR DESCRIPTION
- Integrated systemd notification support using github.com/coreos/go-systemd/v22/daemon.
- Updated manager/runner.go to signal readiness to systemd.
- Modified .golangci.yml to include github.com/coreos/go-systemd in linters-settings.
- Updated dependencies in go.mod and go.sum for github.com/coreos/go-systemd/v22 v22.5.0.

**Purpose**:

- This enhancement enables the application to efficiently notify systemd about its readiness, improving overall service management capabilities and alignment with modern system practices.

See the description of PR #1794 and #1841 respectively for detail info.