### PR TITLE
Fix missing timestamps in file logging output

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -119,7 +119,9 @@ func newWriter(config *Config) (io.Writer, error) {
 		if err := logFile.openNew(); err != nil {
 			return nil, fmt.Errorf("error setting up log_file logging : %w", err)
 		}
-		logOutput = io.MultiWriter(logOutput, logFile)
+		// Wrap the log file with timestamp formatting to match console output
+		logFileWithTimestamp := logWriter{out: logFile}
+		logOutput = io.MultiWriter(logOutput, logFileWithTimestamp)
 	}
 
 	if config.Syslog {


### PR DESCRIPTION
Problem: ( Fixes  #1714 issue)
When using file logging (log_file configuration), log messages written to files lack timestamps, while console output includes them. This inconsistency makes it difficult to correlate events and analyze logs when file logging is used.

The issue occurs because the MultiWriter sends logs to both console (with timestamp wrapper) and file (without timestamp wrapper) outputs.

Solution:
Wrap the file writer with the same logWriter that adds timestamps to console output. This ensures both console and file logs have identical timestamp formatting while preserving all existing functionality including log rotation.

Changes:
- Modified logging/logging.go to wrap logFile with logWriter before adding to MultiWriter
- Preserves log rotation, filtering, and all other existing features
- No configuration changes required
- Maintains same performance characteristics

Fixes timestamp inconsistency between console and file logging output.
before solution - 
<img width="716" height="223" alt="image" src="https://github.com/user-attachments/assets/7e783845-a95a-46f3-bd9b-bb54503a8c0b" />
after bug fix - 
<img width="848" height="230" alt="image" src="https://github.com/user-attachments/assets/63112437-02d2-4630-aa8d-aa3aa13dcb6f" />
