### PR TITLE
Security Fix: Prevent ParseTemplateConfig panic on malformed input

### DIFF
--- a/config/template.go
+++ b/config/template.go
@@ -572,6 +572,8 @@ func ParseTemplateConfig(s string) (*TemplateConfig, error) {
 	parts := configTemplateRe.FindAllString(s, -1)
 
 	switch len(parts) {
+	case 0:
+		return nil, ErrTemplateStringEmpty
 	case 1:
 		source = parts[0]
 	case 2:

--- a/config/template_test.go
+++ b/config/template_test.go
@@ -570,6 +570,18 @@ func TestParseTemplateConfig(t *testing.T) {
 			true,
 		},
 		{
+			"colon_only",
+			":",
+			nil,
+			true,
+		},
+		{
+			"multiple_colons_only",
+			":::",
+			nil,
+			true,
+		},
+		{
 			"default",
 			"/tmp/a.txt:/tmp/b.txt:command",
 			&TemplateConfig{


### PR DESCRIPTION
## Summary
Fixes a security vulnerability in `ParseTemplateConfig` where certain malformed inputs could cause a runtime panic due to improper handling of empty regex matches.

## Problem
The function `ParseTemplateConfig` was vulnerable to runtime panics when processing inputs like `:` or `:::`. The regular expression `configTemplateRe.FindAllString(s, -1)` would return an empty slice for such inputs, but the `default` case in the switch statement assumed `parts[0]` and `parts[1]` would always exist, causing an "index out of range" panic.

## Solution
- Added a new `case 0:` to handle empty parts slices and return `ErrTemplateStringEmpty`
- Added comprehensive test cases for edge cases including `:` and `:::`
- Maintains backward compatibility while eliminating the panic vulnerability

## Security Impact
- **Before**: Malformed inputs could cause runtime panics, potentially leading to denial of service
- **After**: Such inputs now return proper error handling instead of panicking

## Changes
- `config/template.go`: Added case 0 handling in ParseTemplateConfig switch statement
- `config/template_test.go`: Added test cases for "colon_only" and "multiple_colons_only" scenarios

## Testing
- ✅ All existing tests pass
- ✅ New test cases validate the fix
- ✅ Manual verification confirms vulnerability is resolved

## References
- Addresses SECVULN-14566
- Follows security recommendations for input validation