### PR TITLE
fix: pin golangci-lint version to v1.62.0 in workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Run linters
         uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
         with:
-          version: latest
+          version: v1.62.0


### PR DESCRIPTION
- pin golangci-lint version to v1.62.0 instead of using latest version in the lint workflow since lint action is failing with latest version.