### PR TITLE
fix: handle json.Number in parseInt, parseFloat, and parseUint

### DIFF
--- a/template/funcs.go
+++ b/template/funcs.go
@@ -1185,26 +1185,47 @@ func parseBool(s string) (bool, error) {
 	return result, nil
 }
 
-// parseFloat parses a string into a floating-point number with 64-bit precision
-func parseFloat(s string) (float64, error) {
-	if s == "" {
+// parseFloat parses a string or json.Number into a floating-point number with
+// 64-bit precision.
+func parseFloat(s interface{}) (float64, error) {
+	var str string
+	switch v := s.(type) {
+	case string:
+		str = v
+	case json.Number:
+		str = v.String()
+	default:
+		return 0, fmt.Errorf("parseFloat: unsupported type %T", s)
+	}
+
+	if str == "" {
 		return 0.0, nil
 	}
 
-	result, err := strconv.ParseFloat(s, 64)
+	result, err := strconv.ParseFloat(str, 64)
 	if err != nil {
 		return 0, errors.Wrap(err, "parseFloat")
 	}
 	return result, nil
 }
 
-// parseInt parses a string into a base 10 int
-func parseInt(s string) (int64, error) {
-	if s == "" {
+// parseInt parses a string or json.Number into a base 10 int
+func parseInt(s interface{}) (int64, error) {
+	var str string
+	switch v := s.(type) {
+	case string:
+		str = v
+	case json.Number:
+		str = v.String()
+	default:
+		return 0, fmt.Errorf("parseInt: unsupported type %T", s)
+	}
+
+	if str == "" {
 		return 0, nil
 	}
 
-	result, err := strconv.ParseInt(s, 10, 64)
+	result, err := strconv.ParseInt(str, 10, 64)
 	if err != nil {
 		return 0, errors.Wrap(err, "parseInt")
 	}
@@ -1224,13 +1245,23 @@ func parseJSON(s string) (interface{}, error) {
 	return data, nil
 }
 
-// parseUint parses a string into a base 10 int
-func parseUint(s string) (uint64, error) {
-	if s == "" {
+// parseUint parses a string or json.Number into a base 10 unsigned int
+func parseUint(s interface{}) (uint64, error) {
+	var str string
+	switch v := s.(type) {
+	case string:
+		str = v
+	case json.Number:
+		str = v.String()
+	default:
+		return 0, fmt.Errorf("parseUint: unsupported type %T", s)
+	}
+
+	if str == "" {
 		return 0, nil
 	}
 
-	result, err := strconv.ParseUint(s, 10, 64)
+	result, err := strconv.ParseUint(str, 10, 64)
 	if err != nil {
 		return 0, errors.Wrap(err, "parseUint")
 	}

--- a/template/funcs_test.go
+++ b/template/funcs_test.go
@@ -4,6 +4,7 @@
 package template
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -504,4 +505,87 @@ func TestFileFunc_SandboxSymlinkRestoreShouldNotReuseCachedDependencyOutsideCont
 	value, err := file(linkPath)
 	require.NoError(t, err)
 	require.NotEqual(t, secret, value)
+}
+
+func TestParseInt_jsonNumber(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   interface{}
+		want    int64
+		wantErr bool
+	}{
+		{"string", "42", 42, false},
+		{"json.Number", json.Number("42"), 42, false},
+		{"json.Number negative", json.Number("-7"), -7, false},
+		{"empty string", "", 0, false},
+		{"invalid string", "abc", 0, true},
+		{"invalid json.Number", json.Number("abc"), 0, true},
+		{"unsupported type", 3.14, 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseInt(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestParseFloat_jsonNumber(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   interface{}
+		want    float64
+		wantErr bool
+	}{
+		{"string", "3.14", 3.14, false},
+		{"json.Number", json.Number("3.14"), 3.14, false},
+		{"json.Number negative", json.Number("-2.5"), -2.5, false},
+		{"empty string", "", 0.0, false},
+		{"invalid string", "abc", 0, true},
+		{"invalid json.Number", json.Number("abc"), 0, true},
+		{"unsupported type", 42, 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseFloat(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.InDelta(t, tc.want, got, 0.001)
+			}
+		})
+	}
+}
+
+func TestParseUint_jsonNumber(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   interface{}
+		want    uint64
+		wantErr bool
+	}{
+		{"string", "42", 42, false},
+		{"json.Number", json.Number("42"), 42, false},
+		{"empty string", "", 0, false},
+		{"invalid string", "abc", 0, true},
+		{"invalid json.Number", json.Number("abc"), 0, true},
+		{"unsupported type", 3.14, 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseUint(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Problem

The `parseInt`, `parseFloat`, and `parseUint` template functions only accepted `string` arguments. When JSON data is parsed with `json.Decoder.UseNumber()` (or returned from Vault with numeric values), numeric values become `json.Number` — a named string type that Go's template engine cannot auto-convert to `string`.

This means templates like `{{ .Data.ttl | parseInt }}` fail when the value comes from a source that uses `json.Number`.

## Fix

Changed the function signatures from `func(s string)` to `func(s interface{})` with type switches that handle both `string` and `json.Number` inputs. Unsupported types return a clear error message.

## Testing

- All existing tests pass (template integration tests for `parseInt`, `parseFloat`, `parseUint`)
- Added 20 new unit tests covering `json.Number` inputs, empty strings, invalid values, and unsupported types
- `go vet` and `goimports` clean

Fixes #1584