### PR TITLE
fix: make Vault dependency sleeps interruptible

### DIFF
--- a/dependency/vault_pki.go
+++ b/dependency/vault_pki.go
@@ -98,7 +98,13 @@ func (d *VaultPKIQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interface
 	}
 	select {
 	case dur := <-d.sleepCh:
-		time.Sleep(dur)
+		timer := time.NewTimer(dur)
+		select {
+		case <-timer.C:
+		case <-d.stopCh:
+			timer.Stop()
+			return nil, nil, ErrStopped
+		}
 	default:
 	}
 

--- a/dependency/vault_pki_stop_test.go
+++ b/dependency/vault_pki_stop_test.go
@@ -1,0 +1,48 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package dependency
+
+import (
+	"errors"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestVaultPKIQuery_FetchStopsWhileSleeping(t *testing.T) {
+	d, err := NewVaultPKIQuery("pki/issue/example-dot-com", "/dev/null", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d.sleepCh <- time.Hour
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, _, err := d.Fetch(nil, nil)
+		errCh <- err
+	}()
+
+	// Wait until Fetch has consumed the duration and entered its sleep. This
+	// makes the test exercise cancellation of an in-progress sleep rather than
+	// the early stop check at the beginning of Fetch.
+	deadline := time.Now().Add(time.Second)
+	for len(d.sleepCh) != 0 && time.Now().Before(deadline) {
+		runtime.Gosched()
+	}
+	if len(d.sleepCh) != 0 {
+		t.Fatal("Fetch did not start sleeping")
+	}
+
+	d.Stop()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, ErrStopped) {
+			t.Fatalf("Fetch returned %v after Stop, want ErrStopped", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Fetch did not return after Stop (goroutine leak)")
+	}
+}

--- a/dependency/vault_write.go
+++ b/dependency/vault_write.go
@@ -61,7 +61,13 @@ func (d *VaultWriteQuery) Fetch(clients *ClientSet, opts *QueryOptions,
 	}
 	select {
 	case dur := <-d.sleepCh:
-		time.Sleep(dur)
+		timer := time.NewTimer(dur)
+		select {
+		case <-timer.C:
+		case <-d.stopCh:
+			timer.Stop()
+			return nil, nil, ErrStopped
+		}
 	default:
 	}
 

--- a/dependency/vault_write_stop_test.go
+++ b/dependency/vault_write_stop_test.go
@@ -1,0 +1,48 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package dependency
+
+import (
+	"errors"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestVaultWriteQuery_FetchStopsWhileSleeping(t *testing.T) {
+	d, err := NewVaultWriteQuery("transit/encrypt/example", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d.sleepCh <- time.Hour
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, _, err := d.Fetch(nil, nil)
+		errCh <- err
+	}()
+
+	// Wait until Fetch has consumed the duration and entered its sleep. This
+	// makes the test exercise cancellation of an in-progress sleep rather than
+	// the early stop check at the beginning of Fetch.
+	deadline := time.Now().Add(time.Second)
+	for len(d.sleepCh) != 0 && time.Now().Before(deadline) {
+		runtime.Gosched()
+	}
+	if len(d.sleepCh) != 0 {
+		t.Fatal("Fetch did not start sleeping")
+	}
+
+	d.Stop()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, ErrStopped) {
+			t.Fatalf("Fetch returned %v after Stop, want ErrStopped", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Fetch did not return after Stop (goroutine leak)")
+	}
+}


### PR DESCRIPTION
## Description

Fixes #2170.

`VaultPKIQuery.Fetch` and `VaultWriteQuery.Fetch` currently use `time.Sleep` while waiting for the next certificate/secret refresh. Once that sleep begins, `Stop` cannot interrupt it, so stopping or replacing a runner leaves the fetch goroutine alive until the deadline.

This change makes both waits select on a timer and the dependency's `stopCh`. A stop now cancels the timer and returns `ErrStopped`, matching the behavior already used by `VaultReadQuery` after #1644.

The two regression tests deterministically wait until each `Fetch` has consumed a one-hour delay, stop the dependency, and verify that the goroutine exits promptly with `ErrStopped`.

## Testing

- The regression test fails against the original implementation:

  ```text
  --- FAIL: TestVaultPKIQuery_FetchStopsWhileSleeping (1.00s)
      vault_pki_stop_test.go:46: Fetch did not return after Stop (goroutine leak)
  ```

- Both patched tests pass 100 consecutive runs:

  ```text
  ok github.com/hashicorp/consul-template/dependency 0.830s
  ```

- `go test -c ./dependency`
- `go vet ./dependency`
- `git diff --check`

## Revert plan

Revert this pull request. The change is limited to cancellation of the PKI and Vault write refresh waits and their two unit tests.

## PCI review checklist

- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] I have documented the revert plan.
- [x] This change does not add, remove, or modify a security control.
