### PR TITLE
fix(ci): add retry logic and readiness checks for consul and vault in tests

### DIFF
--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -5,10 +5,12 @@ package dependency
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -274,12 +276,25 @@ func (c *ClientSet) createConsulPeerings(tenancy *test.Tenancy) error {
 }
 
 func runTestConsul(tb testutil.TestingTB) {
-	consul, err := testutil.NewTestServerConfigT(tb,
-		func(c *testutil.TestServerConfig) {
-			c.LogLevel = "warn"
-			c.Stdout = io.Discard
-			c.Stderr = io.Discard
-		})
+	cfg := func(c *testutil.TestServerConfig) {
+		c.LogLevel = "warn"
+		c.Stdout = io.Discard
+		c.Stderr = io.Discard
+	}
+	// Retry up to 3 times; the SDK's waitForAPI has only a 2-second window
+	// which can be exceeded on slow CI runners.
+	var (
+		consul *testutil.TestServer
+		err    error
+	)
+	for attempt := 1; attempt <= 3; attempt++ {
+		consul, err = testutil.NewTestServerConfigT(tb, cfg)
+		if err == nil {
+			break
+		}
+		fmt.Printf("consul start attempt %d/3 failed: %v — retrying\n", attempt, err)
+		time.Sleep(time.Duration(attempt) * time.Second)
+	}
 	if err != nil {
 		Fatalf("failed to start consul server: %v", err)
 	}
@@ -437,6 +452,21 @@ type vaultServer struct {
 	cmd         *exec.Cmd
 }
 
+// waitForVaultReady polls addr/v1/sys/health (using client) until it responds
+// or the 15-second deadline is exceeded, at which point it calls Fatalf.
+func waitForVaultReady(addr string, client *http.Client) {
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(addr + "/v1/sys/health")
+		if err == nil {
+			resp.Body.Close()
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	Fatalf("vault at %s did not become ready within 15s", addr)
+}
+
 func runTestVault() {
 	path, err := exec.LookPath("vault")
 	if err != nil || path == "" {
@@ -453,9 +483,8 @@ func runTestVault() {
 	if err := cmd.Start(); err != nil {
 		Fatalf("vault failed to start: %v", err)
 	}
-	testVault = &vaultServer{
-		cmd: cmd,
-	}
+	testVault = &vaultServer{cmd: cmd}
+	waitForVaultReady(vaultAddr, &http.Client{Timeout: 500 * time.Millisecond})
 }
 
 func runTestVaultTLS() {
@@ -486,6 +515,14 @@ func runTestVaultTLS() {
 		cmd:       cmd,
 		caPemPath: filepath.Join(tmpDir, "vault-ca.pem"),
 	}
+	// The TLS server uses a self-signed cert; skip verification for the health check.
+	tlsClient := &http.Client{
+		Timeout: 500 * time.Millisecond,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		},
+	}
+	waitForVaultReady(vaultHttpsAddr, tlsClient)
 }
 
 func (v vaultServer) Stop() error {

--- a/dependency/file.go
+++ b/dependency/file.go
@@ -113,6 +113,16 @@ func (d *FileQuery) watch(lastStat os.FileInfo) <-chan *watchResult {
 				lastStat.ModTime() != stat.ModTime()
 
 			if changed {
+				// A concurrent write using O_TRUNC may cause stat to show an
+				// intermediate size of 0 before the new content is flushed.
+				// Re-stat after a brief pause to confirm the file is stable.
+				if lastStat != nil {
+					time.Sleep(FileQuerySleepTime)
+					if stat2, err2 := os.Stat(d.path); err2 == nil &&
+						(stat2.Size() != stat.Size() || stat2.ModTime() != stat.ModTime()) {
+						stat = stat2
+					}
+				}
 				select {
 				case <-d.stopCh:
 					return

--- a/dependency/file_test.go
+++ b/dependency/file_test.go
@@ -190,6 +190,8 @@ func TestFileQuery_Fetch(t *testing.T) {
 			t.Fatal(err)
 		case data := <-dataCh:
 			assert.Equal(t, "goodbye", data)
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for file change")
 		}
 	})
 }

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -7,11 +7,13 @@ import (
 	"encoding/json"
 	"io"
 	"log"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	dep "github.com/hashicorp/consul-template/dependency"
 	"github.com/hashicorp/vault/api"
@@ -79,9 +81,19 @@ func newTestVault() *vaultServer {
 	if err := cmd.Start(); err != nil {
 		panic("vault failed to start: " + err.Error())
 	}
-	return &vaultServer{
-		cmd: cmd,
+
+	// Wait for Vault to be ready before returning.
+	client := &http.Client{Timeout: 500 * time.Millisecond}
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(vaultAddr + "/v1/sys/health")
+		if err == nil {
+			resp.Body.Close()
+			return &vaultServer{cmd: cmd}
+		}
+		time.Sleep(100 * time.Millisecond)
 	}
+	panic("vault did not become ready within 15s")
 }
 
 // Sets up approle auto-auth for token generation/testing


### PR DESCRIPTION
### Description of the change

This PR fixes three independent causes of flaky CI test failures in the `fix/ci-failure` branch.

---

#### 1. Vault startup race condition (`watch` and `dependency` packages)

`newTestVault()` in `watch/watch_test.go` and `runTestVault()` / `runTestVaultTLS()` in `dependency/dependency_test.go` all called `cmd.Start()` and returned immediately. The first Vault API call that followed (enabling AppRole auth, mounting a secrets engine, etc.) would hit `connection refused` because the Vault process had not yet bound its HTTP listener — especially likely on loaded CI runners.

**Fix:** Each function now polls `GET /v1/sys/health` after starting the process and blocks until the endpoint responds or a 15-second deadline is exceeded. The TLS variant uses a skip-verify transport since the dev server generates a self-signed certificate. A shared `waitForVaultReady(addr, client)` helper is extracted in the dependency package.

---

#### 2. Consul `"api unavailable"` failures (`dependency` package)

`testutil.NewTestServerConfigT` from the Consul SDK uses a hardcoded 2-second `TwoSeconds()` retry window to poll `/v1/status/leader` before declaring the server unavailable. On slow or busy CI runners this window is exhausted before the fresh `consul agent` process is responsive, causing `runTestConsul` to fatal.

**Fix:** `runTestConsul()` now retries `NewTestServerConfigT` up to 3 times with a linear back-off (1 s, 2 s, 3 s between attempts). The SDK cleans up the consul process on failure, so retrying is safe.

---

#### 3. `FileQuery` O_TRUNC write race (`dependency/file.go`)

`TestFileQuery_Fetch/fires_changes` was failing with the second `Fetch` returning `""` instead of `"goodbye"`. The write uses `O_TRUNC`, which zeros the file before writing new content. The polling `watch()` goroutine would observe the intermediate zero-size stat, declare `changed == true`, and fire immediately — at which point `os.ReadFile` would race with the in-progress write and read empty or partial content.

**Fix:** When `watch()` detects a change on a file it has seen before (`lastStat != nil`), it now sleeps one `FileQuerySleepTime` interval and re-stats the file. If the size or mtime changed again during that window the updated stat is used, ensuring `Fetch` reads only after the write is complete. The `lastStat != nil` guard avoids adding latency to the initial read. A `time.After(5s)` timeout is also added to the test's second `select` so any future regression produces a clear failure message instead of a silent hang.

---

### Revert plan

All changes are confined to test infrastructure (`_test.go` files) and the `FileQuery.watch()` polling function. Reverting the PR restores the previous behaviour with no data-path impact.

The `watch()` stabilisation change could theoretically slow down file change detection by one extra `FileQuerySleepTime` interval on updates (50 ms in tests, 2 s in production). If that is unacceptable the stabilisation block can be removed independently; the Vault/Consul startup fixes are entirely separate.

---

### Impact on security controls

No changes to security controls. The affected code is:
- Test setup helpers (`dependency_test.go`, `watch_test.go`) — not shipped in production binaries.
- `FileQuery.watch()` — a local file polling loop with no network access, no authentication, and no logging changes.

---

## PCI review checklist

- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.