### PR TITLE
fix: timeout issues for list.peerings

### DIFF
--- a/dependency/consul_peering.go
+++ b/dependency/consul_peering.go
@@ -99,12 +99,7 @@ func (l *ListPeeringQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interf
 		RawQuery: opts.String(),
 	})
 
-	// list peering is a blocking API, so making sure the ctx passed while calling it
-	// times out after the default wait time.
-	ctx, cancel := context.WithTimeout(context.Background(), DefaultContextTimeout)
-	defer cancel()
-
-	p, meta, err := clients.Consul().Peerings().List(ctx, opts.ToConsulOpts())
+	p, meta, err := clients.Consul().Peerings().List(context.Background(), opts.ToConsulOpts())
 	if err != nil {
 		return nil, nil, errors.Wrap(err, l.String())
 	}

--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -44,11 +44,6 @@ const (
 	TypeNomad
 )
 
-const (
-	// DefaultContextTimeout context wait timeout for blocking queries.
-	DefaultContextTimeout = 60 * time.Second
-)
-
 // Dependency is an interface for a dependency that Consul Template is capable
 // of watching.
 type Dependency interface {


### PR DESCRIPTION
The previously used `DefaultContextTimeout` does not work well with the user-definable `WaitTime`, which can easily exceed this global timeout.

Fixes #2041 