### PR TITLE
Prevent path redirection in writeToFile via symlinked path components

### DIFF
--- a/template/funcs.go
+++ b/template/funcs.go
@@ -1930,7 +1930,11 @@ func writeToFile(path, username, groupName, permissions string, args ...string) 
 	}
 
 	resolvedPath := filepath.Join(dirPath, filepath.Base(cleanPath))
-	if fi, lErr := os.Lstat(resolvedPath); lErr == nil && fi.Mode()&os.ModeSymlink != 0 {
+	fi, lErr := os.Lstat(resolvedPath)
+	if lErr != nil && !os.IsNotExist(lErr) {
+		return "", fmt.Errorf("writeToFile: failed to stat %q: %w", resolvedPath, lErr)
+	}
+	if lErr == nil && fi.Mode()&os.ModeSymlink != 0 {
 		return "", fmt.Errorf("writeToFile: refusing to write to symlink %q", path)
 	}
 

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -1897,25 +1897,51 @@ func writeToFile(path, username, groupName, permissions string, args ...string) 
 	}
 	perm := os.FileMode(p_u)
 
+	// Validate the write path to prevent symlink redirection attacks.
+	//
+	// os.Lstat does not follow the final path component, so it reveals whether
+	// that component is itself a symlink. We check both the immediate parent
+	// directory and the final file component:
+	//   - parent directory symlink: e.g. /secrets -> /attacker/ redirects the
+	//     write to /attacker/cert.key.
+	//   - final component symlink: e.g. /secrets/cert.key -> /etc/backdoor
+	//     overwrites an unintended file.
+	// Note: symlinks in ancestor directories above the direct parent are not
+	// checked here because writeToFile has no sandbox boundary to enforce, and
+	// checking every ancestor would produce false positives for OS-managed
+	// symlinks (e.g. /var -> /private/var on macOS).
+	cleanPath := filepath.Clean(path)
+	dirPath := filepath.Dir(cleanPath)
+
+	if _, err := os.Stat(dirPath); err != nil {
+		if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
+			return "", err
+		}
+	}
+
+	dirInfo, err := os.Lstat(dirPath)
+	if err != nil {
+		return "", fmt.Errorf("writeToFile: failed to stat directory %q: %w", dirPath, err)
+	}
+	if dirInfo.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("writeToFile: refusing to write through symlinked directory in path %q", path)
+	}
+
+	resolvedPath := filepath.Join(dirPath, filepath.Base(cleanPath))
+	if fi, lErr := os.Lstat(resolvedPath); lErr == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("writeToFile: refusing to write to symlink %q", path)
+	}
+
 	// Write to file
 	var f *os.File
 	shouldAppend := strings.Contains(flags, "append")
 	if shouldAppend {
-		f, err = os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, perm)
+		f, err = os.OpenFile(resolvedPath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, perm)
 		if err != nil {
 			return "", err
 		}
 	} else {
-		dirPath := filepath.Dir(path)
-
-		if _, err := os.Stat(dirPath); err != nil {
-			err := os.MkdirAll(dirPath, os.ModePerm)
-			if err != nil {
-				return "", err
-			}
-		}
-
-		f, err = os.Create(path)
+		f, err = os.Create(resolvedPath)
 		if err != nil {
 			return "", err
 		}
@@ -1971,13 +1997,13 @@ func writeToFile(path, username, groupName, permissions string, args ...string) 
 
 	// Avoid the chown call altogether if using current user and group.
 	if username != "" || groupName != "" {
-		err = os.Chown(path, uid, gid)
+		err = os.Chown(resolvedPath, uid, gid)
 		if err != nil {
 			return "", err
 		}
 	}
 
-	err = os.Chmod(path, perm)
+	err = os.Chmod(resolvedPath, perm)
 	if err != nil {
 		return "", err
 	}

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -1932,16 +1932,18 @@ func writeToFile(path, username, groupName, permissions string, args ...string) 
 		return "", fmt.Errorf("writeToFile: refusing to write to symlink %q", path)
 	}
 
-	// Write to file
+	// Write to file. O_NOFOLLOW makes the open fail if the final path component
+	// is a symlink, closing the TOCTOU window between the symlink pre-check
+	// above and the open below (no-op on Windows, which lacks O_NOFOLLOW).
 	var f *os.File
 	shouldAppend := strings.Contains(flags, "append")
 	if shouldAppend {
-		f, err = os.OpenFile(resolvedPath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, perm)
+		f, err = os.OpenFile(resolvedPath, os.O_APPEND|os.O_WRONLY|os.O_CREATE|openNoFollow, perm)
 		if err != nil {
 			return "", err
 		}
 	} else {
-		f, err = os.Create(resolvedPath)
+		f, err = os.OpenFile(resolvedPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC|openNoFollow, perm)
 		if err != nil {
 			return "", err
 		}
@@ -1996,14 +1998,17 @@ func writeToFile(path, username, groupName, permissions string, args ...string) 
 	}
 
 	// Avoid the chown call altogether if using current user and group.
+	// Operate on the open file descriptor (f.Chown/f.Chmod) rather than the
+	// path, so ownership and permissions always target the file we opened even
+	// if the path is swapped after the open.
 	if username != "" || groupName != "" {
-		err = os.Chown(resolvedPath, uid, gid)
+		err = f.Chown(uid, gid)
 		if err != nil {
 			return "", err
 		}
 	}
 
-	err = os.Chmod(resolvedPath, perm)
+	err = f.Chmod(perm)
 	if err != nil {
 		return "", err
 	}

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -1913,10 +1913,12 @@ func writeToFile(path, username, groupName, permissions string, args ...string) 
 	cleanPath := filepath.Clean(path)
 	dirPath := filepath.Dir(cleanPath)
 
-	if _, err := os.Stat(dirPath); err != nil {
+	if _, err := os.Stat(dirPath); os.IsNotExist(err) {
 		if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
 			return "", err
 		}
+	} else if err != nil {
+		return "", err
 	}
 
 	dirInfo, err := os.Lstat(dirPath)

--- a/template/nofollow_unix.go
+++ b/template/nofollow_unix.go
@@ -1,0 +1,14 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !windows
+
+package template
+
+import "syscall"
+
+// openNoFollow adds O_NOFOLLOW to the open flags so that, if the final path
+// component is a symlink, the open fails rather than following it. This closes
+// the TOCTOU window between the symlink pre-check and the open on Unix-like
+// systems. It is not available on Windows (see nofollow_windows.go).
+const openNoFollow = syscall.O_NOFOLLOW

--- a/template/nofollow_windows.go
+++ b/template/nofollow_windows.go
@@ -1,0 +1,11 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build windows
+
+package template
+
+// openNoFollow is a no-op on Windows, which does not support O_NOFOLLOW. The
+// symlink pre-checks in writeToFile still apply; reparse-point/junction
+// handling on Windows is a documented limitation.
+const openNoFollow = 0

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"os/user"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -2653,6 +2654,100 @@ func Test_writeToFile(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_writeToFile_symlink_rejection(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("skipping symlink-rejection tests when running as root")
+	}
+
+	setup := func(t *testing.T) (outDir, targetPath, sensitiveFile string) {
+		t.Helper()
+		outDir = t.TempDir()
+		targetPath = filepath.Join(outDir, "output.txt")
+		sensitiveFile = filepath.Join(t.TempDir(), "sensitive.txt")
+		require.NoError(t, os.WriteFile(sensitiveFile, []byte("secret"), 0o600))
+		return
+	}
+
+	execTemplate := func(t *testing.T, destPath string) error {
+		t.Helper()
+		tmplStr := fmt.Sprintf(`{{ "data" | writeToFile %q "" "" "0644" }}`, destPath)
+		tpl, err := NewTemplate(&NewTemplateInput{Contents: tmplStr})
+		require.NoError(t, err)
+		_, err = tpl.Execute(nil)
+		return err
+	}
+
+	t.Run("rejects_final_component_symlink", func(t *testing.T) {
+		outDir, _, sensitiveFile := setup(t)
+		symlinkPath := filepath.Join(outDir, "output.txt")
+		if err := os.Symlink(sensitiveFile, symlinkPath); err != nil {
+			t.Skipf("skipping: could not create symlink: %v", err)
+		}
+
+		err := execTemplate(t, symlinkPath)
+		require.Error(t, err, "writeToFile should refuse to write through a symlink at the final path component")
+		require.Contains(t, err.Error(), "refusing to write to symlink")
+
+		// The sensitive file must be unmodified.
+		content, readErr := os.ReadFile(sensitiveFile)
+		require.NoError(t, readErr)
+		require.Equal(t, "secret", string(content), "sensitive file must not be overwritten")
+	})
+
+	t.Run("rejects_directory_component_symlink", func(t *testing.T) {
+		redirectDir := t.TempDir()
+		parentDir := t.TempDir()
+
+		// Create a real output file in redirectDir to verify it is not clobbered.
+		redirectTarget := filepath.Join(redirectDir, "output.txt")
+		require.NoError(t, os.WriteFile(redirectTarget, []byte("secret"), 0o600))
+
+		// Make parentDir/subdir a symlink pointing to redirectDir.
+		symlinkDir := filepath.Join(parentDir, "subdir")
+		if err := os.Symlink(redirectDir, symlinkDir); err != nil {
+			t.Skipf("skipping: could not create symlink: %v", err)
+		}
+
+		destPath := filepath.Join(symlinkDir, "output.txt")
+		err := execTemplate(t, destPath)
+		require.Error(t, err, "writeToFile should refuse to write through a symlinked directory component")
+		require.Contains(t, err.Error(), "refusing to write through symlinked directory")
+
+		// The file in the redirect target directory must be unmodified.
+		content, readErr := os.ReadFile(redirectTarget)
+		require.NoError(t, readErr)
+		require.Equal(t, "secret", string(content), "redirect target file must not be overwritten")
+	})
+
+	t.Run("allows_normal_path", func(t *testing.T) {
+		_, targetPath, _ := setup(t)
+		err := execTemplate(t, targetPath)
+		require.NoError(t, err, "writeToFile should succeed for a plain non-symlink path")
+		content, readErr := os.ReadFile(targetPath)
+		require.NoError(t, readErr)
+		require.Equal(t, "data", string(content))
+	})
+
+	t.Run("append_rejects_final_component_symlink", func(t *testing.T) {
+		outDir, _, sensitiveFile := setup(t)
+		symlinkPath := filepath.Join(outDir, "output.txt")
+		if err := os.Symlink(sensitiveFile, symlinkPath); err != nil {
+			t.Skipf("skipping: could not create symlink: %v", err)
+		}
+
+		tmplStr := fmt.Sprintf(`{{ "data" | writeToFile %q "" "" "0644" "append" }}`, symlinkPath)
+		tpl, err := NewTemplate(&NewTemplateInput{Contents: tmplStr})
+		require.NoError(t, err)
+		_, err = tpl.Execute(nil)
+		require.Error(t, err, "writeToFile with append flag should refuse to write through a symlink")
+		require.Contains(t, err.Error(), "refusing to write to symlink")
+
+		content, readErr := os.ReadFile(sensitiveFile)
+		require.NoError(t, readErr)
+		require.Equal(t, "secret", string(content), "sensitive file must not be modified by append")
+	})
 }
 
 const testCert = `


### PR DESCRIPTION
## Summary

The `writeToFile` template helper opened the final user-supplied path directly with `os.Create` / `os.OpenFile`, which follow symlinks in both intermediate directory components and the final filename. This allowed template output to be redirected outside the intended directory, or to overwrite an existing file via a pre-positioned symlink — a particular concern given `writeToFile` is documented for writing certificate and private-key material.

Unlike the main renderer's `AtomicWrite` (temp-file + rename, which replaces the directory entry rather than following it), `writeToFile` wrote directly to the named path and lost that protection.

## Changes

- Validate the write path before opening it:
  - Reject a symlinked **parent directory** component (`os.Lstat`), which would redirect the whole write into an attacker-controlled directory.
  - Reject a symlinked **final filename** component (`os.Lstat`), which would clobber an unintended target.
- Open the destination with `O_NOFOLLOW` (via a per-platform constant; no-op on Windows) so the open itself fails if the final component is a symlink, closing the TOCTOU window between the pre-check and the open.
- Apply ownership and permissions through the **open file descriptor** (`f.Chown` / `f.Chmod`) instead of the path, so metadata always targets the file that was opened rather than a path that could be swapped afterward.
- Fail closed: only create the parent directory when it genuinely does not exist (`os.IsNotExist`), and return immediately if the destination cannot be stat'd for any reason other than non-existence (e.g. permission denied), instead of proceeding to open.

`os.Lstat` is used rather than `filepath.EvalSymlinks` containment (as used by the sandboxed `file` helper) because `writeToFile` has no configured sandbox boundary, and an `EvalSymlinks`-based ancestor check produces false positives on OS-managed symlinks (e.g. macOS `/var -> /private/var`).

### Known limitation

Only the immediate parent directory is checked, not grandparent/ancestor components. This is deliberate: `writeToFile` has no sandbox to anchor a full ancestor walk, and walking every ancestor breaks compatibility on systems with OS-managed symlinks in common path prefixes. `O_NOFOLLOW` only guards the final path component; a residual TOCTOU on ancestor directories remains, consistent with this limitation.

## Tests

Adds `Test_writeToFile_symlink_rejection`:
- `rejects_final_component_symlink` — errors, sensitive file byte-verified unchanged
- `rejects_directory_component_symlink` — errors, redirect target byte-verified unchanged
- `allows_normal_path` — succeeds
- `append_rejects_final_component_symlink` — errors in append mode, sensitive file unchanged

Sub-tests skip gracefully where `os.Symlink` is unsupported and skip entirely as root. All pre-existing `Test_writeToFile` cases continue to pass.
