### PR TITLE
fix(vault_read): don't cache isKVv2 fallback on probe error

### DIFF
--- a/dependency/vault_read.go
+++ b/dependency/vault_read.go
@@ -146,19 +146,32 @@ func (d *VaultReadQuery) readSecret(clients *ClientSet) (*api.Secret, error) {
 	vaultClient := clients.Vault()
 
 	// Check whether this secret refers to a KV v2 entry if we haven't yet.
+	//
+	// Cache only on a SUCCESSFUL probe (err == nil). On a transient probe
+	// failure (e.g. Vault context deadline exceeded during startup) the
+	// "assume not v2" fallback is used for this one read attempt but is
+	// NOT cached, so the next Fetch() call re-probes once Vault is healthy.
+	// Caching the failure-fallback permanently latched the dependency into
+	// v1 mode for the lifetime of the process, even after Vault recovered
+	// — see issue #2149.
 	if d.isKVv2 == nil {
 		mountPath, isKVv2, err := isKVv2(vaultClient, d.rawPath)
 		if err != nil {
 			log.Printf("[WARN] %s: failed to check if %s is KVv2, "+
-				"assume not: %s", d, d.rawPath, err)
-			isKVv2 = false
+				"assume not (will re-probe on next fetch): %s",
+				d, d.rawPath, err)
 			d.secretPath = d.rawPath
+			// Intentionally do not set d.isKVv2 here: a transient Vault
+			// failure must not poison this dependency for the process
+			// lifetime. The next Fetch() will re-enter this block and
+			// probe again.
 		} else if isKVv2 {
 			d.secretPath = shimKVv2Path(d.rawPath, mountPath, clients.Vault().Namespace())
+			d.isKVv2 = &isKVv2
 		} else {
 			d.secretPath = d.rawPath
+			d.isKVv2 = &isKVv2
 		}
-		d.isKVv2 = &isKVv2
 	}
 
 	queryString := d.queryValues.Encode()

--- a/dependency/vault_read_test.go
+++ b/dependency/vault_read_test.go
@@ -879,3 +879,62 @@ func TestDeletedKVv2(t *testing.T) {
 		Data: map[string]interface{}{},
 	}))
 }
+
+// TestVaultReadQuery_isKVv2_NotCachedOnProbeError verifies the fix for
+// hashicorp/consul-template#2149: a transient failure of the isKVv2 mount
+// probe must NOT poison d.isKVv2 with the assumed-not-v2 fallback. Caching
+// the failure-fallback permanently latched the dependency into KV v1 mode
+// for the lifetime of the process, even after Vault recovered — which
+// caused fresh KV v2 reads to keep failing with "Invalid path for a
+// versioned K/V secrets engine" until the agent was restarted.
+//
+// Post-fix: after a failed probe, d.isKVv2 stays nil so the next Fetch()
+// re-enters the probe block and re-detects the mount type once Vault is
+// reachable again.
+func TestVaultReadQuery_isKVv2_NotCachedOnProbeError(t *testing.T) {
+	// Build a fresh ClientSet pointed at an unreachable Vault address.
+	// The isKVv2 probe (GET sys/internal/ui/mounts/<path>) will fail with
+	// a connection error — exactly the transient-error shape from #2149
+	// (the field repro was context-deadline-exceeded against a Vault that
+	// recovered seconds later).
+	clients := NewClientSet()
+	if err := clients.CreateVaultClient(&CreateVaultClientInput{
+		Address:              "http://127.0.0.1:1",
+		Token:                "fake",
+		TransportDialTimeout: 100 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("CreateVaultClient: %s", err)
+	}
+	// Keep the test fast: skip vault-api's default retry backoff (2
+	// retries × ~1-5s) for the connection-refused probe.
+	clients.Vault().SetMaxRetries(0)
+
+	d, err := NewVaultReadQuery("secret/foo/bar")
+	if err != nil {
+		t.Fatalf("NewVaultReadQuery: %s", err)
+	}
+
+	// First probe attempt — must fail at the network layer. The actual
+	// return is irrelevant; we only care about post-call field state.
+	_, _ = d.readSecret(clients)
+
+	if d.isKVv2 != nil {
+		t.Fatalf("d.isKVv2 was cached after a failed probe (= %v); "+
+			"expected nil so the next Fetch re-probes once Vault recovers "+
+			"(see hashicorp/consul-template#2149)", *d.isKVv2)
+	}
+	// Fallback for the one in-flight read attempt is still correct.
+	if d.secretPath != "secret/foo/bar" {
+		t.Errorf("d.secretPath = %q after failed probe; want %q "+
+			"(rawPath fallback for the current read attempt)",
+			d.secretPath, "secret/foo/bar")
+	}
+
+	// A second readSecret call must re-enter the probe block (not the
+	// previously-broken cached-false fast path) and fail the same way.
+	_, _ = d.readSecret(clients)
+	if d.isKVv2 != nil {
+		t.Fatalf("d.isKVv2 was cached after a second failed probe "+
+			"(= %v); the latch fix is defeated", *d.isKVv2)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #2149.

A transient failure of the `isKVv2` mount probe in `dependency/vault_read.go` (e.g. `context deadline exceeded` against Vault during startup) currently writes the assumed-not-v2 fallback into `d.isKVv2`, latching the dependency into KV v1 mode for the lifetime of the process even after Vault recovers. Subsequent reads against a KV v2 mount then fail repeatedly with `Invalid path for a versioned K/V secrets engine` until the consul-template / Nomad agent is restarted.

This change caches `d.isKVv2` **only on a successful probe**. On error, `d.isKVv2` stays `nil` so the next `Fetch()` re-enters the probe block and re-detects the mount type once Vault is reachable again. The existing "assume not v2" fallback for the single in-flight read attempt is preserved.

## Why this matters (real-world repro)

Observed downstream as a Nomad-embedded consul-template instance (`Nomad 1.9.7` shipping CT `v0.40.0`) latching a `letsencrypt/...` KV-v2 mount after a single Vault timeout during startup:

```
[WARN] vault.read(letsencrypt/.../X.kbmaas...): failed to check if ... is KVv2, assume not: Get "https://active.vault.service.consul:8200/v1/sys/internal/ui/mounts/letsencrypt/.../X.kbmaas...": context deadline exceeded
... 633 follow-on errors over the next 30 minutes ...
[ERR] vault.read(letsencrypt/...): Invalid path for a versioned K/V secrets engine.
```

The 633 follow-on errors are not Vault re-probing — Vault recovered seconds after the first timeout. They are CT continuing to issue v1-shape reads against a v2 mount because `d.isKVv2 = &false` was cached. The only way out today is restarting the process.

## The fix

`dependency/vault_read.go` — the unconditional `d.isKVv2 = &isKVv2` at the bottom of the `d.isKVv2 == nil` block is replaced with branch-local assignments. The error branch only sets `d.secretPath = d.rawPath` (the per-attempt fallback) and leaves `d.isKVv2` untouched:

```go
if d.isKVv2 == nil {
    mountPath, isKVv2, err := isKVv2(vaultClient, d.rawPath)
    if err != nil {
        log.Printf("[WARN] %s: failed to check if %s is KVv2, "+
            "assume not (will re-probe on next fetch): %s",
            d, d.rawPath, err)
        d.secretPath = d.rawPath
        // Intentionally do not set d.isKVv2 here: a transient Vault
        // failure must not poison this dependency for the process
        // lifetime. The next Fetch() will re-enter this block and
        // probe again.
    } else if isKVv2 {
        d.secretPath = shimKVv2Path(d.rawPath, mountPath, clients.Vault().Namespace())
        d.isKVv2 = &isKVv2
    } else {
        d.secretPath = d.rawPath
        d.isKVv2 = &isKVv2
    }
}
```

Sibling `dependency/vault_list.go` and `dependency/vault_write.go` already probe per-call with no caching, so they are not affected by this class of bug.

## Test

Added `TestVaultReadQuery_isKVv2_NotCachedOnProbeError` in `dependency/vault_read_test.go`. It points a fresh `ClientSet` at an unreachable Vault address (`http://127.0.0.1:1`, dial timeout 100ms, retries disabled), calls `d.readSecret(clients)` so the `isKVv2` probe fails with connection-refused, and asserts:

- `d.isKVv2 == nil` after the failed probe (proves no latch), and
- `d.secretPath == d.rawPath` (proves the per-attempt fallback still works).

A second `d.readSecret` call repeats the assertions to confirm the re-probe path remains live.

I verified the test passes on the fixed code (`PASS, 0.00s`) and fails on the previous code with the precise diagnostic:

```
d.isKVv2 was cached after a failed probe (= false); expected nil so the next Fetch re-probes once Vault recovers (see hashicorp/consul-template#2149)
```

The full `TestVaultReadQuery_*` test set still passes (`ok ... 3.418s`).

## Behavior change

Before: a single failed probe permanently caches `d.isKVv2 = false`. The dependency is effectively dead until process restart for any KV v2 mount.

After: a failed probe is treated as "assume not v2 for this one read attempt", same as before, but does not poison the cache. The next `Fetch()` re-probes. A successful probe still caches as before — the steady-state behavior is unchanged.

No public API change; no schema change; no config flag.