### PR TITLE
Introduce a tls.Config field on VaultConfig

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -647,7 +647,11 @@ func (c *Config) Finalize() {
 	if c.Vault == nil {
 		c.Vault = DefaultVaultConfig()
 	}
-	c.Vault.Finalize()
+	if err := c.Vault.Finalize(); err != nil {
+		log.Printf("[ERR] (config) %s", err)
+		// Set Vault to disabled state to prevent client creation
+		c.Vault.Enabled = Bool(false)
+	}
 
 	if c.Wait == nil {
 		c.Wait = DefaultWaitConfig()

--- a/config/config.go
+++ b/config/config.go
@@ -647,11 +647,7 @@ func (c *Config) Finalize() {
 	if c.Vault == nil {
 		c.Vault = DefaultVaultConfig()
 	}
-	if err := c.Vault.Finalize(); err != nil {
-		log.Printf("[ERR] (config) %s", err)
-		// Set Vault to disabled state to prevent client creation
-		c.Vault.Enabled = Bool(false)
-	}
+	c.Vault.Finalize()
 
 	if c.Wait == nil {
 		c.Wait = DefaultWaitConfig()

--- a/config/vault.go
+++ b/config/vault.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"crypto/tls"
 	"fmt"
 	"time"
 
@@ -67,6 +68,12 @@ type VaultConfig struct {
 
 	// SSL indicates we should use a secure connection while talking to Vault.
 	SSL *SSLConfig `mapstructure:"ssl"`
+
+	// TLSConfig allows direct configuration of TLS settings for the Vault client.
+	// This is intended for programmatic use only and cannot be set via configuration files.
+	// When present, this takes precedence over the SSL field configuration.
+	// It is an error to set both TLSConfig and SSL fields.
+	TLSConfig *tls.Config `mapstructure:"-" json:"-"`
 
 	// Token is the Vault token to communicate with for requests. It may be
 	// a wrapped token or a real token. This can also be set via the VAULT_TOKEN
@@ -166,6 +173,8 @@ func (c *VaultConfig) Copy() *VaultConfig {
 		o.SSL = c.SSL.Copy()
 	}
 
+	o.TLSConfig = c.TLSConfig
+
 	o.Token = c.Token
 
 	o.VaultAgentTokenFile = c.VaultAgentTokenFile
@@ -229,6 +238,11 @@ func (c *VaultConfig) Merge(o *VaultConfig) *VaultConfig {
 		r.SSL = r.SSL.Merge(o.SSL)
 	}
 
+	if o.TLSConfig != nil {
+		r.TLSConfig = o.TLSConfig
+		//r.SSL = nil
+	}
+
 	if o.Token != nil {
 		r.Token = o.Token
 	}
@@ -277,7 +291,12 @@ func (c *VaultConfig) Merge(o *VaultConfig) *VaultConfig {
 }
 
 // Finalize ensures there no nil pointers.
-func (c *VaultConfig) Finalize() {
+func (c *VaultConfig) Finalize() error {
+	// Validate that both TLSConfig and SSL are not configured simultaneously
+	if c.TLSConfig != nil && c.SSL != nil && c.SSL.Enabled != nil && *c.SSL.Enabled {
+		return fmt.Errorf("vault config: cannot specify both TLSConfig and SSL configuration")
+	}
+
 	if c.Address == nil {
 		c.Address = stringFromEnv([]string{
 			api.EnvVaultAddress,
@@ -403,6 +422,8 @@ func (c *VaultConfig) Finalize() {
 			"VAULT_K8S_SERVICE_MOUNT_PATH",
 		}, DefaultK8SServiceMountPath)
 	}
+
+	return nil
 }
 
 // GoString defines the printable version of this struct.
@@ -418,6 +439,7 @@ func (c *VaultConfig) GoString() string {
 		"RenewToken:%s, "+
 		"Retry:%#v, "+
 		"SSL:%#v, "+
+		"TLSConfig:%t, "+
 		"Token:%t, "+
 		"VaultAgentTokenFile:%t, "+
 		"Transport:%#v, "+
@@ -435,6 +457,7 @@ func (c *VaultConfig) GoString() string {
 		BoolGoString(c.RenewToken),
 		c.Retry,
 		c.SSL,
+		c.TLSConfig != nil,
 		StringPresent(c.Token),
 		StringPresent(c.VaultAgentTokenFile),
 		c.Transport,

--- a/config/vault.go
+++ b/config/vault.go
@@ -173,7 +173,7 @@ func (c *VaultConfig) Copy() *VaultConfig {
 		o.SSL = c.SSL.Copy()
 	}
 
-	o.TLSConfig = c.TLSConfig
+	o.TLSConfig = c.TLSConfig.Clone()
 
 	o.Token = c.Token
 
@@ -292,11 +292,6 @@ func (c *VaultConfig) Merge(o *VaultConfig) *VaultConfig {
 
 // Finalize ensures there no nil pointers.
 func (c *VaultConfig) Finalize() error {
-	// Validate that both TLSConfig and SSL are not configured simultaneously
-	if c.TLSConfig != nil && c.SSL != nil && c.SSL.Enabled != nil && *c.SSL.Enabled {
-		return fmt.Errorf("vault config: cannot specify both TLSConfig and SSL configuration")
-	}
-
 	if c.Address == nil {
 		c.Address = stringFromEnv([]string{
 			api.EnvVaultAddress,

--- a/config/vault.go
+++ b/config/vault.go
@@ -173,8 +173,9 @@ func (c *VaultConfig) Copy() *VaultConfig {
 		o.SSL = c.SSL.Copy()
 	}
 
-	o.TLSConfig = c.TLSConfig.Clone()
-
+	if c.TLSConfig != nil {
+		o.TLSConfig = c.TLSConfig.Clone()
+	}
 	o.Token = c.Token
 
 	o.VaultAgentTokenFile = c.VaultAgentTokenFile

--- a/config/vault.go
+++ b/config/vault.go
@@ -240,7 +240,6 @@ func (c *VaultConfig) Merge(o *VaultConfig) *VaultConfig {
 
 	if o.TLSConfig != nil {
 		r.TLSConfig = o.TLSConfig
-		//r.SSL = nil
 	}
 
 	if o.Token != nil {
@@ -291,7 +290,7 @@ func (c *VaultConfig) Merge(o *VaultConfig) *VaultConfig {
 }
 
 // Finalize ensures there no nil pointers.
-func (c *VaultConfig) Finalize() error {
+func (c *VaultConfig) Finalize() {
 	if c.Address == nil {
 		c.Address = stringFromEnv([]string{
 			api.EnvVaultAddress,
@@ -417,8 +416,6 @@ func (c *VaultConfig) Finalize() error {
 			"VAULT_K8S_SERVICE_MOUNT_PATH",
 		}, DefaultK8SServiceMountPath)
 	}
-
-	return nil
 }
 
 // GoString defines the printable version of this struct.

--- a/config/vault.go
+++ b/config/vault.go
@@ -240,7 +240,7 @@ func (c *VaultConfig) Merge(o *VaultConfig) *VaultConfig {
 	}
 
 	if o.TLSConfig != nil {
-		r.TLSConfig = o.TLSConfig
+		r.TLSConfig = o.TLSConfig.Clone()
 	}
 
 	if o.Token != nil {

--- a/config/vault_test.go
+++ b/config/vault_test.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"crypto/tls"
 	"fmt"
 	"reflect"
 	"testing"
@@ -960,4 +961,179 @@ func TestVaultConfig_TokenRenew(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVaultConfig_Copy_TLSConfig(t *testing.T) {
+	t.Parallel()
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	c := &VaultConfig{TLSConfig: tlsConfig}
+	o := c.Copy()
+
+	if o.TLSConfig != tlsConfig {
+		t.Errorf("expected TLSConfig to be copied (same pointer)")
+	}
+}
+
+func TestVaultConfig_Merge_TLSConfig(t *testing.T) {
+	t.Parallel()
+
+	tlsConfig1 := &tls.Config{InsecureSkipVerify: true}
+	tlsConfig2 := &tls.Config{InsecureSkipVerify: false}
+
+	cases := []struct {
+		name string
+		a    *VaultConfig
+		b    *VaultConfig
+		r    *VaultConfig
+	}{
+		{
+			"nil_a",
+			nil,
+			&VaultConfig{TLSConfig: tlsConfig1},
+			&VaultConfig{TLSConfig: tlsConfig1},
+		},
+		{
+			"nil_b",
+			&VaultConfig{TLSConfig: tlsConfig1},
+			nil,
+			&VaultConfig{TLSConfig: tlsConfig1},
+		},
+		{
+			"nil_both",
+			nil,
+			nil,
+			nil,
+		},
+		{
+			"empty",
+			&VaultConfig{},
+			&VaultConfig{},
+			&VaultConfig{},
+		},
+		{
+			"tlsconfig_overrides",
+			&VaultConfig{TLSConfig: tlsConfig1},
+			&VaultConfig{TLSConfig: tlsConfig2},
+			&VaultConfig{TLSConfig: tlsConfig2},
+		},
+		{
+			"tlsconfig_empty",
+			&VaultConfig{TLSConfig: tlsConfig1},
+			&VaultConfig{},
+			&VaultConfig{TLSConfig: tlsConfig1},
+		},
+		{
+			"tlsconfig_empty_one",
+			&VaultConfig{},
+			&VaultConfig{TLSConfig: tlsConfig1},
+			&VaultConfig{TLSConfig: tlsConfig1},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.a.Merge(tc.b)
+			if tc.r == nil {
+				if r != nil {
+					t.Errorf("\nexp: %#v\nact: %#v", tc.r, r)
+				}
+			} else {
+				if r.TLSConfig != tc.r.TLSConfig {
+					t.Errorf("\nexp: %#v\nact: %#v", tc.r.TLSConfig, r.TLSConfig)
+				}
+			}
+		})
+	}
+}
+
+func TestVaultConfig_Finalize_TLSConfig(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		c         *VaultConfig
+		expectErr bool
+	}{
+		{
+			"tlsconfig_only",
+			&VaultConfig{
+				TLSConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+			false,
+		},
+		{
+			"ssl_only",
+			&VaultConfig{
+				SSL: &SSLConfig{
+					Enabled: Bool(true),
+					Verify:  Bool(true),
+				},
+			},
+			false,
+		},
+		{
+			"both_tlsconfig_and_ssl_enabled",
+			&VaultConfig{
+				TLSConfig: &tls.Config{},
+				SSL: &SSLConfig{
+					Enabled: Bool(true),
+					Verify:  Bool(true),
+				},
+			},
+			true,
+		},
+		{
+			"both_but_ssl_disabled",
+			&VaultConfig{
+				TLSConfig: &tls.Config{},
+				SSL: &SSLConfig{
+					Enabled: Bool(false),
+				},
+			},
+			false,
+		},
+		{
+			"both_but_ssl_nil_enabled",
+			&VaultConfig{
+				TLSConfig: &tls.Config{},
+				SSL: &SSLConfig{
+					Verify: Bool(true),
+				},
+			},
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.c.Finalize()
+			if tc.expectErr && err == nil {
+				t.Fatal("expected error when both TLSConfig and SSL are set")
+			}
+			if !tc.expectErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.expectErr && err != nil {
+				if !contains(err.Error(), "cannot specify both") {
+					t.Errorf("unexpected error message: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// Helper function to check if a string contains a substring
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		(len(s) > 0 && len(substr) > 0 && findSubstring(s, substr)))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
 }

--- a/config/vault_test.go
+++ b/config/vault_test.go
@@ -36,6 +36,9 @@ func TestVaultConfig_Copy(t *testing.T) {
 				Retry:      &RetryConfig{Enabled: Bool(true)},
 				SSL:        &SSLConfig{Enabled: Bool(true)},
 				Token:      String("token"),
+				TLSConfig: &tls.Config{
+					ServerName: "server",
+				},
 				Transport: &TransportConfig{
 					DialKeepAlive: TimeDuration(20 * time.Second),
 				},
@@ -963,18 +966,6 @@ func TestVaultConfig_TokenRenew(t *testing.T) {
 	}
 }
 
-func TestVaultConfig_Copy_TLSConfig(t *testing.T) {
-	t.Parallel()
-
-	tlsConfig := &tls.Config{InsecureSkipVerify: true}
-	c := &VaultConfig{TLSConfig: tlsConfig}
-	o := c.Copy()
-
-	if o.TLSConfig != tlsConfig {
-		t.Errorf("expected TLSConfig to be copied (same pointer)")
-	}
-}
-
 func TestVaultConfig_Merge_TLSConfig(t *testing.T) {
 	t.Parallel()
 
@@ -1039,94 +1030,12 @@ func TestVaultConfig_Merge_TLSConfig(t *testing.T) {
 					t.Errorf("\nexp: %#v\nact: %#v", tc.r, r)
 				}
 			} else {
-				if r.TLSConfig != tc.r.TLSConfig {
+				if !reflect.DeepEqual(r.TLSConfig, tc.r.TLSConfig) {
 					t.Errorf("\nexp: %#v\nact: %#v", tc.r.TLSConfig, r.TLSConfig)
 				}
 			}
 		})
 	}
-}
-
-func TestVaultConfig_Finalize_TLSConfig(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name      string
-		c         *VaultConfig
-		expectErr bool
-	}{
-		{
-			"tlsconfig_only",
-			&VaultConfig{
-				TLSConfig: &tls.Config{InsecureSkipVerify: true},
-			},
-			false,
-		},
-		{
-			"ssl_only",
-			&VaultConfig{
-				SSL: &SSLConfig{
-					Enabled: Bool(true),
-					Verify:  Bool(true),
-				},
-			},
-			false,
-		},
-		{
-			"both_tlsconfig_and_ssl_enabled",
-			&VaultConfig{
-				TLSConfig: &tls.Config{},
-				SSL: &SSLConfig{
-					Enabled: Bool(true),
-					Verify:  Bool(true),
-				},
-			},
-			true,
-		},
-		{
-			"both_but_ssl_disabled",
-			&VaultConfig{
-				TLSConfig: &tls.Config{},
-				SSL: &SSLConfig{
-					Enabled: Bool(false),
-				},
-			},
-			false,
-		},
-		{
-			"both_but_ssl_nil_enabled",
-			&VaultConfig{
-				TLSConfig: &tls.Config{},
-				SSL: &SSLConfig{
-					Verify: Bool(true),
-				},
-			},
-			false,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := tc.c.Finalize()
-			if tc.expectErr && err == nil {
-				t.Fatal("expected error when both TLSConfig and SSL are set")
-			}
-			if !tc.expectErr && err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if tc.expectErr && err != nil {
-				if !contains(err.Error(), "cannot specify both") {
-					t.Errorf("unexpected error message: %v", err)
-				}
-			}
-		})
-	}
-}
-
-// Helper function to check if a string contains a substring
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
-		(len(s) > 0 && len(substr) > 0 && findSubstring(s, substr)))
 }
 
 func findSubstring(s, substr string) bool {

--- a/dependency/client_set.go
+++ b/dependency/client_set.go
@@ -101,6 +101,10 @@ type CreateVaultClientInput struct {
 	ServerName      string
 	ClientUserAgent string
 
+	// TLSConfig allows direct configuration of TLS settings.
+	// When present, this takes precedence over SSL* fields.
+	TLSConfig *tls.Config
+
 	K8SAuthRoleName            string
 	K8SServiceAccountTokenPath string
 	K8SServiceAccountToken     string
@@ -288,8 +292,12 @@ func (c *ClientSet) CreateVaultClient(i *CreateVaultClientInput) error {
 		TLSHandshakeTimeout: i.TransportTLSHandshakeTimeout,
 	}
 
-	// Configure SSL
-	if i.SSLEnabled {
+	// Configure TLS
+	if i.TLSConfig != nil {
+		// Use the provided TLS config directly
+		transport.TLSClientConfig = i.TLSConfig
+	} else if i.SSLEnabled {
+		// Build TLS config from SSL fields
 		var tlsConfig tls.Config
 
 		// Custom certificate or certificate and key

--- a/dependency/client_set_test.go
+++ b/dependency/client_set_test.go
@@ -4,14 +4,18 @@
 package dependency
 
 import (
+	"crypto/tls"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul-template/test"
+	"github.com/hashicorp/go-rootcerts"
 	"github.com/hashicorp/vault/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -204,12 +208,17 @@ func (m vaultMock) processReq(tb testing.TB, w http.ResponseWriter, r *http.Requ
 		tb.Fatalf("User-Agent header not as expected. Expected %s, got %s. Request was to %s", userAgent, r.UserAgent(), r.RequestURI)
 	}
 
-	var data map[string]interface{}
-	err := json.NewDecoder(r.Body).Decode(&data)
-	if !assert.NoError(tb, err) {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	body, err := io.ReadAll(r.Body)
+	assert.NoError(tb, err)
 
-		return
+	var data map[string]interface{}
+	if len(body) > 0 {
+		err := json.NewDecoder(strings.NewReader(string(body))).Decode(&data)
+		if !assert.NoError(tb, err) {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+
+			return
+		}
 	}
 
 	tb.Logf("%s: %s: %+v", r.Method, r.URL, data)
@@ -247,4 +256,60 @@ func newVaultMockReversedProxy(tb testing.TB, mocks ...vaultMock) string {
 	tb.Cleanup(testServer.Close)
 
 	return testServer.URL
+}
+
+func TestClientSet_CreateVaultClient_TLSConfig(t *testing.T) {
+	t.Parallel()
+
+	tlsConfig := &tls.Config{}
+	rootConfig := &rootcerts.Config{
+		CAFile: testVaultTLS.caPemPath,
+	}
+	require.NoError(t, rootcerts.ConfigureTLS(tlsConfig, rootConfig))
+
+	t.Run("with_tlsconfig", func(t *testing.T) {
+		clientSet := NewClientSet()
+		err := clientSet.CreateVaultClient(&CreateVaultClientInput{
+			ClientUserAgent: userAgent,
+			Address:         vaultHttpsAddr,
+			Token:           vaultToken,
+			TLSConfig:       tlsConfig,
+		})
+		require.NoError(t, err)
+
+		// Verify client was created and can communicate
+		client := clientSet.Vault()
+		require.NotNil(t, client)
+
+		// Make a simple API call to verify it works
+		health, err := client.Sys().Health()
+		require.NoError(t, err)
+		require.NotNil(t, health)
+	})
+
+	t.Run("tlsconfig_precedence_over_ssl", func(t *testing.T) {
+		// This test verifies that when TLSConfig is provided,
+		// SSL fields are ignored (even if they would cause errors)
+
+		clientSet := NewClientSet()
+		err := clientSet.CreateVaultClient(&CreateVaultClientInput{
+			ClientUserAgent: userAgent,
+			Address:         vaultHttpsAddr,
+			Token:           vaultToken,
+			TLSConfig:       tlsConfig,
+			SSLEnabled:      true,
+			SSLVerify:       true,
+			SSLCert:         "/invalid/path/to/cert.pem", // This should be ignored
+			SSLKey:          "/invalid/path/to/key.pem",  // This should be ignored
+		})
+		require.NoError(t, err)
+
+		// Verify client works despite invalid SSL fields
+		client := clientSet.Vault()
+		require.NotNil(t, client)
+
+		health, err := client.Sys().Health()
+		require.NoError(t, err)
+		require.NotNil(t, health)
+	})
 }

--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -24,13 +25,16 @@ import (
 )
 
 const (
-	vaultAddr  = "http://127.0.0.1:8200"
-	vaultToken = "a_token"
+	vaultAddr        = "http://127.0.0.1:8200"
+	vaultHttpsListen = "127.0.0.1:8210"
+	vaultHttpsAddr   = "https://" + vaultHttpsListen
+	vaultToken       = "a_token"
 )
 
 var (
 	testConsul    *testutil.TestServer
 	testVault     *vaultServer
+	testVaultTLS  *vaultServer
 	testNomad     *nomadServer
 	testClients   *ClientSet
 	tenancyHelper *test.TenancyHelper
@@ -40,6 +44,7 @@ func TestMain(m *testing.M) {
 	log.SetOutput(io.Discard)
 	nomadFuture := runTestNomad()
 	runTestVault()
+	runTestVaultTLS()
 	tb := &test.TestingTB{}
 	runTestConsul(tb)
 	clients := NewClientSet()
@@ -52,6 +57,7 @@ func TestMain(m *testing.M) {
 		if r := recover(); r != nil {
 			testConsul.Stop()
 			testVault.Stop()
+			testVaultTLS.Stop()
 			testNomad.Stop()
 			panic(r)
 		}
@@ -111,6 +117,14 @@ func TestMain(m *testing.M) {
 		Fatalf("failed to start Nomad: %v\n", err)
 	}
 
+	if err := clients.CreateVaultClient(&CreateVaultClientInput{
+		Address:   vaultHttpsAddr,
+		Token:     vaultToken,
+		SSLCACert: testVaultTLS.caPemPath,
+	}); err != nil {
+		Fatalf("failed to create TLS vault client: %v\n", err)
+	}
+
 	exit := m.Run()
 
 	tb.DoCleanup()
@@ -121,6 +135,7 @@ func TestMain(m *testing.M) {
 func stopTestClients() {
 	testConsul.Stop()
 	testVault.Stop()
+	testVaultTLS.Stop()
 	testNomad.Stop()
 }
 
@@ -426,6 +441,7 @@ func (n *nomadServer) Stop() error {
 
 type vaultServer struct {
 	secretsPath string
+	caPemPath   string
 	cmd         *exec.Cmd
 }
 
@@ -447,6 +463,36 @@ func runTestVault() {
 	}
 	testVault = &vaultServer{
 		cmd: cmd,
+	}
+}
+
+func runTestVaultTLS() {
+	path, err := exec.LookPath("vault")
+	if err != nil || path == "" {
+		Fatalf("vault not found on $PATH")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "")
+	if err != nil {
+		Fatalf("error creating temp dir: %v", err)
+	}
+
+	args := []string{
+		"server", "-dev", "-dev-root-token-id", vaultToken,
+		"-dev-listen-address", vaultHttpsListen,
+		"-dev-no-store-token", "-dev-tls", "-dev-tls-cert-dir", tmpDir,
+	}
+	cmd := exec.Command("vault", args...)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+
+	fmt.Println("tpmdir", tmpDir)
+	if err := cmd.Start(); err != nil {
+		Fatalf("vault failed to start: %v", err)
+	}
+	testVaultTLS = &vaultServer{
+		cmd:       cmd,
+		caPemPath: filepath.Join(tmpDir, "vault-ca.pem"),
 	}
 }
 

--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -117,14 +117,6 @@ func TestMain(m *testing.M) {
 		Fatalf("failed to start Nomad: %v\n", err)
 	}
 
-	if err := clients.CreateVaultClient(&CreateVaultClientInput{
-		Address:   vaultHttpsAddr,
-		Token:     vaultToken,
-		SSLCACert: testVaultTLS.caPemPath,
-	}); err != nil {
-		Fatalf("failed to create TLS vault client: %v\n", err)
-	}
-
 	exit := m.Run()
 
 	tb.DoCleanup()

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -1428,6 +1428,7 @@ func NewClientSet(c *config.Config) (*dep.ClientSet, error) {
 		SSLCAPath:                    config.StringVal(c.Vault.SSL.CaPath),
 		ServerName:                   config.StringVal(c.Vault.SSL.ServerName),
 		ClientUserAgent:              config.StringVal(c.Vault.ClientUserAgent),
+		TLSConfig:                    c.Vault.TLSConfig,
 		TransportCustomDialer:        c.Vault.Transport.CustomDialer,
 		TransportDialKeepAlive:       config.TimeDurationVal(c.Vault.Transport.DialKeepAlive),
 		TransportDialTimeout:         config.TimeDurationVal(c.Vault.Transport.DialTimeout),


### PR DESCRIPTION
Context: https://hashicorp.atlassian.net/browse/VAULT-46384 adds support for authenticating to Vault using a client cert whose private key is stored in a TPM, meaning it can't be referenced as a file.

To accommodate this, introduce a `TLSConfig *tls.Config` field on `VaultConfig` that allows callers to supply a pre-built TLS configuration instead of using the file-based TLS config fields. .

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
