### PR TITLE
fix: isolate template rendering failures so one failing template does not abort others [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/manager/runner.go
+++ b/manager/runner.go
@@ -648,7 +648,8 @@ func (r *Runner) Run() error {
 	for _, tmpl := range r.templates {
 		event, err := r.runTemplate(tmpl, runCtx)
 		if err != nil {
-			return err
+			log.Printf("[ERR] (runner) template %s errored: %s, continuing with remaining templates", tmpl.ID(), err)
+			continue
 		}
 
 		// If there was a render event store it


### PR DESCRIPTION
## Problem

When multiple templates are configured and one has a fatal error (e.g. an `exec {}` block that fails), the `Run()` method returns immediately on the first error, leaving remaining templates unprocessed. The error propagates to `Start()` which sends it to `ErrCh` and stops the entire runner.

This causes:
1. All other templates (including successfully rendered ones) are aborted mid-cycle
2. The entire runner is stopped and restarted (with backoff)
3. ALL templates are re-rendered, including their `exec {}` blocks
4. The failing template's `exec {}` block fails again, starting the cycle over

This is reported in hashicorp/vault#32035.

## Fix

Instead of returning immediately on the first template error, log the error and continue processing remaining templates. The failed template is already marked with the error in its `RenderEvent`, and the runner continues watching its dependencies. When the dependencies change, the template will be re-rendered naturally.

## Testing

- Existing tests: all pass with the same behavior for non-fatal errors
- For fatal errors: the template error is logged, `RenderEvent` is not stored for the failed template, but the runner continues processing other templates normally
- The runner continues to watch dependencies and will retry the failed template when data changes
