### PR TITLE
dependency: account for the HTTP Age header when timing lease re-renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## UNRELEASED
+
+BUG FIXES:
+* fix: Account for the HTTP Age header so leases read through a caching proxy are re-rendered before they expire [GH-2160](https://github.com/hashicorp/consul-template/pull/2160)
+
 # 0.42.1
 
 IMPROVEMENTS:

--- a/dependency/vault_common.go
+++ b/dependency/vault_common.go
@@ -250,6 +250,11 @@ func updateSecret(ours *Secret, theirs *api.Secret) {
 		ours.LeaseDuration = theirs.LeaseDuration
 	}
 
+	// Age is how long this response sat in a cache before arriving, a property
+	// of the response rather than the secret, so it is set directly rather than
+	// preserved across renewals like the fields above.
+	ours.Age = theirs.Age
+
 	if theirs.Renewable {
 		ours.Renewable = theirs.Renewable
 	}

--- a/dependency/vault_common.go
+++ b/dependency/vault_common.go
@@ -48,6 +48,11 @@ type Secret struct {
 	// cubbyhole of the given token (which has a TTL of the given number of
 	// seconds)
 	WrapInfo *SecretWrapInfo
+
+	// Age reports how long this response was held by an intermediate cache
+	// before reaching the client. It is zero for a response served directly by
+	// Vault. The lifetime a lease has left is its LeaseDuration less its Age.
+	Age time.Duration
 }
 
 // SecretAuth is the structure containing auth information if we have it.

--- a/dependency/vault_common.go
+++ b/dependency/vault_common.go
@@ -195,6 +195,18 @@ func leaseCheckWait(s *Secret) (time.Duration, error) {
 		sleep = sleep * finalFraction
 	}
 
+	// Discount the time this response has already spent in a cache. A cached
+	// lease reports its duration measured from when the lease was issued, and
+	// the Age header says how long ago that was, so that much of the wait has
+	// already elapsed. Without this the sleep runs from now rather than from
+	// issuance, and the client wakes after the credential has already expired.
+	if s.LeaseID != "" && s.Age > 0 {
+		sleep -= float64(s.Age)
+		if sleep < 0 {
+			sleep = 0
+		}
+	}
+
 	return time.Duration(sleep), nil
 }
 

--- a/dependency/vault_common_cache_age_test.go
+++ b/dependency/vault_common_cache_age_test.go
@@ -1,0 +1,42 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package dependency
+
+import (
+	"testing"
+	"time"
+)
+
+// A caching proxy in front of Vault replays a stored response verbatim and
+// reports how stale it is via the HTTP Age header. The lease_duration in that
+// response is measured from when the lease was issued, not from when the client
+// received it, so the lifetime a lease has left is lease_duration - Age.
+//
+// leaseCheckWait decides how long to sleep before re-rendering a non-renewable
+// secret. It must wake before the lease has run out, or the secret it renders
+// on waking is already dead. The package init sets VaultLeaseRenewalThreshold
+// to 0.90, so the sleep is a deterministic fraction of the remaining lease.
+func TestLeaseCheckWait_AccountsForCacheAge(t *testing.T) {
+	const (
+		leaseDurationSeconds = 100
+		age                  = 90 * time.Second
+	)
+	remaining := time.Duration(leaseDurationSeconds)*time.Second - age
+
+	secret := &Secret{
+		LeaseID:       "database/creds/readonly/abcd1234",
+		LeaseDuration: leaseDurationSeconds,
+		Age:           age,
+	}
+
+	dur, err := leaseCheckWait(secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if dur >= remaining {
+		t.Fatalf("a lease %ds old on a %ds duration has only %s left; slept %s, waking after it expired",
+			int(age.Seconds()), leaseDurationSeconds, remaining, dur)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -69,3 +69,9 @@ require (
 	golang.org/x/time v0.15.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+// NOTE: TEMPORARY, DO NOT MERGE! This pulls the api's Age field from an
+// unreleased branch. Drop this replace and require a released
+// github.com/hashicorp/vault/api once
+// https://github.com/hashicorp/vault/pull/32040 has merged and shipped.
+replace github.com/hashicorp/vault/api => github.com/peteski22/vault/api v0.0.0-20260721211811-5a9a4f8b8159

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,6 @@ github.com/hashicorp/nomad/api v0.0.0-20260410071528-9e6d492b59a8 h1:stpZF8Zu7RG
 github.com/hashicorp/nomad/api v0.0.0-20260410071528-9e6d492b59a8/go.mod h1:KkLNLU0Nyfh5jWsFoF/PsmMbKpRIAoIV4lmQoJWgKCk=
 github.com/hashicorp/serf v0.10.4 h1:TCQOrJXHZ1Xf80c4WBhMM9OwUFgDaIP0R+YvoQUKadI=
 github.com/hashicorp/serf v0.10.4/go.mod h1:l+s5Q1OSPWU6b9l9m7ODJzTp7mLevSaVzAI03Nka2F0=
-github.com/hashicorp/vault/api v1.23.0 h1:gXgluBsSECfRWTSW9niY2jwg2e9mMJc4WoHNv4g3h6A=
-github.com/hashicorp/vault/api v1.23.0/go.mod h1:zransKiB9ftp+kgY8ydjnvCU7Wk8i9L0DYWpXeMj9ko=
 github.com/hashicorp/vault/api/auth/kubernetes v0.10.0 h1:5rqWmUFxnu3S7XYq9dafURwBgabYDFzo2Wv+AMopPHs=
 github.com/hashicorp/vault/api/auth/kubernetes v0.10.0/go.mod h1:cZZmhF6xboMDmDbMY52oj2DKW6gS0cQ9g0pJ5XIXQ5U=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
@@ -167,6 +165,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/peteski22/vault/api v0.0.0-20260721211811-5a9a4f8b8159 h1:hsuu4hCQ1HsrmjSdL67fIDwov5FdTo7zo4MFHFAapOo=
+github.com/peteski22/vault/api v0.0.0-20260721211811-5a9a4f8b8159/go.mod h1:zX8rcb/scdq0SDfp58rA+xIe9HtTREgbIv0yzNyufmA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
## Description

`leaseCheckWait` decides how long Consul Template sleeps before re-rendering a non-renewable Vault secret, using `lease_duration` measured from now. Behind a caching proxy in front of Vault, the response has already been held for some time — reported in the HTTP `Age` header — so the lease has `lease_duration - Age` left, not `lease_duration`. Consul Template ignored `Age`, so it slept for most of the original lease again and re-rendered only after the credential had already expired. This shows up most as a lease approaches its `max_ttl`, where the template keeps rendering a secret that is already dead.

This change:

- adds an `Age` field to `dependency.Secret`, populated from the api response (which gains the field in hashicorp/vault#32040), and
- subtracts `Age` from the computed sleep in `leaseCheckWait`, clamped at zero.

It is a no-op for responses served directly by Vault (`Age` is zero), so behaviour without a cache in front is unchanged.

The first two commits are a failing test and its fix; the third wires the value through from the api response.

> [!WARNING]
> **This is a draft and must not be merged yet.** It depends on hashicorp/vault#32040, which adds `api.Secret.Age`. Until that merges and a new `github.com/hashicorp/vault/api` is released, `go.mod` carries a **temporary `replace`** to an unreleased branch (marked `// NOTE: TEMPORARY, DO NOT MERGE!`). Before this can merge, that replace must be dropped and the api dependency bumped to the real release.
>
> The `dependency` package's tests need `consul` and `nomad` on `$PATH` (its `TestMain` starts them), so the new test runs in CI.

## Rationale

This is the client-side counterpart to hashicorp/vault#32040, which fixes `api.LifetimeWatcher` — the mechanism Consul Template uses for *renewable* secrets. This change covers the *non-renewable* secret path, which has its own timing logic in `leaseCheckWait` and is not touched by that fix.

Canonical issue: hashicorp/vault#19684 (Vault Agent lease cache interferes with template refresh for dynamic secrets). Background: hashicorp/vault#19227, hashicorp/vault#16439.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.
