### PR TITLE
cve: fix sandbox path bypass in file helper through symlink attack

### DIFF
--- a/template/funcs.go
+++ b/template/funcs.go
@@ -242,13 +242,11 @@ func fileFunc(b *Brain, used, missing *dep.Set, sandboxPath string) func(string)
 			return "", nil
 		}
 
-		// Normalize and resolve symlinks BEFORE both sandbox check and file query
-		normalized := strings.TrimSpace(s)
-		err := pathInSandbox(sandboxPath, normalized)
+		resolvedPath, err := resolveSandboxedPath(sandboxPath, strings.TrimSpace(s))
 		if err != nil {
 			return "", err
 		}
-		d, err := dep.NewFileQuery(s)
+		d, err := dep.NewFileQuery(resolvedPath)
 		if err != nil {
 			return "", err
 		}
@@ -1811,30 +1809,35 @@ func denied(...string) (string, error) {
 // pathInSandbox returns an error if the provided path doesn't fall within the
 // sandbox or if the file can't be evaluated (missing, invalid symlink, etc.)
 func pathInSandbox(sandbox, path string) error {
+	_, err := resolveSandboxedPath(sandbox, path)
+	return err
+}
+
+func resolveSandboxedPath(sandbox, path string) (string, error) {
 	if sandbox == "" {
-		return nil
+		return filepath.Clean(path), nil
 	}
 
 	// Clean and resolve symlinks for both paths
 	sandboxResolved, err := filepath.EvalSymlinks(filepath.Clean(sandbox))
 	if err != nil {
-		return fmt.Errorf("failed to resolve sandbox path: %w", err)
+		return "", fmt.Errorf("failed to resolve sandbox path: %w", err)
 	}
 	targetResolved, err := filepath.EvalSymlinks(filepath.Clean(path))
 	if err != nil {
-		return fmt.Errorf("failed to resolve target path: %w", err)
+		return "", fmt.Errorf("failed to resolve target path: %w", err)
 	}
 
 	// Check containment
 	rel, err := filepath.Rel(sandboxResolved, targetResolved)
 	if err != nil {
-		return fmt.Errorf("failed to get relative path: %w", err)
+		return "", fmt.Errorf("failed to get relative path: %w", err)
 	}
 	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return fmt.Errorf("'%s' is outside of sandbox", path)
+		return "", fmt.Errorf("'%s' is outside of sandbox", path)
 	}
 
-	return nil
+	return targetResolved, nil
 }
 
 // sockaddr wraps go-sockaddr templating

--- a/template/funcs_test.go
+++ b/template/funcs_test.go
@@ -463,3 +463,45 @@ func Test_importedServicesFunc_emptyPartition(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "partition name is required")
 }
+
+func TestFileFunc_SandboxSymlinkRestoreShouldNotReuseCachedDependencyOutsideContents(t *testing.T) {
+	sandboxDir := t.TempDir()
+	outsideDir := t.TempDir()
+
+	safePath := filepath.Join(sandboxDir, "safe.txt")
+	require.NoError(t, os.WriteFile(safePath, []byte("safe"), 0o644))
+
+	secretPath := filepath.Join(outsideDir, "secret.txt")
+	secret := "outside-sandbox-secret"
+	require.NoError(t, os.WriteFile(secretPath, []byte(secret), 0o644))
+
+	linkPath := filepath.Join(sandboxDir, "watched.txt")
+	if err := os.Symlink(safePath, linkPath); err != nil {
+		t.Skipf("skipping symlink test: %v", err)
+	}
+
+	brain := NewBrain()
+	used := &dep.Set{}
+	missing := &dep.Set{}
+	file := fileFunc(brain, used, missing, sandboxDir)
+
+	_, err := file(linkPath)
+	require.NoError(t, err)
+
+	d := used.List()[0]
+
+	require.NoError(t, os.Remove(linkPath))
+	require.NoError(t, os.Symlink(secretPath, linkPath))
+
+	fetched, _, err := d.Fetch(nil, nil)
+	require.NoError(t, err)
+	brain.Remember(d, fetched)
+
+	require.NoError(t, os.Remove(linkPath))
+	require.NoError(t, os.Symlink(safePath, linkPath))
+	require.NoError(t, pathInSandbox(sandboxDir, linkPath))
+
+	value, err := file(linkPath)
+	require.NoError(t, err)
+	require.NotEqual(t, secret, value)
+}


### PR DESCRIPTION
The file template helper enforces sandbox_path during template evaluation, but the later dependency fetch reads the original raw path without re-checking the sandbox. This creates a time-of-check to time-of-use gap. If an attacker can retarget a symlink or equivalent link target after validation but before dependency fetch, consul-template can read an out-of-sandbox file and then render the cached contents even after the link is restored to an in-sandbox target.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
