### PR TITLE
runner: isolate template errors instead of aborting all templates [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/manager/runner.go
+++ b/manager/runner.go
@@ -645,10 +645,14 @@ func (r *Runner) Run() error {
 		depsMap: make(map[string]dep.Dependency),
 	}
 
+	var templateErrs []error
+
 	for _, tmpl := range r.templates {
 		event, err := r.runTemplate(tmpl, runCtx)
 		if err != nil {
-			return err
+			log.Printf("[ERR] (runner) template %s failed: %s", tmpl.ID(), err)
+			templateErrs = append(templateErrs, err)
+			continue
 		}
 
 		// If there was a render event store it
@@ -739,6 +743,21 @@ func (r *Runner) Run() error {
 			result = multierror.Append(result, err)
 		}
 		return result.ErrorOrNil()
+	}
+
+	// Return any template errors if all commands succeeded
+	if len(templateErrs) != 0 {
+		// Suppress the run-level error when all templates failed — the caller
+		// will see individual template errors in their render events and can
+		// decide whether to stop or continue on the next iteration.
+		if wouldRenderAny || renderedAny {
+			// At least one template rendered successfully, so don't stop the
+			// runner — just log and continue.
+			log.Printf("[WARN] (runner) %d template(s) failed, but %d rendered successfully",
+				len(templateErrs), len(r.templates)-len(templateErrs))
+			return nil
+		}
+		return fmt.Errorf("%d template(s) failed to render", len(templateErrs))
 	}
 
 	return nil


### PR DESCRIPTION
## Description

When one template in a multi-template Vault Agent configuration encounters a fatal error (e.g., an `exec {}` template function fails), the consul-template runner's `Run()` method returns immediately after the first failure, skipping all remaining templates.

This means:
1. Template A with a failing `exec {}` block causes templates B, C, D to be skipped
2. The runner stops and sends the error to `ErrCh`
3. On restart, ALL templates are re-processed from scratch
4. The failing template fails again, creating an infinite loop

## Fix

Collect template errors and continue processing the remaining templates:
- When a template has a fatal error, log it, add to the error list, and continue to the next template
- If at least one template rendered successfully, return `nil` (don't stop the runner — the failed template will be retried on the next dependency change)
- If ALL templates failed, return an error so the caller can handle it

## Changes

`manager/runner.go` — 20 lines added, 1 deleted

## Related issue

Fixes hashicorp/vault#32035