### PR TITLE
fix(vault_read): don't cache isKVv2 fallback on probe error

### DIFF
--- a/dependency/vault_read.go
+++ b/dependency/vault_read.go
@@ -146,19 +146,32 @@ func (d *VaultReadQuery) readSecret(clients *ClientSet) (*api.Secret, error) {
 	vaultClient := clients.Vault()
 
 	// Check whether this secret refers to a KV v2 entry if we haven't yet.
+	//
+	// Cache only on a SUCCESSFUL probe (err == nil). On a transient probe
+	// failure (e.g. Vault context deadline exceeded during startup) the
+	// "assume not v2" fallback is used for this one read attempt but is
+	// NOT cached, so the next Fetch() call re-probes once Vault is healthy.
+	// Caching the failure-fallback permanently latched the dependency into
+	// v1 mode for the lifetime of the process, even after Vault recovered
+	// — see issue #2149.
 	if d.isKVv2 == nil {
 		mountPath, isKVv2, err := isKVv2(vaultClient, d.rawPath)
 		if err != nil {
 			log.Printf("[WARN] %s: failed to check if %s is KVv2, "+
-				"assume not: %s", d, d.rawPath, err)
-			isKVv2 = false
+				"assume not (will re-probe on next fetch): %s",
+				d, d.rawPath, err)
 			d.secretPath = d.rawPath
+			// Intentionally do not set d.isKVv2 here: a transient Vault
+			// failure must not poison this dependency for the process
+			// lifetime. The next Fetch() will re-enter this block and
+			// probe again.
 		} else if isKVv2 {
 			d.secretPath = shimKVv2Path(d.rawPath, mountPath, clients.Vault().Namespace())
+			d.isKVv2 = &isKVv2
 		} else {
 			d.secretPath = d.rawPath
+			d.isKVv2 = &isKVv2
 		}
-		d.isKVv2 = &isKVv2
 	}
 
 	queryString := d.queryValues.Encode()

--- a/dependency/vault_read_test.go
+++ b/dependency/vault_read_test.go
@@ -5,9 +5,12 @@ package dependency
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -878,4 +881,146 @@ func TestDeletedKVv2(t *testing.T) {
 	assert.False(t, deletedKVv2(&api.Secret{
 		Data: map[string]interface{}{},
 	}))
+}
+
+// TestVaultReadQuery_isKVv2_NotCachedOnProbeError verifies the fix for
+// hashicorp/consul-template#2149: a transient failure of the isKVv2 mount
+// probe must NOT poison d.isKVv2 with the assumed-not-v2 fallback. Caching
+// the failure-fallback permanently latched the dependency into KV v1 mode
+// for the lifetime of the process, even after Vault recovered — which
+// caused fresh KV v2 reads to keep failing with "Invalid path for a
+// versioned K/V secrets engine" until the agent was restarted.
+//
+// Post-fix: after a failed probe, d.isKVv2 stays nil so the next Fetch()
+// re-enters the probe block and re-detects the mount type once Vault is
+// reachable again.
+func TestVaultReadQuery_isKVv2_NotCachedOnProbeError(t *testing.T) {
+	// Build a fresh ClientSet pointed at an unreachable Vault address.
+	// The isKVv2 probe (GET sys/internal/ui/mounts/<path>) will fail with
+	// a connection error — exactly the transient-error shape from #2149
+	// (the field repro was context-deadline-exceeded against a Vault that
+	// recovered seconds later).
+	clients := NewClientSet()
+	if err := clients.CreateVaultClient(&CreateVaultClientInput{
+		Address:              "http://127.0.0.1:1",
+		Token:                "fake",
+		TransportDialTimeout: 100 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("CreateVaultClient: %s", err)
+	}
+	// Keep the test fast: skip vault-api's default retry backoff (2
+	// retries × ~1-5s) for the connection-refused probe.
+	clients.Vault().SetMaxRetries(0)
+
+	d, err := NewVaultReadQuery("secret/foo/bar")
+	if err != nil {
+		t.Fatalf("NewVaultReadQuery: %s", err)
+	}
+
+	// First probe attempt — must fail at the network layer. The actual
+	// return is irrelevant; we only care about post-call field state.
+	_, _ = d.readSecret(clients)
+
+	if d.isKVv2 != nil {
+		t.Fatalf("d.isKVv2 was cached after a failed probe (= %v); "+
+			"expected nil so the next Fetch re-probes once Vault recovers "+
+			"(see hashicorp/consul-template#2149)", *d.isKVv2)
+	}
+	// Fallback for the one in-flight read attempt is still correct.
+	if d.secretPath != "secret/foo/bar" {
+		t.Errorf("d.secretPath = %q after failed probe; want %q "+
+			"(rawPath fallback for the current read attempt)",
+			d.secretPath, "secret/foo/bar")
+	}
+
+	// A second readSecret call must re-enter the probe block (not the
+	// previously-broken cached-false fast path) and fail the same way.
+	_, _ = d.readSecret(clients)
+	if d.isKVv2 != nil {
+		t.Fatalf("d.isKVv2 was cached after a second failed probe "+
+			"(= %v); the latch fix is defeated", *d.isKVv2)
+	}
+}
+
+// TestVaultReadQuery_isKVv2_RecoversAndDetectsKVv2 is the recovery half of
+// hashicorp/consul-template#2149: after a failed isKVv2 probe leaves
+// d.isKVv2 nil, a later successful probe must actually detect KV v2
+// (shim /data/ into secretPath) rather than remaining stuck on the
+// "assume not v2" fallback. The probe is stubbed with httptest so this
+// does not require a live Vault or Nomad agent.
+func TestVaultReadQuery_isKVv2_RecoversAndDetectsKVv2(t *testing.T) {
+	var recovered atomic.Bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/v1/sys/internal/ui/mounts/"):
+			if !recovered.Load() {
+				// Transient probe failure: isKVv2 must return err so the
+				// assumed-not-v2 fallback is used for this attempt only.
+				w.WriteHeader(http.StatusInternalServerError)
+				fmt.Fprintln(w, `{"errors":["temporary"]}`)
+				return
+			}
+			fmt.Fprintln(w, `{
+				"data": {
+					"path": "secret/",
+					"type": "kv",
+					"options": {"version": "2"}
+				}
+			}`)
+		case r.URL.Path == "/v1/secret/data/foo/bar":
+			fmt.Fprintln(w, `{
+				"data": {
+					"data": {"k": "v"},
+					"metadata": {"deletion_time": "", "destroyed": false, "version": 1}
+				}
+			}`)
+		default:
+			// v1 fallback path during the failed-probe attempt.
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprintln(w, `{"errors":["no secret"]}`)
+		}
+	}))
+	defer srv.Close()
+
+	clients := NewClientSet()
+	if err := clients.CreateVaultClient(&CreateVaultClientInput{
+		Address: srv.URL,
+		Token:   "fake",
+	}); err != nil {
+		t.Fatalf("CreateVaultClient: %s", err)
+	}
+	// Avoid vault-api retrying the 500 probe (default is 2 retries).
+	clients.Vault().SetMaxRetries(0)
+
+	d, err := NewVaultReadQuery("secret/foo/bar")
+	if err != nil {
+		t.Fatalf("NewVaultReadQuery: %s", err)
+	}
+
+	_, _ = d.readSecret(clients)
+	if d.isKVv2 != nil {
+		t.Fatalf("d.isKVv2 was cached after a failed probe (= %v); expected nil", *d.isKVv2)
+	}
+	if d.secretPath != "secret/foo/bar" {
+		t.Fatalf("d.secretPath = %q after failed probe; want rawPath fallback", d.secretPath)
+	}
+
+	recovered.Store(true)
+
+	secret, err := d.readSecret(clients)
+	if err != nil {
+		t.Fatalf("readSecret after probe recovery: %s", err)
+	}
+	if d.isKVv2 == nil || !*d.isKVv2 {
+		t.Fatalf("after successful probe, d.isKVv2 = %v; want true (KV v2 detected)", d.isKVv2)
+	}
+	if d.secretPath != "secret/data/foo/bar" {
+		t.Fatalf("d.secretPath = %q after recovery; want %q (KV v2 shim)",
+			d.secretPath, "secret/data/foo/bar")
+	}
+	if secret == nil || secret.Data == nil {
+		t.Fatal("expected a KV v2 secret after recovery")
+	}
 }


### PR DESCRIPTION
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

Fixes #2149

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

## Problem

If Vault is temporarily unreachable during the first `isKVv2` mount probe for a `secret "secret/..."` template, consul-template logs `failed to check if <path> is KVv2, assume not` and caches that assumed-not-v2 result on the dependency for process lifetime. After Vault recovers, reads keep going to `/v1/secret/...` instead of the KV v2 path `/v1/secret/data/...`, producing persistent 403s until restart. In Nomad this can wedge allocation recovery because template prestart never completes.

## Fix

Cache `d.isKVv2` only on a **successful** probe. On probe error, keep using the existing per-attempt "assume not v2" fallback (`d.secretPath = d.rawPath`) but leave `d.isKVv2` nil so the next `Fetch()` re-probes. Successful v1/v2 detections still cache as before.

Note: a permanent 403 on `sys/internal/ui/mounts` is a probe error, so the next Fetch re-probes; this matches #2149's request to re-detect rather than latch, and no extra retry/backoff is added beyond the existing fetch retry.

Revert plan: revert this PR.

## Testing

- `TestVaultReadQuery_isKVv2_NotCachedOnProbeError` — failed probe does not write the cache.
- `TestVaultReadQuery_isKVv2_RecoversAndDetectsKVv2` — failed probe then a successful one actually detects KV v2 (`secret/data/...`), stubbed with `httptest` (no live Vault/Nomad).

```
go test ./dependency -run 'TestVaultReadQuery_isKVv2_NotCachedOnProbeError|TestVaultReadQuery_isKVv2_RecoversAndDetectsKVv2' -count=1 -timeout 60s
```

Both pass.