### PR TITLE
signals: add aix build constraint and SIGVTALRM

### DIFF
--- a/signals/signals_unix.go
+++ b/signals/signals_unix.go
@@ -1,8 +1,8 @@
 // Copyright IBM Corp. 2014, 2025
 // SPDX-License-Identifier: MPL-2.0
 
-//go:build linux || darwin || freebsd || openbsd || solaris || netbsd
-// +build linux darwin freebsd openbsd solaris netbsd
+//go:build linux || darwin || freebsd || openbsd || solaris || netbsd || aix
+// +build linux darwin freebsd openbsd solaris netbsd aix
 
 package signals
 
@@ -16,32 +16,33 @@ import (
 // SIGURG  - used by the golang scheduler for parallel runtime.
 
 var SignalLookup = map[string]os.Signal{
-	"SIGNULL":  SIGNULL,
-	"SIGABRT":  syscall.SIGABRT,
-	"SIGALRM":  syscall.SIGALRM,
-	"SIGBUS":   syscall.SIGBUS,
-	"SIGCONT":  syscall.SIGCONT,
-	"SIGFPE":   syscall.SIGFPE,
-	"SIGHUP":   syscall.SIGHUP,
-	"SIGILL":   syscall.SIGILL,
-	"SIGINT":   syscall.SIGINT,
-	"SIGIO":    syscall.SIGIO,
-	"SIGIOT":   syscall.SIGIOT,
-	"SIGKILL":  syscall.SIGKILL,
-	"SIGPIPE":  syscall.SIGPIPE,
-	"SIGPROF":  syscall.SIGPROF,
-	"SIGQUIT":  syscall.SIGQUIT,
-	"SIGSEGV":  syscall.SIGSEGV,
-	"SIGSTOP":  syscall.SIGSTOP,
-	"SIGSYS":   syscall.SIGSYS,
-	"SIGTERM":  syscall.SIGTERM,
-	"SIGTRAP":  syscall.SIGTRAP,
-	"SIGTSTP":  syscall.SIGTSTP,
-	"SIGTTIN":  syscall.SIGTTIN,
-	"SIGTTOU":  syscall.SIGTTOU,
-	"SIGUSR1":  syscall.SIGUSR1,
-	"SIGUSR2":  syscall.SIGUSR2,
-	"SIGWINCH": syscall.SIGWINCH,
-	"SIGXCPU":  syscall.SIGXCPU,
-	"SIGXFSZ":  syscall.SIGXFSZ,
+	"SIGNULL":   SIGNULL,
+	"SIGABRT":   syscall.SIGABRT,
+	"SIGALRM":   syscall.SIGALRM,
+	"SIGBUS":    syscall.SIGBUS,
+	"SIGCONT":   syscall.SIGCONT,
+	"SIGFPE":    syscall.SIGFPE,
+	"SIGHUP":    syscall.SIGHUP,
+	"SIGILL":    syscall.SIGILL,
+	"SIGINT":    syscall.SIGINT,
+	"SIGIO":     syscall.SIGIO,
+	"SIGIOT":    syscall.SIGIOT,
+	"SIGKILL":   syscall.SIGKILL,
+	"SIGPIPE":   syscall.SIGPIPE,
+	"SIGPROF":   syscall.SIGPROF,
+	"SIGQUIT":   syscall.SIGQUIT,
+	"SIGSEGV":   syscall.SIGSEGV,
+	"SIGSTOP":   syscall.SIGSTOP,
+	"SIGSYS":    syscall.SIGSYS,
+	"SIGTERM":   syscall.SIGTERM,
+	"SIGTRAP":   syscall.SIGTRAP,
+	"SIGTSTP":   syscall.SIGTSTP,
+	"SIGTTIN":   syscall.SIGTTIN,
+	"SIGTTOU":   syscall.SIGTTOU,
+	"SIGUSR1":   syscall.SIGUSR1,
+	"SIGUSR2":   syscall.SIGUSR2,
+	"SIGVTALRM": syscall.SIGVTALRM,
+	"SIGWINCH":  syscall.SIGWINCH,
+	"SIGXCPU":   syscall.SIGXCPU,
+	"SIGXFSZ":   syscall.SIGXFSZ,
 }


### PR DESCRIPTION
## Summary

Adds `aix` to the build constraint of `signals/signals_unix.go` and `SIGVTALRM` to `SignalLookup`, so the package compiles for `GOOS=aix GOARCH=ppc64`.

Fixes #2158

## Background

`GOOS=aix go build ./signals/` currently fails with `undefined: SignalLookup`. Every signal referenced in the unix lookup map exists on aix/ppc64 with the stock Go toolchain, so the constraint addition is sufficient — no platform-specific file needed. `SIGVTALRM` is added to the map for AIX workloads that configure it (e.g. as a kill/reload signal).

This patch has been validated by the IBM Power integration team, who have been carrying it as a fork patch for AIX builds of Vault Agent (which vendors consul-template for template rendering); credited as commit co-author.

## Testing

- `GOOS=aix GOARCH=ppc64 go build ./signals/` — compiles
- Native `go build` / `go test ./signals/` — green
- `git diff --check` clean; constraint-only change for existing platforms (plus one new map entry available on all of them)