### PR TITLE
fix: use 3.21 instead of latest for alpine in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 #   Release image
 #
 # ===================================
-FROM alpine:latest AS release-default
+FROM alpine:3.21 AS release-default
 
 ARG BIN_NAME=consul-template
 # Export BIN_NAME for the CMD below, it can't see ARGs directly.


### PR DESCRIPTION
- Use 3.21 version instead of latest for alpine in the Dockerfile.