### PR TITLE
Enhance File Sandbox Security and Add Comprehensive Path Handling Tests

### DIFF
--- a/dependency/file.go
+++ b/dependency/file.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -32,7 +31,6 @@ type FileQuery struct {
 
 // NewFileQuery creates a file dependency from the given path.
 func NewFileQuery(s string) (*FileQuery, error) {
-	s = strings.TrimSpace(s)
 	if s == "" {
 		return nil, fmt.Errorf("file: invalid format: %q", s)
 	}


### PR DESCRIPTION
### feat(security): Harden file sandboxing and path handling

This pull request improves the security and reliability of file sandboxing and path handling in Consul Template. It addresses potential vulnerabilities related to symlink and path confusion attacks by enforcing stricter path validation and adds comprehensive unit tests for edge cases.

---

### Description

This change hardens the file sandbox functionality to prevent potential security vulnerabilities where a malicious template could escape the sandbox or disclose sensitive data. By normalizing, resolving, and using absolute paths for all checks and file operations, we mitigate the risk of symlink and path manipulation attacks.

The primary benefits are:
* **Stronger Security**: Ensures sandbox boundaries are strictly enforced and mitigates risks of unauthorized file disclosure.
* **Better Reliability**: Guarantees consistent path handling across all file operations and improves cross-platform compatibility.

There are no breaking changes to public APIs.

---

### Key Changes

* **Sandbox Enforcement**:
    * Improved `pathInSandbox` and `fileFunc` to use normalized, resolved, and absolute paths for all sandbox checks and file reads.
    * Prevents symlink and path manipulation attacks that could otherwise escape the sandbox.

* **Path Handling**:
    * Removed unsafe path trimming from `NewFileQuery` to ensure the exact path checked is the one accessed.
    * Ensures all file operations use the same, fully-resolved path for both validation and reading.

* **Comprehensive Testing**:
    * Added robust unit tests covering sandbox boundaries, symlink escapes, and files with leading/trailing spaces.
    * Tests automatically skip scenarios unsupported by the underlying filesystem (e.g., trailing spaces on macOS).

---

### Notes

* Filesystems like macOS APFS/HFS+ do not support trailing spaces in filenames; related tests are skipped on these platforms.



## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
