### PR TITLE
fix dirty commits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           mkdir dist out
           cp LICENSE dist/LICENSE.txt
-          go build -o dist/ -ldflags "-s -w -X $(go list -m)/version.GitCommit=$(git rev-parse --short HEAD)" .
+          go build -buildvcs=false -o dist/ -ldflags "-s -w -X $(go list -m)/version.GitCommit=$(git rev-parse --short HEAD)" .
           zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -144,7 +144,7 @@ jobs:
         run: |
           mkdir dist out
           cp LICENSE dist/LICENSE.txt
-          go build -o dist/ -ldflags "-s -w -X $(go list -m)/version.GitCommit=$(git rev-parse --short HEAD)" .
+          go build -buildvcs=false -o dist/ -ldflags "-s -w -X $(go list -m)/version.GitCommit=$(git rev-parse --short HEAD)" .
           zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,12 @@
 /vendor
 consul-template
 
+### Build artifacts that can make git status dirty
+dist/LICENSE
+dist/LICENSE.txt
+*.zip
+out/
+
 ### Golang ###
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ dev:
 
 # dev docker builds
 docker:
-	@env CGO_ENABLED="0" go build -ldflags "${LD_FLAGS}" -o $(NAME)
+	@env CGO_ENABLED="0" go build -buildvcs=false -ldflags "${LD_FLAGS}" -o $(NAME)
 	mkdir -p dist/linux/amd64/
 	cp consul-template dist/linux/amd64/
 	env DOCKER_BUILDKIT=1 docker build -t consul-template .


### PR DESCRIPTION
Add `-buildvcs=false` flag to all `go build` commands, which disables embedding VCS (version control system) information during builds. This can help avoid issues with reproducibility or unnecessary build metadata.
And also clean the workspace before building (.gitignore changes) for having non dirty commits.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
