### PR TITLE
Secvuln 25354 tob consul 25 3 symlink vulnerability in file sandbox enforcement due to inconsistent whitespace trimming fix

### DIFF
--- a/dependency/file.go
+++ b/dependency/file.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -32,7 +31,6 @@ type FileQuery struct {
 
 // NewFileQuery creates a file dependency from the given path.
 func NewFileQuery(s string) (*FileQuery, error) {
-	s = strings.TrimSpace(s)
 	if s == "" {
 		return nil, fmt.Errorf("file: invalid format: %q", s)
 	}

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -218,7 +218,7 @@ func fileFunc(b *Brain, used, missing *dep.Set, sandboxPath string) func(string)
 
 		// Normalize and resolve symlinks BEFORE both sandbox check and file query
 		normalized := strings.TrimSpace(s)
-		err := pathInSandbox(normalized, s)
+		err := pathInSandbox(sandboxPath, normalized)
 		if err != nil {
 			return "", err
 		}

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -218,15 +218,11 @@ func fileFunc(b *Brain, used, missing *dep.Set, sandboxPath string) func(string)
 
 		// Normalize and resolve symlinks BEFORE both sandbox check and file query
 		normalized := strings.TrimSpace(s)
-		resolved, err := filepath.EvalSymlinks(filepath.Clean(normalized))
+		err := pathInSandbox(normalized, s)
 		if err != nil {
 			return "", err
 		}
-		err = pathInSandbox(sandboxPath, resolved)
-		if err != nil {
-			return "", err
-		}
-		d, err := dep.NewFileQuery(resolved)
+		d, err := dep.NewFileQuery(s)
 		if err != nil {
 			return "", err
 		}
@@ -1803,18 +1799,8 @@ func pathInSandbox(sandbox, path string) error {
 		return fmt.Errorf("failed to resolve target path: %w", err)
 	}
 
-	// Get absolute paths
-	sandboxAbs, err := filepath.Abs(sandboxResolved)
-	if err != nil {
-		return fmt.Errorf("failed to get absolute sandbox path: %w", err)
-	}
-	targetAbs, err := filepath.Abs(targetResolved)
-	if err != nil {
-		return fmt.Errorf("failed to get absolute target path: %w", err)
-	}
-
 	// Check containment
-	rel, err := filepath.Rel(sandboxAbs, targetAbs)
+	rel, err := filepath.Rel(sandboxResolved, targetResolved)
 	if err != nil {
 		return fmt.Errorf("failed to get relative path: %w", err)
 	}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -324,12 +324,12 @@ func TestTemplate_Execute(t *testing.T) {
 		{
 			"func_file",
 			&NewTemplateInput{
-				Contents: `{{ file "/path/to/file" }}`,
+				Contents: fmt.Sprintf(`{{ file "%s" }}`, f.Name()),
 			},
 			&ExecuteInput{
 				Brain: func() *Brain {
 					b := NewBrain()
-					d, err := dep.NewFileQuery("/path/to/file")
+					d, err := dep.NewFileQuery(f.Name())
 					if err != nil {
 						t.Fatal(err)
 					}


### PR DESCRIPTION
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
