### PR TITLE
Prep release/0.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.41.0 (June 5, 2025)
+
+IMPROVEMENTS:
+* feat: Pre-compute Sprig template functions during package init [GH-2052](https://github.com/hashicorp/consul-template/pull/2052)
+* update: go version to 1.24.3 [GH-2063](https://github.com/hashicorp/consul-template/pull/2063)
+* security: go-jose/v4 to v4.1.0 to fix CVE-2025-27144 [GH-2063](https://github.com/hashicorp/consul-template/pull/2063)
+* update: github.com/hashicorp/consul/api to v1.32.1 [GH-2063](https://github.com/hashicorp/consul-template/pull/2063)
+* update: github.com/hashicorp/vault/api to v1.16.0 [GH-2063](https://github.com/hashicorp/consul-template/pull/2063)
+
+BUG FIXES:
+* fix: timeout issues for list.peerings [GH-2042](https://github.com/hashicorp/consul-template/pull/2042)
+* fix: use 3.21 instead of latest for alpine in Dockerfile [GH-2064](https://github.com/hashicorp/consul-template/pull/2064)
+
 # 0.40.0 (February 14, 2025)
 
 IMPROVEMENTS:

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ package version
 import "fmt"
 
 const (
-	Version           = "0.40.1"
+	Version           = "0.41.0"
 	VersionPrerelease = "" // "-dev", "-beta", "-rc1", etc. (include dash)
 )
 


### PR DESCRIPTION
Preparation for release v0.41.0:
- [add: changelog for release v0.41.0](https://github.com/hashicorp/consul-template/commit/bcd6a9a4e23189fe02687369550923082dce8bf7)
- [update: version to 0.41.0 for release](https://github.com/hashicorp/consul-template/commit/cceffa33fc58a6f95a9d538a7b0e13d9ee360014)