### PR TITLE
update: suppress open alpine vulnerabilities

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -5,6 +5,15 @@ container {
 	dependencies = true
 	alpine_secdb = true
 	secrets      = true
+	triage {
+		suppress {
+			vulnerabilites = [
+				"CVE-2024-58251",	# fix unavailable at time of writing
+				"CVE-2025-46394"	# fix unavailable at time of writing
+			]
+		}
+	}
+
 }
 
 binary {


### PR DESCRIPTION
Suppress the following vulnerabilities in alpine since no fix is available at this point:
- CVE-2025-46394
- CVE-2024-58251