### PR TITLE
fix: add quiescenceRun flag to avoid render loops

### DIFF
--- a/manager/runner.go
+++ b/manager/runner.go
@@ -99,8 +99,12 @@ type Runner struct {
 	// quiescenceMap is the map of templates to their quiescence timers.
 	// quiescenceCh is the channel where templates report returns from quiescence
 	// fires.
+	// quiescenceRun is the template that was triggered to render via
+	// its respective timer. This flag is an optimization used to avoid infinite
+	// rendering when multiple templates exist.
 	quiescenceMap map[string]*quiescence
 	quiescenceCh  chan *template.Template
+	quiescenceRun *template.Template
 
 	// dedup is the deduplication manager if enabled
 	dedup *DedupManager
@@ -474,6 +478,7 @@ func (r *Runner) Start() {
 			// Remove the quiescence for this template from the map. This will force
 			// the upcoming Run call to actually evaluate and render the template.
 			log.Printf("[DEBUG] (runner) received template %q from quiescence", tmpl.ID())
+			r.quiescenceRun = tmpl
 			delete(r.quiescenceMap, tmpl.ID())
 
 		case c := <-childExitCh:
@@ -666,6 +671,9 @@ func (r *Runner) Run() error {
 			}
 		}
 	}
+
+	// Always reset quiescenceRun in case this run was triggered by a quiescence timer
+	r.quiescenceRun = nil
 
 	// Perform the diff and update the known dependencies.
 	r.diffAndUpdateDeps(runCtx.depsMap)
@@ -890,6 +898,13 @@ func (r *Runner) runTemplate(tmpl *template.Template, runCtx *templateRunCtx) (*
 		if err := r.dedup.UpdateDeps(tmpl, used.List()); err != nil {
 			log.Printf("[ERR] (runner) failed to update dependency data for de-duplication: %v", err)
 		}
+	}
+
+	if r.quiescenceRun != nil && r.quiescenceRun != tmpl {
+		// During a run triggered via quiescence, mark any template not corresponding to
+		// the quiescence timer as ForQuiescence, signaling it was purposefully skipped.
+		event.ForQuiescence = true
+		return event, nil
 	}
 
 	// If quiescence is activated, start/update the timers and loop back around.

--- a/manager/runner_test.go
+++ b/manager/runner_test.go
@@ -945,17 +945,9 @@ func TestRunner_Start(t *testing.T) {
 	t.Run("multi-template-no-render-cycle", func(t *testing.T) {
 		testConsul.SetKVString(t, "multi-template-no-cycle-foo", "bar")
 
-		out1, err := os.CreateTemp("", "")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.Remove(out1.Name())
-
-		out2, err := os.CreateTemp("", "")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.Remove(out2.Name())
+		tmpDir := t.TempDir()
+		out1 := filepath.Join(tmpDir, "out1")
+		out2 := filepath.Join(tmpDir, "out2")
 
 		minWait := 1 * time.Second
 		maxWait := 10 * time.Second
@@ -971,11 +963,11 @@ func TestRunner_Start(t *testing.T) {
 			Templates: &config.TemplateConfigs{
 				&config.TemplateConfig{
 					Contents:    config.String(`{{ key "multi-template-no-cycle-foo" }}`),
-					Destination: config.String(out1.Name()),
+					Destination: config.String(out1),
 				},
 				&config.TemplateConfig{
 					Contents:    config.String(`foobar`),
-					Destination: config.String(out2.Name()),
+					Destination: config.String(out2),
 				},
 			},
 		})
@@ -994,7 +986,7 @@ func TestRunner_Start(t *testing.T) {
 		case err := <-r.ErrCh:
 			t.Fatal(err)
 		case <-r.renderedCh:
-			act, err := os.ReadFile(out2.Name())
+			act, err := os.ReadFile(out2)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1011,7 +1003,7 @@ func TestRunner_Start(t *testing.T) {
 		case err := <-r.ErrCh:
 			t.Fatal(err)
 		case <-r.renderedCh:
-			act, err := os.ReadFile(out1.Name())
+			act, err := os.ReadFile(out1)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1026,6 +1018,7 @@ func TestRunner_Start(t *testing.T) {
 		// Update the value we are watching, it should update after the quiescence timer fires
 		testConsul.SetKVString(t, "multi-template-no-cycle-foo", "bar_again")
 
+		renderCount := 0
 	OUTER:
 		// Wait for the quiescence timer to fire and the value to actually render to disk
 		for {
@@ -1033,12 +1026,13 @@ func TestRunner_Start(t *testing.T) {
 			case err := <-r.ErrCh:
 				t.Fatal(err)
 			case <-r.renderedCh:
-				act, err := os.ReadFile(out1.Name())
-				if err != nil {
-					t.Fatal(err)
-				}
-				exp := "bar_again"
-				if exp != string(act) {
+				// Run() will be called a total of 3 times when the dep is updated.
+				// The first run will tick both the templates quiescence timers, and return
+				// early without sending a render event. The next 2 runs will be from both the
+				// templates quiescence timers firing. We don't want to move on until both of
+				// those take place.
+				renderCount++
+				if renderCount < 2 {
 					continue
 				}
 				break OUTER


### PR DESCRIPTION
When quiescence is configured and there are multiple templates, they will trigger eachothers quiescence timers indefinitely. This can be avoided by not ticking the timer of other templates when an individual template's timer fires.

Fixes: [GH #1427](https://github.com/hashicorp/consul-template/issues/1427), [GH #20618](https://github.com/hashicorp/nomad/issues/20618)