### PR TITLE
support cross-namespace Nomad service queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# UNRELEASED
+
+IMPROVEMENTS:
+* nomad: add support for querying services from specific Nomad namespaces in `nomadService` and `nomadServices` [GH-2182](https://github.com/hashicorp/consul-template/pull/2182)
+
 # 0.42.1
 
 IMPROVEMENTS:

--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -16,21 +16,23 @@ import (
 )
 
 const (
-	dcRe           = `(@(?P<dc>[[:word:]\.\-\_]+))?`
-	keyRe          = `/?(?P<key>[^@\?]+)`
-	filterRe       = `(\|(?P<filter>[[:word:]\,]+))?`
-	serviceNameRe  = `(?P<name>[[:word:]\-\_]+)`
-	queryRe        = `(\?(?P<query>[[:word:]\-\_\=\&]+))?`
-	nodeNameRe     = `(?P<name>[[:word:]\.\-\_]+)`
-	nearRe         = `(~(?P<near>[[:word:]\.\-\_]+))?`
-	prefixRe       = `/?(?P<prefix>[^@\?]+)`
-	tagRe          = `((?P<tag>[[:word:]=:\.\-\_]+)\.)?`
-	regionRe       = `(@(?P<region>[[:word:]\.\-\_]+))?`
-	nvPathRe       = `/?(?P<path>[^@]+)`
-	nvNamespaceRe  = `(@(?P<namespace>[[:word:]\-\_]+))?`
-	nvListPrefixRe = `/?(?P<prefix>[^@]*)`
-	nvListNSRe     = `(@(?P<namespace>([[:word:]\-\_]+|\*)))?`
-	nvRegionRe     = `(\.(?P<region>[[:word:]\-\_]+))?`
+	dcRe                     = `(@(?P<dc>[[:word:]\.\-\_]+))?`
+	keyRe                    = `/?(?P<key>[^@\?]+)`
+	filterRe                 = `(\|(?P<filter>[[:word:]\,]+))?`
+	serviceNameRe            = `(?P<name>[[:word:]\-\_]+)`
+	queryRe                  = `(\?(?P<query>[[:word:]\-\_\=\&]+))?`
+	nodeNameRe               = `(?P<name>[[:word:]\.\-\_]+)`
+	nearRe                   = `(~(?P<near>[[:word:]\.\-\_]+))?`
+	prefixRe                 = `/?(?P<prefix>[^@\?]+)`
+	tagRe                    = `((?P<tag>[[:word:]=:\.\-\_]+)\.)?`
+	regionRe                 = `(@(?P<region>[[:word:]\.\-\_]+))?`
+	nomadNamespaceRe         = `(\?ns=(?P<namespace>[a-zA-Z0-9\-]{1,128}))?`
+	nomadNamespaceWildcardRe = `(\?ns=(?P<namespace>([a-zA-Z0-9\-]{1,128}|\*)))?`
+	nvPathRe                 = `/?(?P<path>[^@]+)`
+	nvNamespaceRe            = `(@(?P<namespace>[[:word:]\-\_]+))?`
+	nvListPrefixRe           = `/?(?P<prefix>[^@]*)`
+	nvListNSRe               = `(@(?P<namespace>([[:word:]\-\_]+|\*)))?`
+	nvRegionRe               = `(\.(?P<region>[[:word:]\-\_]+))?`
 
 	DefaultNonBlockingQuerySleepTime = 15 * time.Second
 )

--- a/dependency/nomad_service.go
+++ b/dependency/nomad_service.go
@@ -21,8 +21,8 @@ var (
 	// NomadServiceQueryRe is the regex that is used to understand a service
 	// specific Nomad query.
 	//
-	// e.g. "<tag=value>.<name>@<region>"
-	NomadServiceQueryRe = regexp.MustCompile(`\A` + tagRe + serviceNameRe + regionRe + `\z`)
+	// e.g. "<tag=value>.<name><?ns=namespace>@<region>"
+	NomadServiceQueryRe = regexp.MustCompile(`\A` + tagRe + serviceNameRe + nomadNamespaceRe + regionRe + `\z`)
 )
 
 func init() {
@@ -48,10 +48,11 @@ type NomadService struct {
 type NomadServiceQuery struct {
 	stopCh chan struct{}
 
-	region string
-	name   string
-	tag    string
-	choose string
+	region    string
+	name      string
+	namespace string
+	tag       string
+	choose    string
 }
 
 // NewNomadServiceQuery parses a string into a NomadServiceQuery which is
@@ -64,10 +65,11 @@ func NewNomadServiceQuery(s string) (*NomadServiceQuery, error) {
 	m := regexpMatch(NomadServiceQueryRe, s)
 
 	return &NomadServiceQuery{
-		stopCh: make(chan struct{}, 1),
-		region: m["region"],
-		name:   m["name"],
-		tag:    m["tag"],
+		stopCh:    make(chan struct{}, 1),
+		region:    m["region"],
+		name:      m["name"],
+		namespace: m["namespace"],
+		tag:       m["tag"],
 	}, nil
 }
 
@@ -107,7 +109,9 @@ func (d *NomadServiceQuery) Fetch(client *ClientSet, opts *QueryOptions) (interf
 
 	log.Printf("[TRACE] %s: GET %s", d, u)
 
-	entries, qm, err := client.Nomad().Services().Get(d.name, opts.ToNomadOpts())
+	nOpts := opts.ToNomadOpts()
+	nOpts.Namespace = d.namespace
+	entries, qm, err := client.Nomad().Services().Get(d.name, nOpts)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, d.String())
 	}
@@ -157,6 +161,9 @@ func (d *NomadServiceQuery) String() string {
 	name := d.name
 	if d.tag != "" {
 		name = d.tag + "." + name
+	}
+	if d.namespace != "" {
+		name = name + "?ns=" + d.namespace
 	}
 	if d.region != "" {
 		name = name + "@" + d.region

--- a/dependency/nomad_service_test.go
+++ b/dependency/nomad_service_test.go
@@ -81,6 +81,42 @@ func TestNewNomadServiceQuery(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"name_namespace",
+			"myservice?ns=foo",
+			&NomadServiceQuery{
+				name:      "myservice",
+				namespace: "foo",
+			},
+			false,
+		},
+		{
+			"name_namespace_region",
+			"myservice?ns=foo@us-east-1",
+			&NomadServiceQuery{
+				region:    "us-east-1",
+				name:      "myservice",
+				namespace: "foo",
+			},
+			false,
+		},
+		{
+			"tag_name_namespace_region",
+			"tag.myservice?ns=foo@us-east-1",
+			&NomadServiceQuery{
+				region:    "us-east-1",
+				name:      "myservice",
+				namespace: "foo",
+				tag:       "tag",
+			},
+			false,
+		},
+		{
+			"namespace_only",
+			"?ns=foo",
+			nil,
+			true,
+		},
 	}
 
 	for i, tc := range cases {
@@ -274,6 +310,21 @@ func TestNomadServiceQuery_String(t *testing.T) {
 			"tag_name_region",
 			"tag.name@us-east-1",
 			"nomad.service(tag.name@us-east-1)",
+		},
+		{
+			"name_namespace",
+			"myservice?ns=foo",
+			"nomad.service(myservice?ns=foo)",
+		},
+		{
+			"name_namespace_region",
+			"myservice?ns=foo@us-east-1",
+			"nomad.service(myservice?ns=foo@us-east-1)",
+		},
+		{
+			"tag_name_namespace_region",
+			"tag.myservice?ns=foo@us-east-1",
+			"nomad.service(tag.myservice?ns=foo@us-east-1)",
 		},
 	}
 

--- a/dependency/nomad_services.go
+++ b/dependency/nomad_services.go
@@ -11,7 +11,6 @@ import (
 	"regexp"
 	"sort"
 
-	nomadapi "github.com/hashicorp/nomad/api"
 	"github.com/pkg/errors"
 )
 
@@ -21,7 +20,9 @@ var (
 
 	// NomadServicesQueryRe is the regex that is used to understand a service
 	// listing Nomad query.
-	NomadServicesQueryRe = regexp.MustCompile(`\A` + regionRe + `\z`)
+	//
+	// e.g. "<?ns=namespace>@<region>", namespace may also be the wildcard "*"
+	NomadServicesQueryRe = regexp.MustCompile(`\A` + nomadNamespaceWildcardRe + regionRe + `\z`)
 )
 
 func init() {
@@ -30,8 +31,9 @@ func init() {
 
 // NomadServicesSnippet is a stub service entry in Nomad.
 type NomadServicesSnippet struct {
-	Name string
-	Tags ServiceTags
+	Name      string
+	Namespace string
+	Tags      ServiceTags
 }
 
 // nomadSortableSnippet is a sortable slice of NomadServicesSnippet structs.
@@ -46,7 +48,8 @@ func (s nomadSortableSnippet) Less(i, j int) bool { return s[i].Name < s[j].Name
 type NomadServicesQuery struct {
 	stopCh chan struct{}
 
-	region string
+	region    string
+	namespace string
 }
 
 // NewNomadServicesQuery parses a string into a NomadServicesQuery which is
@@ -58,8 +61,9 @@ func NewNomadServicesQuery(s string) (*NomadServicesQuery, error) {
 
 	m := regexpMatch(NomadServicesQueryRe, s)
 	return &NomadServicesQuery{
-		stopCh: make(chan struct{}, 1),
-		region: m["region"],
+		stopCh:    make(chan struct{}, 1),
+		region:    m["region"],
+		namespace: m["namespace"],
 	}, nil
 }
 
@@ -86,27 +90,31 @@ func (d *NomadServicesQuery) Fetch(clients *ClientSet, opts *QueryOptions) (inte
 		RawQuery: opts.String(),
 	})
 
-	namespaces, qm, err := clients.Nomad().Services().List(opts.ToNomadOpts())
+	nOpts := opts.ToNomadOpts()
+	nOpts.Namespace = d.namespace
+	listStubs, qm, err := clients.Nomad().Services().List(nOpts)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, d.String())
 	}
 
-	// Cross namespaces queries aren't allowed via consul-template, so only
-	// the namespace the client is configured for will be returned.
-	var entries []*nomadapi.ServiceRegistrationStub
-	if len(namespaces) > 0 {
-		entries = namespaces[0].Services
-	}
+	// The List API returns one entry per namespace. Flatten all namespace
+	// entries into a single slice (there will be more than one when the
+	// wildcard namespace "*" is used).
+	services := []*NomadServicesSnippet{}
 
-	log.Printf("[TRACE] %s: returned %d results", d, len(entries))
-
-	services := make([]*NomadServicesSnippet, len(entries))
-	for i, s := range entries {
-		services[i] = &NomadServicesSnippet{
-			Name: s.ServiceName,
-			Tags: deepCopyAndSortTags(s.Tags),
+	//	var entries []*nomadapi.ServiceRegistrationStub
+	for _, listStub := range listStubs {
+		for _, s := range listStub.Services {
+			services = append(services,
+				&NomadServicesSnippet{
+					Name:      s.ServiceName,
+					Namespace: listStub.Namespace,
+					Tags:      deepCopyAndSortTags(s.Tags),
+				})
 		}
 	}
+
+	log.Printf("[TRACE] %s: returned %d results", d, len(services))
 
 	sort.Stable(nomadSortableSnippet(services))
 
@@ -120,8 +128,15 @@ func (d *NomadServicesQuery) Fetch(clients *ClientSet, opts *QueryOptions) (inte
 
 // String returns the human-friendly version of this dependency.
 func (d *NomadServicesQuery) String() string {
-	if d.region != "" {
-		return fmt.Sprintf("nomad.services(@%s)", d.region)
+	if d.namespace != "" || d.region != "" {
+		ns, region := "", ""
+		if d.namespace != "" {
+			ns = "?ns=" + d.namespace
+		}
+		if d.region != "" {
+			region = "@" + d.region
+		}
+		return fmt.Sprintf("nomad.services(%s%s)", ns, region)
 	}
 	return "nomad.services"
 }

--- a/dependency/nomad_services_test.go
+++ b/dependency/nomad_services_test.go
@@ -37,6 +37,40 @@ func TestNewNomadServicesQueryQuery(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"namespace",
+			"?ns=foo",
+			&NomadServicesQuery{
+				namespace: "foo",
+			},
+			false,
+		},
+		{
+			"namespace_region",
+			"?ns=foo@us-east-1",
+			&NomadServicesQuery{
+				region:    "us-east-1",
+				namespace: "foo",
+			},
+			false,
+		},
+		{
+			"wildcard_namespace",
+			"?ns=*",
+			&NomadServicesQuery{
+				namespace: "*",
+			},
+			false,
+		},
+		{
+			"wildcard_namespace_region",
+			"?ns=*@us-east-1",
+			&NomadServicesQuery{
+				region:    "us-east-1",
+				namespace: "*",
+			},
+			false,
+		},
 	}
 
 	for i, tc := range cases {
@@ -66,8 +100,9 @@ func TestNomadServicesQuery_Fetch_1arg(t *testing.T) {
 			service: "",
 			exp: []*NomadServicesSnippet{
 				{
-					Name: "example-cache",
-					Tags: ServiceTags([]string{"tag1", "tag2"}),
+					Name:      "example-cache",
+					Namespace: "default",
+					Tags:      ServiceTags([]string{"tag1", "tag2"}),
 				},
 			},
 		},
@@ -105,6 +140,26 @@ func TestNomadServicesQuery_String(t *testing.T) {
 			"region",
 			"@us-east-1",
 			"nomad.services(@us-east-1)",
+		},
+		{
+			"namespace",
+			"?ns=foo",
+			"nomad.services(?ns=foo)",
+		},
+		{
+			"namespace_region",
+			"?ns=foo@us-east-1",
+			"nomad.services(?ns=foo@us-east-1)",
+		},
+		{
+			"wildcard_namespace",
+			"?ns=*",
+			"nomad.services(?ns=*)",
+		},
+		{
+			"wildcard_namespace_region",
+			"?ns=*@us-east-1",
+			"nomad.services(?ns=*@us-east-1)",
 		},
 	}
 

--- a/docs/templating-language.md
+++ b/docs/templating-language.md
@@ -2038,9 +2038,12 @@ This can also be used with a pipe function.
 
 ## Nomad Functions
 
-Nomad service registrations can be queried using the `nomadServices` and `nomadService` functions.
-Nomad variables can be queried using the `nomadVarList` and `nomadVar` functions.
-Typically these will be used from within a Nomad [template](https://www.nomadproject.io/docs/job-specification/template#nomad-services) configuration.
+Nomad service registrations can be queried using the `nomadServices` and
+`nomadService` functions.  Nomad variables can be queried using the
+`nomadVarList` and `nomadVar` functions.  Typically these will be used from
+within a Nomad
+[template](https://www.nomadproject.io/docs/job-specification/template#nomad-services)
+configuration.
 
 ### `nomadServices`
 
@@ -2052,9 +2055,29 @@ This can be used to query the names of services registered in Nomad.
 {{ end }}
 ```
 
+You can query for services within a specific namespace or region with syntax
+like `"?ns=<NAMESPACE>@<REGION>`. For example, to query within the `prod`
+namespace in the `us-east-1` region:
+
+```golang
+{{ range nomadServices "?ns=prod@us-east-1 }}
+  {{ .Name .Tags }}
+{{ end }}
+```
+
+You can query for services across all namespaces by providing the wildcard
+`*`. The `.Namespace` field may be useful here:
+
+```golang
+{{ range nomadServices "?ns=*@us-east-1 }}
+  {{ .Name .Namespace .Tags }}
+{{ end }}
+```
+
 ### `nomadService`
 
-This can be used to query for additional information about each instance of a service registered in Nomad.
+This can be used to query for additional information about each instance of a
+service registered in Nomad.
 
 ```golang
 {{ range nomadService "my-app" }}
@@ -2062,9 +2085,11 @@ This can be used to query for additional information about each instance of a se
 {{ end}}
 ```
 
-The `nomadService` function also supports basic load-balancing via a [rendezvous hashing](https://en.wikipedia.org/wiki/Rendezvous_hashing)
-algorithm implemented in Nomad's API. To activate this behavior, the function requires three arguments in this order:
-the number of instances desired, a unique but consistent identifier associated with the requester, and the service name.
+The `nomadService` function also supports basic load-balancing via a [rendezvous
+hashing](https://en.wikipedia.org/wiki/Rendezvous_hashing) algorithm implemented
+in Nomad's API. To activate this behavior, the function requires three arguments
+in this order: the number of instances desired, a unique but consistent
+identifier associated with the requester, and the service name.
 
 Typically the unique identifier would be the allocation ID in a Nomad job.
 
@@ -2073,6 +2098,17 @@ Typically the unique identifier would be the allocation ID in a Nomad job.
 {{range nomadService 3 $allocID "redis"}}
   {{.Address}} {{.Port}} | {{.Tags}} @ {{.Datacenter}}
 {{- end}}
+```
+
+You can query for services with a specific tag or within a specific namespace or
+region with syntax like `"<TAG>.<NAME>?ns=<NAMESPACE>@<REGION>`. For example, to
+query the `web` tag of the `app` service within the `prod` namespace in the
+`us-east-1` region:
+
+```golang
+{{ range nomadService "web.app?ns=prod@us-east-1" }}
+  {{ .Address }} {{ .Port }}
+{{ end}}
 ```
 
 ## Nomad Variables
@@ -2370,4 +2406,3 @@ If you would prefer to use format strings with a compacted inline printing style
 [text-template]: https://golang.org/pkg/text/template/ "Go's text/template package"
 [vault]: https://www.vaultproject.io "Vault by HashiCorp"
 [nomad]: https://www.nomadproject.io "Nomad by HashiCorp"
-


### PR DESCRIPTION
Add support in the Nomad service(s) dependencies for including a Nomad namespace in the queries. The syntax for this matches the namespace syntax of the existing Consul service queries. The `nomadServices` query will also support wildcard namespaces.

Fixes: https://github.com/hashicorp/consul-template/issues/2072
Ref: https://hashicorp.atlassian.net/browse/NMD-920
Ref: https://github.com/hashicorp/nomad/issues/14177

---

In addition to the added unit tests, I built a Nomad binary with this change included and ran an end-to-end test with Nomad jobs that register themselves with Nomad service discovery. The template text of the jobspec was as follows:

```
# all services
{{ range nomadServices "?ns=prod" }}
service {{ .Name | toLower }} {{ .Tags }}{
{{end}}
# end

# one service
{{ range nomadService "httpd-web?ns=prod" }}
upstream  {{ .Address }} {{ .Port }}
{{ end }}
# end
```

The full jobspec was as follows:

<details><summary>jobspec</summary>

```hcl
job "httpd" {

  group "web" {

    network {
      mode = "bridge"
      port "www" {
        to = 8001
      }
    }

    service {
      name     = "httpd-web"
      provider = "nomad"
      port     = "www"
    }

    task "http" {

      driver = "docker"

      config {
        image   = "busybox:1"
        command = "httpd"
        args    = ["-vv", "-f", "-p", "8001", "-h", "/local"]
        ports   = ["www"]
      }

      template {
        data = <<EOF
# all services
{{ range nomadServices "?ns=prod" }}
service {{ .Name | toLower }} {{ .Tags }}{
{{end}}
# end

# one service
{{ range nomadService "httpd-web?ns=prod" }}
upstream  {{ .Address }} {{ .Port }}
{{ end }}
# end

EOF

        destination = "local/out.txt"
      }

      resources {
        cpu    = 100
        memory = 100
      }

    }
  }
}
```

</details>

Setup:

```sh
$ nomad namespace apply prod
$ nomad job run -namespace prod ./httpd.nomad.hcl
$ nomad namespace apply dev
$ nomad job run -namespace dev ./httpd.nomad.hcl
```

See that the expected services are registered with Nomad:

```sh
$ nomad service list -namespace prod
Service Name  Tags
httpd-web     []

$ nomad service info -namespace prod httpd-web
Job ID  Address              Tags  Node ID   Alloc ID
httpd   192.168.1.194:29615  []    e9d0aa14  e53a9790
```

And see that consul-template in the Nomad binary has queried the services cross-namespace:

```sh
$ nomad alloc exec -namespace dev 8a cat local/out.txt
# all services

service httpd-web []{

# end

# one service

upstream  192.168.1.194 29615

# end
```


---

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
