### PR TITLE
fix: Make Vault sleeps cancelable to prevent leaked goroutines

### DIFF
--- a/dependency/vault_pki.go
+++ b/dependency/vault_pki.go
@@ -98,7 +98,15 @@ func (d *VaultPKIQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interface
 	}
 	select {
 	case dur := <-d.sleepCh:
-		time.Sleep(dur)
+		timer := time.NewTimer(dur)
+		select {
+		case <-timer.C:
+		case <-d.stopCh:
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return nil, nil, ErrStopped
+		}
 	default:
 	}
 

--- a/dependency/vault_read.go
+++ b/dependency/vault_read.go
@@ -64,10 +64,14 @@ func (d *VaultReadQuery) Fetch(clients *ClientSet, opts *QueryOptions,
 	}
 	select {
 	case dur := <-d.sleepCh:
+		timer := time.NewTimer(dur)
 		select {
-		case <-time.After(dur):
-			break
+		case <-timer.C:
+			// continue
 		case <-d.stopCh:
+			if !timer.Stop() {
+				<-timer.C
+			}
 			return nil, nil, ErrStopped
 		}
 	default:

--- a/dependency/vault_write.go
+++ b/dependency/vault_write.go
@@ -61,7 +61,15 @@ func (d *VaultWriteQuery) Fetch(clients *ClientSet, opts *QueryOptions,
 	}
 	select {
 	case dur := <-d.sleepCh:
-		time.Sleep(dur)
+		timer := time.NewTimer(dur)
+		select {
+		case <-timer.C:
+		case <-d.stopCh:
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return nil, nil, ErrStopped
+		}
 	default:
 	}
 


### PR DESCRIPTION
We had our Vault Agents DDoS our Vault cluster due to accumulated leaked goroutines that all woke up at the same time (thousands of them).

The agents in question were missing access to a particular secret they were requesting. This meant they restarted the consul template runner after 12 tries (approximately every 5 min).

Over the period of 27 days we saw a slow buildup of goroutines which then _all_ suddenly woke up. Initially we suspected authentication renewal (our agent token is 30 days), but that was ruled out.

Eventually we found out the `vault_pki` file has a goroutine which sleeps until 90% of a PKI's cert expiry - which in our case is 30 days - and thus slept until 27 days after cert issuance. Critically, on an consul template runner restart these goroutines don't respond to the stop channel, but instead continue sleeping until 90% of the cert is expired.

This PR makes the sleep paths in Vault dependencies cancelable so goroutines exit promptly when a runner is stopped.