### PR TITLE
dependency: fix runaway credential creation on renewal failure

### DIFF
--- a/dependency/vault_common.go
+++ b/dependency/vault_common.go
@@ -82,8 +82,11 @@ func renewSecret(clients *ClientSet, d renewer) error {
 
 	secret, vaultSecret := d.secrets()
 	renewer, err := clients.Vault().NewLifetimeWatcher(&api.LifetimeWatcherInput{
-		Secret:        vaultSecret,
-		RenewBehavior: api.RenewBehaviorErrorOnErrors,
+		Secret: vaultSecret,
+		// RenewBehaviorIgnoreErrors retries transient renewal failures with
+		// exponential backoff (10s→5m) until the original lease expires,
+		// rather than exiting the watcher immediately on the first error.
+		RenewBehavior: api.RenewBehaviorIgnoreErrors,
 	})
 	if err != nil {
 		return err

--- a/dependency/vault_common_test.go
+++ b/dependency/vault_common_test.go
@@ -276,7 +276,7 @@ type renewalTestDep struct {
 	stopCh      chan struct{}
 }
 
-func (d *renewalTestDep) stopChan() chan struct{}          { return d.stopCh }
+func (d *renewalTestDep) stopChan() chan struct{}         { return d.stopCh }
 func (d *renewalTestDep) secrets() (*Secret, *api.Secret) { return d.secret, d.vaultSecret }
 func (d *renewalTestDep) CanShare() bool                  { return false }
 func (d *renewalTestDep) Fetch(*ClientSet, *QueryOptions) (interface{}, *ResponseMetadata, error) {

--- a/dependency/vault_common_test.go
+++ b/dependency/vault_common_test.go
@@ -5,8 +5,12 @@ package dependency
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -186,3 +190,98 @@ func setupVaultPKI(clients *ClientSet) {
 		panic(err)
 	}
 }
+
+// TestRenewSecretBoundedOnRenewalFailure verifies that renewSecret does not
+// return immediately when every renewal attempt fails with HTTP 400. The
+// LifetimeWatcher must block via exponential backoff for the duration of the
+// lease rather than exiting on the first error and triggering a new credential
+// fetch on each iteration.
+func TestRenewSecretBoundedOnRenewalFailure(t *testing.T) {
+	var renewAttempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut && r.URL.Path == "/v1/sys/leases/renew" {
+			atomic.AddInt32(&renewAttempts, 1)
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintln(w, `{"errors":["failed to renew entry: bad renew_statement"]}`)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{}`)
+	}))
+	defer srv.Close()
+
+	cfg := api.DefaultConfig()
+	cfg.Address = srv.URL
+	client, err := api.NewClient(cfg)
+	if err != nil {
+		t.Fatalf("failed to create vault client: %v", err)
+	}
+	client.SetToken("test-token")
+
+	clients := &ClientSet{
+		vault: &vaultClient{
+			client:     client,
+			httpClient: cfg.HttpClient,
+		},
+	}
+
+	// 60s TTL — typical database credential lease.
+	vaultSecret := &api.Secret{
+		LeaseID:       "database/creds/my-role/abc123",
+		LeaseDuration: 60,
+		Renewable:     true,
+	}
+	secret := transformSecret(vaultSecret)
+	stopCh := make(chan struct{})
+	d := &renewalTestDep{
+		secret:      secret,
+		vaultSecret: vaultSecret,
+		stopCh:      stopCh,
+	}
+
+	// Simulate the Fetch() loop: call renewSecret in a tight loop and count
+	// returns. The watcher should block via backoff — 0 returns expected in 5s.
+	var returns int32
+	go func() {
+		for {
+			select {
+			case <-stopCh:
+				return
+			default:
+			}
+			renewSecret(clients, d) //nolint:errcheck
+			atomic.AddInt32(&returns, 1)
+		}
+	}()
+
+	time.Sleep(5 * time.Second)
+	close(stopCh)
+
+	got := int(atomic.LoadInt32(&returns))
+	t.Logf("renewSecret returned %d times, renew endpoint hit %d times in 5s (TTL=60s)",
+		got, atomic.LoadInt32(&renewAttempts))
+
+	if got > 0 {
+		t.Errorf("renewSecret returned %d times in 5s with a 60s TTL and failing renewals "+
+			"(want 0); RenewBehaviorIgnoreErrors backoff is not working — "+
+			"credential creation would be unbounded on renewal failure", got)
+	}
+}
+
+// renewalTestDep is a minimal implementation of the renewer interface for
+// use in TestRenewSecretBoundedOnRenewalFailure.
+type renewalTestDep struct {
+	secret      *Secret
+	vaultSecret *api.Secret
+	stopCh      chan struct{}
+}
+
+func (d *renewalTestDep) stopChan() chan struct{}          { return d.stopCh }
+func (d *renewalTestDep) secrets() (*Secret, *api.Secret) { return d.secret, d.vaultSecret }
+func (d *renewalTestDep) CanShare() bool                  { return false }
+func (d *renewalTestDep) Fetch(*ClientSet, *QueryOptions) (interface{}, *ResponseMetadata, error) {
+	return nil, nil, nil
+}
+func (d *renewalTestDep) Stop()          {}
+func (d *renewalTestDep) String() string { return "test.renewal" }
+func (d *renewalTestDep) Type() Type     { return TypeVault }

--- a/dependency/vault_common_test.go
+++ b/dependency/vault_common_test.go
@@ -5,6 +5,7 @@ package dependency
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -239,32 +240,34 @@ func TestRenewSecretBoundedOnRenewalFailure(t *testing.T) {
 		stopCh:      stopCh,
 	}
 
-	// Simulate the Fetch() loop: call renewSecret in a tight loop and count
-	// returns. The watcher should block via backoff — 0 returns expected in 5s.
-	var returns int32
+	// Run renewSecret once. It must not return before stopCh is closed because
+	// RenewBehaviorIgnoreErrors should block via backoff for the lease duration
+	// rather than exiting immediately on every renewal failure.
+	resultCh := make(chan error, 1)
 	go func() {
-		for {
-			select {
-			case <-stopCh:
-				return
-			default:
-			}
-			renewSecret(clients, d) //nolint:errcheck
-			atomic.AddInt32(&returns, 1)
-		}
+		resultCh <- renewSecret(clients, d)
 	}()
 
-	time.Sleep(5 * time.Second)
+	select {
+	case err := <-resultCh:
+		t.Errorf("renewSecret returned early (err=%v, renew endpoint hit %d times in 10s); "+
+			"RenewBehaviorIgnoreErrors backoff is not working — "+
+			"credential creation would be unbounded on renewal failure",
+			err, atomic.LoadInt32(&renewAttempts))
+		return
+	case <-time.After(10 * time.Second):
+		// Good: renewSecret is still blocking through the full first backoff interval.
+	}
+
 	close(stopCh)
 
-	got := int(atomic.LoadInt32(&returns))
-	t.Logf("renewSecret returned %d times, renew endpoint hit %d times in 5s (TTL=60s)",
-		got, atomic.LoadInt32(&renewAttempts))
-
-	if got > 0 {
-		t.Errorf("renewSecret returned %d times in 5s with a 60s TTL and failing renewals "+
-			"(want 0); RenewBehaviorIgnoreErrors backoff is not working — "+
-			"credential creation would be unbounded on renewal failure", got)
+	select {
+	case err := <-resultCh:
+		if !errors.Is(err, ErrStopped) {
+			t.Errorf("renewSecret returned %v after stopCh closed, want ErrStopped", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Error("renewSecret did not return after stopCh was closed (goroutine leak)")
 	}
 }
 


### PR DESCRIPTION
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
Fixes #2165

## Problem

When a Vault lease renewal fails — due to a bad `renew_statement` on a database
role, or intermittent database connectivity — consul-template mints a new
dynamic credential on every view-loop iteration (~600 new database roles per
minute with a 1-minute TTL) instead of waiting out the original lease.

The root cause is in `dependency/vault_common.go`. The `LifetimeWatcher` was
created with `RenewBehaviorErrorOnErrors`:

```go
renewer, err := clients.Vault().NewLifetimeWatcher(&api.LifetimeWatcherInput{
    Secret:        vaultSecret,
    RenewBehavior: api.RenewBehaviorErrorOnErrors,
})
```

RenewBehaviorErrorOnErrors is the legacy watcher mode — it closes DoneCh
and exits immediately on the first renewal error. renewSecret() treats any
DoneCh close as a clean completion and returns nil. VaultReadQuery.Fetch()
then unconditionally calls fetchSecret(), minting a new credential.
Because fetchSecret succeeds, the view loop's retry counter resets to zero and
the 100ms rate-limiter floor is the only throttle.

Fix
```go
Change RenewBehaviorErrorOnErrors to RenewBehaviorIgnoreErrors:

renewer, err := clients.Vault().NewLifetimeWatcher(&api.LifetimeWatcherInput{
    Secret:        vaultSecret,
    RenewBehavior: api.RenewBehaviorIgnoreErrors,
})
```

RenewBehaviorIgnoreErrors is the current default mode of LifetimeWatcher.
On a renewal error it applies exponential backoff (initial 10s, max 5m) bounded
by the remaining lease duration, and only signals DoneCh when the original
lease has genuinely expired — so fetchSecret is called at most once per TTL
regardless of how many transient errors occur in between.

Testing
Tested manually with Vault Agent v1.16.1 and v1.17.0 using a database role with an intentionally
invalid renew_statement. Without this fix, pg_roles grows by ~600 rows per
minute. With this fix, the count stays at 1 for the full TTL.


- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
