### PR TITLE
Fix once=true from config file being overwritten by CLI default

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -469,7 +469,7 @@ func (cli *CLI) ParseFlags(args []string) (
 	}), "max-stale", "")
 
 	flags.Var((funcBoolVar)(func(b bool) error {
-		c.Once = *(config.Bool(b))
+		c.Once = config.Bool(b)
 		return nil
 	}), "once", "")
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -878,7 +878,7 @@ func TestCLI_ParseFlags(t *testing.T) {
 				Wait: &config.WaitConfig{
 					Enabled: config.Bool(false),
 				},
-				Once: true,
+				Once: config.Bool(true),
 			},
 			false,
 		},
@@ -1076,4 +1076,51 @@ func TestCLI_Run(t *testing.T) {
 			t.Errorf("timeout: %q", out.String())
 		}
 	})
+}
+
+func TestLoadConfigs_OnceFromConfigFile(t *testing.T) {
+	f, err := os.CreateTemp("", "ct-once-*.hcl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString("once = true\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	cliConfig := config.DefaultConfig()
+	got, err := loadConfigs([]string{f.Name()}, cliConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !config.BoolVal(got.Once) {
+		t.Fatal("once from config file should be respected when -once is not set on the CLI")
+	}
+}
+
+func TestLoadConfigs_OnceCLIFalseOverridesConfigFile(t *testing.T) {
+	f, err := os.CreateTemp("", "ct-once-*.hcl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString("once = true\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	cliConfig := config.DefaultConfig()
+	cliConfig.Once = config.Bool(false)
+	got, err := loadConfigs([]string{f.Name()}, cliConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.BoolVal(got.Once) {
+		t.Fatal("explicit -once=false should override once = true in the config file")
+	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -98,9 +98,9 @@ type Config struct {
 	// Wait is the quiescence timers.
 	Wait *WaitConfig `mapstructure:"wait"`
 
-	// Additional command line options
-	// Run once, executing each template exactly once, and exit
-	Once bool
+	// Once, when true, executes each template exactly once and exits.
+	// It may be set from the command line (-once) or a configuration file.
+	Once *bool `mapstructure:"once"`
 
 	// ParseOnly prevents any rendering and only loads the templates for
 	// checking well formedness.
@@ -285,7 +285,9 @@ func (c *Config) Merge(o *Config) *Config {
 		r.BlockQueryWaitTime = o.BlockQueryWaitTime
 	}
 
-	r.Once = o.Once
+	if o.Once != nil {
+		r.Once = o.Once
+	}
 	r.ParseOnly = o.ParseOnly
 	if o.ErrOnFailedLookup {
 		r.ErrOnFailedLookup = o.ErrOnFailedLookup
@@ -654,8 +656,12 @@ func (c *Config) Finalize() {
 	}
 	c.Wait.Finalize()
 
+	if c.Once == nil {
+		c.Once = Bool(false)
+	}
+
 	// disable Wait if -once was specified
-	if c.Once {
+	if BoolVal(c.Once) {
 		c.Wait = &WaitConfig{Enabled: Bool(false)}
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1974,7 +1974,7 @@ func TestFinalize(t *testing.T) {
 					Min:     TimeDuration(10 * time.Second),
 					Max:     TimeDuration(20 * time.Second),
 				},
-				Once: true,
+				Once: Bool(true),
 			},
 			&Config{
 				Wait: &WaitConfig{
@@ -2348,6 +2348,28 @@ func TestConfig_Merge(t *testing.T) {
 				ParseOnly: true,
 			},
 		},
+		{
+			"once_unset_does_not_overwrite",
+			&Config{
+				Once: Bool(true),
+			},
+			&Config{},
+			&Config{
+				Once: Bool(true),
+			},
+		},
+		{
+			"once_false_overrides_true",
+			&Config{
+				Once: Bool(true),
+			},
+			&Config{
+				Once: Bool(false),
+			},
+			&Config{
+				Once: Bool(false),
+			},
+		},
 	}
 
 	for i, tc := range cases {
@@ -2626,5 +2648,27 @@ func TestDefaultConfig(t *testing.T) {
 				t.Errorf("Config diff: %s", r.Diff(c))
 			}
 		})
+	}
+}
+
+func TestParse_Once(t *testing.T) {
+	c, err := Parse("once = true\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !BoolVal(c.Once) {
+		t.Fatalf("expected once=true from config file, got %#v", c.Once)
+	}
+}
+
+func TestConfig_Merge_OnceFromFileNotOverwrittenByCLIDefault(t *testing.T) {
+	file, err := Parse("once = true\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cli := DefaultConfig()
+	got := DefaultConfig().Merge(file).Merge(cli)
+	if !BoolVal(got.Once) {
+		t.Fatal("once from config file was overwritten by CLI default")
 	}
 }

--- a/manager/example_extfuncmap_test.go
+++ b/manager/example_extfuncmap_test.go
@@ -46,7 +46,7 @@ func Example_customFuncMap() {
 
 	// Create the (consul-template) Config
 	cfg := config.DefaultConfig()                // Start with default configuration
-	cfg.Once = true                              // Perform a one-shot render
+	cfg.Once = config.Bool(true)                 // Perform a one-shot render
 	cfg.Templates = &config.TemplateConfigs{tc1} // Add the template created earlier
 	cfg.Finalize()                               // Finalize the consul-template configuration
 

--- a/manager/example_manager_test.go
+++ b/manager/example_manager_test.go
@@ -38,7 +38,7 @@ func Example() {
 
 	// Create the (consul-template) Config
 	cfg := config.DefaultConfig()                 // Start with default configuration
-	cfg.Once = true                               // Perform a one-shot render
+	cfg.Once = config.Bool(true)                  // Perform a one-shot render
 	cfg.Templates = &config.TemplateConfigs{tCfg} // Add the template created earlier
 	cfg.Finalize()                                // Finalize the consul-template configuration
 

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -208,7 +208,7 @@ type RenderEvent struct {
 // Runner and any error that occurred during creation.
 func NewRunner(config *config.Config, dry bool) (*Runner, error) {
 	log.Printf("[INFO] (runner) creating new runner (dry: %v, once: %v)",
-		dry, config.Once)
+		dry, config.Once != nil && *config.Once)
 
 	runner := &Runner{
 		ErrCh:         make(chan error),
@@ -399,7 +399,7 @@ func (r *Runner) Start() {
 
 			// If we are running in once mode and all our templates are rendered,
 			// then we should exit here.
-			if r.config.Once {
+			if config.BoolVal(r.config.Once) {
 				log.Printf("[INFO] (runner) once mode and all templates rendered")
 
 				if r.child != nil {
@@ -795,7 +795,7 @@ func (r *Runner) runTemplate(tmpl *template.Template, runCtx *templateRunCtx) (*
 	// If we are in once mode and this template was already rendered, move
 	// onto the next one. We do not want to re-render the template if we are
 	// in once mode, and we certainly do not want to re-run any commands.
-	if r.config.Once {
+	if config.BoolVal(r.config.Once) {
 		r.renderEventsLock.RLock()
 		onceEvent, ok := r.renderEvents[tmpl.ID()]
 		r.renderEventsLock.RUnlock()
@@ -1061,7 +1061,7 @@ func (r *Runner) init(clients *dep.ClientSet) error {
 	r.renderEvents = make(map[string]*RenderEvent, numTemplates)
 
 	if *r.config.Dedup.Enabled {
-		if r.config.Once {
+		if config.BoolVal(r.config.Once) {
 			log.Printf("[INFO] (runner) disabling de-duplication in once mode")
 		} else {
 			r.dedup, err = NewDedupManager(r.config.Dedup, clients, r.brain, r.templates)
@@ -1482,7 +1482,7 @@ func newWatcher(c *config.Config, clients *dep.ClientSet) *watch.Watcher {
 	return watch.NewWatcher(&watch.NewWatcherInput{
 		Clients:             clients,
 		MaxStale:            config.TimeDurationVal(c.MaxStale),
-		Once:                c.Once,
+		Once:                config.BoolVal(c.Once),
 		BlockQueryWaitTime:  config.TimeDurationVal(c.BlockQueryWaitTime),
 		RenewVault:          clients.Vault().Token() != "" && config.BoolVal(c.Vault.RenewToken),
 		VaultAgentTokenFile: config.StringVal(c.Vault.VaultAgentTokenFile),

--- a/manager/runner_test.go
+++ b/manager/runner_test.go
@@ -56,7 +56,7 @@ func TestRunner_initTemplates(t *testing.T) {
 }
 
 func TestRunner_Receive(t *testing.T) {
-	c := config.TestConfig(&config.Config{Once: true})
+	c := config.TestConfig(&config.Config{Once: config.Bool(true)})
 	r, err := NewRunner(c, true)
 	if err != nil {
 		t.Fatal(err)
@@ -479,7 +479,7 @@ func TestRunner_Run(t *testing.T) {
 			var out bytes.Buffer
 
 			c := config.TestConfig(tc.c)
-			c.Once = true
+			c.Once = config.Bool(true)
 			c.Finalize()
 
 			r, err := NewRunner(c, true)
@@ -762,7 +762,7 @@ func TestRunner_Start(t *testing.T) {
 					Destination: config.String(out.Name()),
 				},
 			},
-			Once: true,
+			Once: config.Bool(true),
 		})
 		c.Finalize()
 
@@ -1064,7 +1064,7 @@ func TestRunner_Start(t *testing.T) {
 					Contents: config.String(`{{ key "render-in-memory" }}`),
 				},
 			},
-			Once: true,
+			Once: config.Bool(true),
 		})
 		c.Finalize()
 


### PR DESCRIPTION
## Summary
`once = true` in a config file was ignored because `Config.Merge` always copied the CLI's zero-value `Once` over the file value. `Once` is now `*bool`, so an unset `-once` flag no longer clobbers the file setting; an explicit `-once=false` still overrides.

Fixes #2100.

## Test plan
- [x] `go test ./config/`
- [x] `go test ./manager/` (with consul on PATH)
- [x] `go test . -run 'TestLoadConfigs_Once|TestCLI_ParseFlags'`