### PR TITLE
template: preserve existing file when writeToFile receives empty content

### DIFF
--- a/docs/templating-language.md
+++ b/docs/templating-language.md
@@ -792,7 +792,7 @@ to separate files from a template.
 ```golang
 {{- with pkiCert "pki/issue/my-domain-dot-com" "common_name=foo.example.com" -}}
 {{ .Cert }}{{ .CA }}{{ .Key }}
-{{ .Key | writeToFile "/my/path/to/cert.key" "root" "root" "0400" }}
+{{ .Key | writeToFile "/my/path/to/cert.key" "root" "root" "0400" "preserve_on_empty" }}
 {{ .CA | writeToFile "/my/path/to/cert.pem" "root" "root" "0644" }}
 {{ .Cert | writeToFile "/my/path/to/cert.pem" "root" "root" "0644" "append" }}
 {{- end -}}
@@ -1896,9 +1896,17 @@ for more information.
 ### `writeToFile`
 
 Writes the content to a file with permissions, username (or UID), group name (or GID),
-and optional flags to select appending mode or add a newline.
+and optional flags to select appending mode, add a newline, or preserve existing content.
 
 The username and group name fields can be left blank to default to the current user and group.
+
+Available flags:
+
+| Flag | Description |
+|---|---|
+| `append` | Append to the file instead of overwriting it |
+| `newline` | Append a newline after the content |
+| `preserve_on_empty` | If content is empty and the file already has content, skip the write but still apply ownership and permissions. Useful with `pkiCert` to prevent side-files (e.g. private keys) from being blanked when a lease is reused on agent restart. |
 
 For example:
 
@@ -1908,6 +1916,7 @@ For example:
 {{ key "my/key/path" | writeToFile "/my/file/path.txt" "my-user" "my-group" "0644" }}
 {{ key "my/key/path" | writeToFile "/my/file/path.txt" "my-user" "my-group" "0644" "append" }}
 {{ key "my/key/path" | writeToFile "/my/file/path.txt" "my-user" "my-group" "0644" "append,newline" }}
+{{ key "my/key/path" | writeToFile "/my/file/path.txt" "my-user" "my-group" "0644" "preserve_on_empty" }}
 ```
 
 ---

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -1943,36 +1943,42 @@ func writeToFile(path, username, groupName, permissions string, args ...string) 
 	// above and the open below (no-op on Windows, which lacks O_NOFOLLOW).
 	var f *os.File
 	shouldAppend := strings.Contains(flags, "append")
-	// Guard: when content is empty and we are not in append mode, do not
-	// truncate an existing non-empty file.  This prevents Vault Agent from
-	// blanking a pkiCert side-file (e.g. the private key) when it restarts
-	// within a lease TTL and consul-template re-executes the template body
-	// without re-rendering the destination file (VAULT-38287).
-	if !shouldAppend && content == "" {
-		if existing, err := os.ReadFile(resolvedPath); err == nil && len(existing) > 0 {
-			return "", nil
-		}
-	}
-	if shouldAppend {
-		f, err = os.OpenFile(resolvedPath, os.O_APPEND|os.O_WRONLY|os.O_CREATE|openNoFollow, perm)
-		if err != nil {
-			return "", err
-		}
-	} else {
-		f, err = os.OpenFile(resolvedPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC|openNoFollow, perm)
-		if err != nil {
-			return "", err
-		}
-	}
-	defer f.Close()
+	shouldPreserveOnEmpty := strings.Contains(flags, "preserve_on_empty")
 
-	writingContent := []byte(content)
-	shouldAddNewLine := strings.Contains(flags, "newline")
-	if shouldAddNewLine {
-		writingContent = append(writingContent, []byte("\n")...)
+	// When preserve_on_empty is set and content is empty, skip the write to
+	// protect an existing non-empty file from being truncated (VAULT-38287).
+	// The newline flag is intentionally not applied when content is empty and
+	// preserve_on_empty is set — a "\n"-only write should not bypass the guard.
+	// Ownership and permissions are still applied below regardless.
+	skipWrite := false
+	if shouldPreserveOnEmpty && content == "" {
+		if existing, err := os.ReadFile(resolvedPath); err == nil && len(existing) > 0 {
+			skipWrite = true
+		}
 	}
-	if _, err = f.Write(writingContent); err != nil {
-		return "", err
+
+	if !skipWrite {
+		if shouldAppend {
+			f, err = os.OpenFile(resolvedPath, os.O_APPEND|os.O_WRONLY|os.O_CREATE|openNoFollow, perm)
+			if err != nil {
+				return "", err
+			}
+		} else {
+			f, err = os.OpenFile(resolvedPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC|openNoFollow, perm)
+			if err != nil {
+				return "", err
+			}
+		}
+		defer f.Close()
+
+		writingContent := []byte(content)
+		shouldAddNewLine := strings.Contains(flags, "newline")
+		if shouldAddNewLine {
+			writingContent = append(writingContent, []byte("\n")...)
+		}
+		if _, err = f.Write(writingContent); err != nil {
+			return "", err
+		}
 	}
 
 	// Change ownership and permissions
@@ -2013,20 +2019,28 @@ func writeToFile(path, username, groupName, permissions string, args ...string) 
 		}
 	}
 
-	// Avoid the chown call altogether if using current user and group.
-	// Operate on the open file descriptor (f.Chown/f.Chmod) rather than the
-	// path, so ownership and permissions always target the file we opened even
-	// if the path is swapped after the open.
-	if username != "" || groupName != "" {
-		err = f.Chown(uid, gid)
-		if err != nil {
+	// Apply ownership and permissions. When the write was skipped (skipWrite),
+	// use path-based calls since there is no open file descriptor. Otherwise
+	// operate on the open fd so ownership/permissions target the file we
+	// opened even if the path is swapped after the open.
+	if skipWrite {
+		if username != "" || groupName != "" {
+			if err = os.Lchown(resolvedPath, uid, gid); err != nil {
+				return "", err
+			}
+		}
+		if err = os.Chmod(resolvedPath, perm); err != nil {
 			return "", err
 		}
-	}
-
-	err = f.Chmod(perm)
-	if err != nil {
-		return "", err
+	} else {
+		if username != "" || groupName != "" {
+			if err = f.Chown(uid, gid); err != nil {
+				return "", err
+			}
+		}
+		if err = f.Chmod(perm); err != nil {
+			return "", err
+		}
 	}
 
 	return "", nil

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -1943,6 +1943,16 @@ func writeToFile(path, username, groupName, permissions string, args ...string) 
 	// above and the open below (no-op on Windows, which lacks O_NOFOLLOW).
 	var f *os.File
 	shouldAppend := strings.Contains(flags, "append")
+	// Guard: when content is empty and we are not in append mode, do not
+	// truncate an existing non-empty file.  This prevents Vault Agent from
+	// blanking a pkiCert side-file (e.g. the private key) when it restarts
+	// within a lease TTL and consul-template re-executes the template body
+	// without re-rendering the destination file (VAULT-38287).
+	if !shouldAppend && content == "" {
+		if existing, err := os.ReadFile(resolvedPath); err == nil && len(existing) > 0 {
+			return "", nil
+		}
+	}
 	if shouldAppend {
 		f, err = os.OpenFile(resolvedPath, os.O_APPEND|os.O_WRONLY|os.O_CREATE|openNoFollow, perm)
 		if err != nil {

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -1945,32 +1945,38 @@ func writeToFile(path, username, groupName, permissions string, args ...string) 
 	shouldAppend := strings.Contains(flags, "append")
 	shouldPreserveOnEmpty := strings.Contains(flags, "preserve_on_empty")
 
-	// When preserve_on_empty is set and content is empty, skip the write to
-	// protect an existing non-empty file from being truncated (VAULT-38287).
+	// When preserve_on_empty is set and content is empty, open the file
+	// without O_TRUNC to preserve existing content (VAULT-38287).
 	// The newline flag is intentionally not applied when content is empty and
 	// preserve_on_empty is set — a "\n"-only write should not bypass the guard.
-	// Ownership and permissions are still applied below regardless.
-	skipWrite := false
-	if shouldPreserveOnEmpty && content == "" {
-		if existing, err := os.ReadFile(resolvedPath); err == nil && len(existing) > 0 {
-			skipWrite = true
+	// In all cases we open via O_NOFOLLOW so the fd-based chown/chmod below
+	// remains protected against symlink races.
+	preserveContent := shouldPreserveOnEmpty && content == "" &&
+		func() bool {
+			existing, err := os.ReadFile(resolvedPath)
+			return err == nil && len(existing) > 0
+		}()
+
+	if shouldAppend {
+		f, err = os.OpenFile(resolvedPath, os.O_APPEND|os.O_WRONLY|os.O_CREATE|openNoFollow, perm)
+		if err != nil {
+			return "", err
+		}
+	} else if preserveContent {
+		// Open without O_TRUNC — content stays intact, fd used for chown/chmod.
+		f, err = os.OpenFile(resolvedPath, os.O_RDWR|openNoFollow, perm)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		f, err = os.OpenFile(resolvedPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC|openNoFollow, perm)
+		if err != nil {
+			return "", err
 		}
 	}
+	defer f.Close()
 
-	if !skipWrite {
-		if shouldAppend {
-			f, err = os.OpenFile(resolvedPath, os.O_APPEND|os.O_WRONLY|os.O_CREATE|openNoFollow, perm)
-			if err != nil {
-				return "", err
-			}
-		} else {
-			f, err = os.OpenFile(resolvedPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC|openNoFollow, perm)
-			if err != nil {
-				return "", err
-			}
-		}
-		defer f.Close()
-
+	if !preserveContent {
 		writingContent := []byte(content)
 		shouldAddNewLine := strings.Contains(flags, "newline")
 		if shouldAddNewLine {
@@ -2019,28 +2025,15 @@ func writeToFile(path, username, groupName, permissions string, args ...string) 
 		}
 	}
 
-	// Apply ownership and permissions. When the write was skipped (skipWrite),
-	// use path-based calls since there is no open file descriptor. Otherwise
-	// operate on the open fd so ownership/permissions target the file we
-	// opened even if the path is swapped after the open.
-	if skipWrite {
-		if username != "" || groupName != "" {
-			if err = os.Lchown(resolvedPath, uid, gid); err != nil {
-				return "", err
-			}
-		}
-		if err = os.Chmod(resolvedPath, perm); err != nil {
+	// Operate on the open file descriptor so ownership and permissions always
+	// target the file we opened, even if the path is swapped after the open.
+	if username != "" || groupName != "" {
+		if err = f.Chown(uid, gid); err != nil {
 			return "", err
 		}
-	} else {
-		if username != "" || groupName != "" {
-			if err = f.Chown(uid, gid); err != nil {
-				return "", err
-			}
-		}
-		if err = f.Chmod(perm); err != nil {
-			return "", err
-		}
+	}
+	if err = f.Chmod(perm); err != nil {
+		return "", err
 	}
 
 	return "", nil

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -2656,37 +2656,39 @@ func Test_writeToFile(t *testing.T) {
 	}
 }
 
-// Test_writeToFile_empty_content_guard verifies the VAULT-38287 fix: when
-// writeToFile is called with empty content and the destination file already
-// contains data, the existing file must not be truncated.  It also confirms
-// that empty content to a new (non-existent) file still creates the file.
-func Test_writeToFile_empty_content_guard(t *testing.T) {
-	t.Run("empty_content_does_not_overwrite_existing_file", func(t *testing.T) {
+// Test_writeToFile_preserve_on_empty verifies the preserve_on_empty flag
+// (VAULT-38287): when the flag is set and content is empty, an existing
+// non-empty file must not be truncated, but ownership and permissions are
+// still applied. Default behaviour (no flag) must be unchanged.
+func Test_writeToFile_preserve_on_empty(t *testing.T) {
+	const originalContent = "-----BEGIN RSA PRIVATE KEY-----\nbefore\n-----END RSA PRIVATE KEY-----\n"
+
+	// helper creates a temp dir with a pre-existing file containing originalContent.
+	setup := func(t *testing.T) (outDir, filePath string) {
+		t.Helper()
 		outDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer os.RemoveAll(outDir)
-
-		// Create a pre-existing file containing a "private key" payload.
-		existing, err := os.CreateTemp(outDir, "")
+		f, err := os.CreateTemp(outDir, "")
 		if err != nil {
 			t.Fatal(err)
 		}
-		const originalContent = "-----BEGIN RSA PRIVATE KEY-----\nbefore\n-----END RSA PRIVATE KEY-----\n"
-		if _, err = existing.WriteString(originalContent); err != nil {
+		if _, err = f.WriteString(originalContent); err != nil {
 			t.Fatal(err)
 		}
-		if err = existing.Close(); err != nil {
+		if err = f.Close(); err != nil {
 			t.Fatal(err)
 		}
-		outputFilePath := existing.Name()
+		return outDir, f.Name()
+	}
 
-		// Execute a template that pipes an empty string into writeToFile.
-		templateContent := fmt.Sprintf(
-			`{{ "" | writeToFile "%s" "" "" "0644" }}`,
-			outputFilePath)
-		tpl, err := NewTemplate(&NewTemplateInput{Contents: templateContent})
+	t.Run("preserve_on_empty_preserves_existing_file", func(t *testing.T) {
+		outDir, filePath := setup(t)
+		defer os.RemoveAll(outDir)
+
+		tmpl := fmt.Sprintf(`{{ "" | writeToFile "%s" "" "" "0644" "preserve_on_empty" }}`, filePath)
+		tpl, err := NewTemplate(&NewTemplateInput{Contents: tmpl})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2694,30 +2696,33 @@ func Test_writeToFile_empty_content_guard(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		got, err := os.ReadFile(outputFilePath)
+		got, err := os.ReadFile(filePath)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if string(got) != originalContent {
-			t.Errorf("writeToFile() with empty content overwrote existing file: got %q, want %q",
-				string(got), originalContent)
+			t.Errorf("preserve_on_empty: file overwritten, got %q, want %q", string(got), originalContent)
+		}
+		// Permissions must still be applied even though write was skipped.
+		info, err := os.Stat(filePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode() != 0644 {
+			t.Errorf("preserve_on_empty: permissions not applied, got %v, want 0644", info.Mode())
 		}
 	})
 
-	t.Run("empty_content_creates_new_file", func(t *testing.T) {
+	t.Run("preserve_on_empty_creates_new_file", func(t *testing.T) {
 		outDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer os.RemoveAll(outDir)
 
-		// Path that does not yet exist.
-		outputFilePath := outDir + "/new_file.key"
-
-		templateContent := fmt.Sprintf(
-			`{{ "" | writeToFile "%s" "" "" "0644" }}`,
-			outputFilePath)
-		tpl, err := NewTemplate(&NewTemplateInput{Contents: templateContent})
+		filePath := outDir + "/new_file.key"
+		tmpl := fmt.Sprintf(`{{ "" | writeToFile "%s" "" "" "0644" "preserve_on_empty" }}`, filePath)
+		tpl, err := NewTemplate(&NewTemplateInput{Contents: tmpl})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2725,12 +2730,58 @@ func Test_writeToFile_empty_content_guard(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		got, err := os.ReadFile(outputFilePath)
+		got, err := os.ReadFile(filePath)
 		if err != nil {
-			t.Fatalf("writeToFile() with empty content to new path did not create file: %v", err)
+			t.Fatalf("preserve_on_empty: new file not created: %v", err)
 		}
 		if len(got) != 0 {
-			t.Errorf("writeToFile() with empty content to new path: got %q, want empty file", string(got))
+			t.Errorf("preserve_on_empty: new file not empty, got %q", string(got))
+		}
+	})
+
+	t.Run("preserve_on_empty_with_newline_preserves_existing_file", func(t *testing.T) {
+		outDir, filePath := setup(t)
+		defer os.RemoveAll(outDir)
+
+		// newline flag must not bypass the preserve guard when content is empty.
+		tmpl := fmt.Sprintf(`{{ "" | writeToFile "%s" "" "" "0644" "preserve_on_empty,newline" }}`, filePath)
+		tpl, err := NewTemplate(&NewTemplateInput{Contents: tmpl})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err = tpl.Execute(nil); err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := os.ReadFile(filePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != originalContent {
+			t.Errorf("preserve_on_empty+newline: file overwritten, got %q, want %q", string(got), originalContent)
+		}
+	})
+
+	t.Run("no_flag_empty_content_overwrites_existing_file", func(t *testing.T) {
+		outDir, filePath := setup(t)
+		defer os.RemoveAll(outDir)
+
+		// Default behaviour unchanged: no preserve_on_empty → empty content truncates.
+		tmpl := fmt.Sprintf(`{{ "" | writeToFile "%s" "" "" "0644" }}`, filePath)
+		tpl, err := NewTemplate(&NewTemplateInput{Contents: tmpl})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err = tpl.Execute(nil); err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := os.ReadFile(filePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 0 {
+			t.Errorf("no flag: expected file truncated to empty, got %q", string(got))
 		}
 	})
 }

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -2656,6 +2656,87 @@ func Test_writeToFile(t *testing.T) {
 	}
 }
 
+// Test_writeToFile_empty_content_guard verifies the VAULT-38287 fix: when
+// writeToFile is called with empty content and the destination file already
+// contains data, the existing file must not be truncated.  It also confirms
+// that empty content to a new (non-existent) file still creates the file.
+func Test_writeToFile_empty_content_guard(t *testing.T) {
+	t.Run("empty_content_does_not_overwrite_existing_file", func(t *testing.T) {
+		outDir, err := os.MkdirTemp("", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(outDir)
+
+		// Create a pre-existing file containing a "private key" payload.
+		existing, err := os.CreateTemp(outDir, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		const originalContent = "-----BEGIN RSA PRIVATE KEY-----\nbefore\n-----END RSA PRIVATE KEY-----\n"
+		if _, err = existing.WriteString(originalContent); err != nil {
+			t.Fatal(err)
+		}
+		if err = existing.Close(); err != nil {
+			t.Fatal(err)
+		}
+		outputFilePath := existing.Name()
+
+		// Execute a template that pipes an empty string into writeToFile.
+		templateContent := fmt.Sprintf(
+			`{{ "" | writeToFile "%s" "" "" "0644" }}`,
+			outputFilePath)
+		tpl, err := NewTemplate(&NewTemplateInput{Contents: templateContent})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err = tpl.Execute(nil); err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := os.ReadFile(outputFilePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != originalContent {
+			t.Errorf("writeToFile() with empty content overwrote existing file: got %q, want %q",
+				string(got), originalContent)
+		}
+	})
+
+	t.Run("empty_content_creates_new_file", func(t *testing.T) {
+		outDir, err := os.MkdirTemp("", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(outDir)
+
+		// Path that does not yet exist.
+		outputFilePath := outDir + "/new_file.key"
+
+		templateContent := fmt.Sprintf(
+			`{{ "" | writeToFile "%s" "" "" "0644" }}`,
+			outputFilePath)
+		tpl, err := NewTemplate(&NewTemplateInput{Contents: templateContent})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err = tpl.Execute(nil); err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := os.ReadFile(outputFilePath)
+		if err != nil {
+			t.Fatalf("writeToFile() with empty content to new path did not create file: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("writeToFile() with empty content to new path: got %q, want empty file", string(got))
+		}
+	})
+}
+
+
+
 func Test_writeToFile_symlink_rejection(t *testing.T) {
 	if os.Getuid() == 0 {
 		t.Skip("skipping symlink-rejection tests when running as root")

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -2786,8 +2786,6 @@ func Test_writeToFile_preserve_on_empty(t *testing.T) {
 	})
 }
 
-
-
 func Test_writeToFile_symlink_rejection(t *testing.T) {
 	if os.Getuid() == 0 {
 		t.Skip("skipping symlink-rejection tests when running as root")


### PR DESCRIPTION
## Problem
When Vault Agent restarts while a PKI certificate is still within its 
TTL, the agent skips re-rendering but still executes the writeToFile 
directive — overwriting the private key file with blank content.
Fixes: https://hashicorp.atlassian.net/browse/VAULT-38287
## Solution
Added a guard in writeToFile that skips the write if the incoming 
content is empty and the destination file already has content.
## Testing
- Added regression tests for empty content with existing file
- Added regression tests for empty content with new file
- All existing tests pass

Fixes: https://hashicorp.atlassian.net/browse/VAULT-38287