### PR TITLE
Enhance with pkiCert template to return full CA chain

### DIFF
--- a/dependency/vault_pki_test.go
+++ b/dependency/vault_pki_test.go
@@ -238,7 +238,8 @@ func Test_VaultPKI_refetch(t *testing.T) {
 		t.Fatalf("expected a pems but found: %s", pems2)
 	}
 	// using cached copy, so should be a match
-	if pems1 != pems2 {
+
+	if !pems1.Equals(pems2) {
 		t.Errorf("pemss don't match and should.")
 	}
 
@@ -261,7 +262,7 @@ func Test_VaultPKI_refetch(t *testing.T) {
 		t.Fatalf("expected a pems but found: %s", pems2)
 	}
 
-	if pems2 == pems3 {
+	if pems2.Equals(pems3) {
 		t.Errorf("pemss match and shouldn't.")
 	}
 }


### PR DESCRIPTION
This is for Github issue https://github.com/hashicorp/consul-template/issues/1961

This provides the `CAChain` data on the `with pkiCert` function. This is necessary to support rotation of a intermediary CA without causing service interruptions.

Instead of using this template:
```
          {{- with pkiCert "pki/astundzia/issuing_ca/issue/genctl-consoleproxy-tls" "common_name=console-proxy.vpc.cloud.ibm.local" "format=pem" -}}
          {{ .Cert }}
          {{ .Key  }}
          {{ .Key | writeToFile "/etc/certs/client.key" "" "" "0644" }}
          {{ .Cert | writeToFile "/etc/certs/client.crt" "" "" "0644" }}
          {{- end }}
          {{- with secret "pki/astundzia/issuing_ca/cert/ca_chain" -}}
          {{- .Data.ca_chain }}
          {{- .Data.ca_chain | writeToFile "/etc/certs/client.crt" "" "" "0644" "append,newline" }}
          {{ end }}
```

I can instead just use:
```
          {{- with pkiCert "pki/astundzia/issuing_ca/issue/genctl-consoleproxy-tls" "common_name=console-proxy.vpc.cloud.ibm.local" "format=pem" -}}
          {{ .Cert }}
          {{ .Key  }}
          {{ .CAChain }}
          {{ .Key | writeToFile "/etc/certs/client.key" "" "" "0644" }}
          {{ .Cert | writeToFile "/etc/certs/client.crt" "" "" "0644" }}
          {{- range .CAChain }}
          {{- . | writeToFile "/etc/certs/client.crt" "" "" "0644" "append" }}
          {{- end }}
          {{- end }}
```

While similar, this has two critical benefits:
1. During intermediary CA rotation, the leaf certificate never expires. Vault agent is not aware nor should it be. The `with secret` however now pulls a new `ca_chain` which causes a client certificate to be created that is `{Leaf cert v1, Issuing CA V2}`. Since The leaf cert was issued by a different issuer (the previous one) the chain that vault-agent creates is invalid (Authority/signatures do not match).
2. Since `ca_chain` is returned on the `with pkiCert`, we no longer make a high number of API calls to vault `ca_chain` endpoint.

Without this code, we could not find a way to trust a single rootCA & support rotation of a intermediary CA/issuing CA.

This passes existing tests, and I've tested it manually using a self built version of the `vault 1.8.0-beta` code.

This also retains backwards compatibility (CA object on `with pkiCert` does not change functionally.

Please review!