### PR TITLE
support Vault KV subkeys to avoid consul-template adding /data/ to the path

### DIFF
--- a/dependency/vault_read.go
+++ b/dependency/vault_read.go
@@ -212,9 +212,9 @@ func shimKVv2Path(rawPath, mountPath, clientNamespace string) string {
 		// Trim (mount path - client namespace) from the raw path
 		p := strings.TrimPrefix(rawPath, rawPathNsAndMountPath)
 
-		// Only add /data/ prefix to the path if neither /data/ or /metadata/ are
+		// Only add /data/ prefix to the path if neither /data/, or /metadata/ or /subkeys/ are
 		// present.
-		if strings.HasPrefix(p, "data/") || strings.HasPrefix(p, "metadata/") {
+		if strings.HasPrefix(p, "data/") || strings.HasPrefix(p, "metadata/") || strings.HasPrefix(p, "subkeys/") {
 			return rawPath
 		}
 

--- a/dependency/vault_read_test.go
+++ b/dependency/vault_read_test.go
@@ -706,7 +706,22 @@ func TestShimKVv2Path(t *testing.T) {
 			"secret/",
 			"secret/data/foometadata/foo/bar",
 			"",
-		}, {
+		},
+		{
+			"prefix not added to subkeys",
+			"/secret/subkeys/foo",
+			"secret/",
+			"secret/subkeys/foo",
+			"",
+		},
+		{
+			"prefix added with subkeys* in subpath",
+			"/secret/subkeysfoo/foo/bar",
+			"secret/",
+			"secret/data/subkeysfoo/foo/bar",
+			"",
+		},
+		{
 			"prefix added to mount path",
 			"secret/",
 			"secret/",

--- a/dependency/vault_read_test.go
+++ b/dependency/vault_read_test.go
@@ -709,14 +709,14 @@ func TestShimKVv2Path(t *testing.T) {
 		},
 		{
 			"prefix not added to subkeys",
-			"/secret/subkeys/foo",
+			"secret/subkeys/foo",
 			"secret/",
 			"secret/subkeys/foo",
 			"",
 		},
 		{
 			"prefix added with subkeys* in subpath",
-			"/secret/subkeysfoo/foo/bar",
+			"secret/subkeysfoo/foo/bar",
 			"secret/",
 			"secret/data/subkeysfoo/foo/bar",
 			"",


### PR DESCRIPTION
Add support for the [Vault KV subkeys](https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#read-secret-subkeys) API path.

Cf. https://github.com/hashicorp/consul-template/issues/2015