### PR TITLE
fix(lint): govet and staticcheck issues

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2058,7 +2058,7 @@ func TestFinalize(t *testing.T) {
 				}
 			default:
 				if eq, err := tc.isEqual(tc.test, tc.expt); !eq {
-					t.Errorf(err.Error())
+					t.Error(err.Error())
 				}
 			}
 		})

--- a/dependency/catalog_datacenters.go
+++ b/dependency/catalog_datacenters.go
@@ -68,7 +68,7 @@ func (d *CatalogDatacentersQuery) Fetch(clients *ClientSet, opts *QueryOptions) 
 
 	result, err := clients.Consul().Catalog().Datacenters()
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, d.String())
+		return nil, nil, errors.Wrap(err, d.String())
 	}
 
 	// If the user opted in for skipping "down" datacenters, figure out which

--- a/dependency/catalog_node.go
+++ b/dependency/catalog_node.go
@@ -99,7 +99,7 @@ func (d *CatalogNodeQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interf
 		var err error
 		name, err = clients.Consul().Agent().NodeName()
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, d.String())
+			return nil, nil, errors.Wrap(err, d.String())
 		}
 	}
 

--- a/dependency/vault_pki_test.go
+++ b/dependency/vault_pki_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-// go:build ignore
+//go:build ignore
 
 package dependency
 

--- a/template/template.go
+++ b/template/template.go
@@ -298,7 +298,7 @@ func redactinator(used *dep.Set, b *Brain, err error) error {
 			}
 		}
 	}
-	return fmt.Errorf(strings.NewReplacer(pairs...).Replace(err.Error()))
+	return errors.New(strings.NewReplacer(pairs...).Replace(err.Error()))
 }
 
 // funcMapInput is input to the funcMap, which builds the template functions.


### PR DESCRIPTION
Fix the following quality-of-life issues:

- `govet`:
  - `printf: non-constant format string`
- `staticcheck`:
  - `SA9009: ineffectual compiler directive due to extraneous space: "// go:build ignore`    