### PR TITLE
security: fix Vault KV v2 secret redaction bypass in template errors

### DIFF
--- a/template/funcs.go
+++ b/template/funcs.go
@@ -980,7 +980,7 @@ func explodeHelper(m map[string]interface{}, k string, v interface{}, p string) 
 		}
 		nest, ok := m[top].(map[string]interface{})
 		if !ok {
-			return fmt.Errorf("not a map: %q: %q already has value %q", p, top, m[top])
+			return fmt.Errorf("not a map: %q: %q already has a non-map value", p, top)
 		}
 		return explodeHelper(nest, key, v, k)
 	}

--- a/template/template.go
+++ b/template/template.go
@@ -12,6 +12,7 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
+	"github.com/hashicorp/consul/api"
 	"github.com/pkg/errors"
 	"github.com/ryanuber/go-glob"
 	"golang.org/x/exp/maps"
@@ -298,16 +299,90 @@ func (t *Template) Execute(i *ExecuteInput) (*ExecuteResult, error) {
 
 func redactinator(used *dep.Set, b *Brain, err error) error {
 	pairs := make([]string, 0, used.Len())
+
+	// collect recursively walks v and appends every scalar leaf value that is
+	// meaningful to redact. String and []byte values (the shape secret material
+	// takes) are redacted whenever they are non-empty, regardless of length, so
+	// short secrets (e.g. "1234", short usernames or access keys) are not
+	// leaked. Empty strings are skipped because registering "" would cause
+	// strings.NewReplacer to insert "[redacted]" between every character of the
+	// error message. Non-string scalars (e.g. a KV v2 metadata "version": 1)
+	// only carry a length threshold so short numbers don't corrupt unrelated
+	// parts of the message such as line and column numbers.
+	var collect func(v interface{})
+	collect = func(v interface{}) {
+		switch val := v.(type) {
+		case map[string]interface{}:
+			for _, child := range val {
+				collect(child)
+			}
+		case []interface{}:
+			for _, child := range val {
+				collect(child)
+			}
+		case string:
+			if val != "" {
+				pairs = append(pairs, val, "[redacted]")
+			}
+		case []byte:
+			if len(val) > 0 {
+				pairs = append(pairs, string(val), "[redacted]")
+			}
+		case bool, nil:
+			// no meaningful string to redact
+		default:
+			if s := fmt.Sprintf("%v", val); len(s) >= 5 {
+				pairs = append(pairs, s, "[redacted]")
+			}
+		}
+	}
+
 	for _, d := range used.List() {
 		if data, ok := b.Recall(d); ok {
 			if vd, ok := data.(*dep.Secret); ok {
-				for _, v := range vd.Data {
-					pairs = append(pairs, fmt.Sprintf("%v", v), "[redacted]")
+				// Walk Data recursively so KV v2 secrets (fields live under
+				// Data["data"]) are covered in addition to flat KV v1 secrets.
+				collect(vd.Data)
+				// Auth and WrapInfo are outside Data but can appear in errors
+				// e.g. via .Auth.ClientToken or .WrapInfo.Token in templates.
+				if vd.Auth != nil {
+					collect(vd.Auth.ClientToken)
+					collect(vd.Auth.Accessor)
+					// Metadata holds auth-method-specific values (e.g. LDAP
+					// username, AWS ARN) that can appear in error messages.
+					for _, v := range vd.Auth.Metadata {
+						collect(v)
+					}
 				}
+				if vd.WrapInfo != nil {
+					collect(vd.WrapInfo.Token)
+					// WrappedAccessor is a live Vault accessor; redact it
+					// alongside Token.
+					collect(vd.WrapInfo.WrappedAccessor)
+				}
+			}
+			// VaultPKIQuery stores a dep.PemEncoded; Key is private key
+			// material and must be redacted along with Cert, CA and CAChain.
+			if pem, ok := data.(dep.PemEncoded); ok {
+				collect(pem.Key)
+				collect(pem.Cert)
+				collect(pem.CA)
+				for _, c := range pem.CAChain {
+					collect(c)
+				}
+			}
+			// connectLeafFunc (caLeaf) stores *api.LeafCert which contains
+			// PrivateKeyPEM and CertPEM — both must be redacted.
+			if leaf, ok := data.(*api.LeafCert); ok {
+				collect(leaf.PrivateKeyPEM)
+				collect(leaf.CertPEM)
 			}
 			if nVar, ok := data.(*dep.NomadVarItems); ok {
 				for _, v := range nVar.Values() {
-					pairs = append(pairs, fmt.Sprintf("%v", v), "[redacted]")
+					// Route through collect so empty values are skipped;
+					// registering "" would make strings.NewReplacer insert
+					// "[redacted]" between every character of the error.
+					collect(v)
 				}
 			}
 		}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -2443,6 +2443,137 @@ func TestTemplate_error_secret_leak_SV(t *testing.T) {
 	require.ErrorContains(t, err, "[redacted]")
 }
 
+// TestTemplate_error_secret_leak_SV_emptyValue verifies that an empty Nomad
+// variable value does not poison strings.NewReplacer and corrupt the error
+// message (which would happen if "" were registered as a replacement key).
+func TestTemplate_error_secret_leak_SV_emptyValue(t *testing.T) {
+	b := NewBrain()
+	b.RWMutex = sync.RWMutex{}
+	nVar, err := dep.NewNVGetQuery("", "var/test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	nVar.EnableBlocking()
+	b.Remember(nVar, &dep.NomadVarItems{
+		"empty":  dep.NomadVarItem{Key: "empty", Value: ""},
+		"secret": dep.NomadVarItem{Key: "secret", Value: "varSecret"},
+	})
+	tpl, _ := NewTemplate(&NewTemplateInput{
+		Contents: `{{ with nomadVar "var/test" }}{{ .secret.Value | parseInt }}{{ end }}`,
+	})
+	_, err = tpl.Execute(&ExecuteInput{Brain: b})
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "varSecret")
+	// The message must not be corrupted by a "[redacted]" inserted between
+	// every character, which is what registering an empty key would cause.
+	require.NotContains(t, err.Error(), "[redacted][redacted]")
+	require.Contains(t, err.Error(), "parseInt")
+}
+
+// TestTemplate_error_secret_leak_KVv2 verifies that KV v2 secrets (fields
+// nested under Data["data"]) are redacted from error messages.
+func TestTemplate_error_secret_leak_KVv2(t *testing.T) {
+	b := NewBrain()
+	b.RWMutex = sync.RWMutex{}
+	d, err := dep.NewVaultReadQuery("secret/db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.Remember(d, &dep.Secret{
+		Data: map[string]interface{}{
+			"data":     map[string]interface{}{"max_conns": "s3cr3tROTATED-VALUE", "password": "s3cr3tPASSWORD"},
+			"metadata": map[string]interface{}{"version": 1, "deletion_time": ""},
+		},
+	})
+	tpl, _ := NewTemplate(&NewTemplateInput{
+		Contents: `{{ with secret "secret/db" }}{{ printf "%s %s" .Data.data.max_conns .Data.data.password | parseInt }}{{ end }}`,
+	})
+	_, err = tpl.Execute(&ExecuteInput{Brain: b})
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "s3cr3tROTATED-VALUE")
+	require.NotContains(t, err.Error(), "s3cr3tPASSWORD")
+	require.Contains(t, err.Error(), "[redacted]")
+	// Sanity check: the error prefix must survive intact. If the empty
+	// deletion_time string were ever registered as a replacer needle, the
+	// message would be corrupted and this would fail.
+	require.Contains(t, err.Error(), "parseInt")
+}
+
+// TestTemplate_error_secret_leak_ShortValue verifies that short secret string
+// values (fewer than 5 characters) are still redacted from error messages and
+// are not skipped by the numeric length threshold.
+func TestTemplate_error_secret_leak_ShortValue(t *testing.T) {
+	b := NewBrain()
+	b.RWMutex = sync.RWMutex{}
+	d, err := dep.NewVaultReadQuery("secret/db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.Remember(d, &dep.Secret{
+		Data: map[string]interface{}{
+			"data": map[string]interface{}{"pin": "1234"},
+		},
+	})
+	tpl, _ := NewTemplate(&NewTemplateInput{
+		Contents: `{{ with secret "secret/db" }}{{ printf "pin=%s!" .Data.data.pin | parseInt }}{{ end }}`,
+	})
+	_, err = tpl.Execute(&ExecuteInput{Brain: b})
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "1234")
+	require.Contains(t, err.Error(), "[redacted]")
+}
+
+// TestTemplate_error_secret_leak_AuthAndWrap verifies that Auth.ClientToken,
+// Auth.Accessor and WrapInfo.Token are redacted from error messages.
+func TestTemplate_error_secret_leak_AuthAndWrap(t *testing.T) {
+	// Auth.ClientToken + Auth.Accessor
+	b := NewBrain()
+	b.RWMutex = sync.RWMutex{}
+	d, err := dep.NewVaultWriteQuery("auth/token/create", map[string]interface{}{"policies": "pol"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.Remember(d, &dep.Secret{
+		Auth:     &dep.SecretAuth{ClientToken: "hvs.CAESIHXfaLongVaultToken", Accessor: "accessor-value-xyz"},
+		WrapInfo: &dep.SecretWrapInfo{Token: "hvs.WRAPINFOTokenLong"},
+	})
+	tpl, _ := NewTemplate(&NewTemplateInput{
+		Contents: `{{ with secret "auth/token/create" "policies=pol" }}{{ printf "%s %s %s" .Auth.ClientToken .Auth.Accessor .WrapInfo.Token | parseInt }}{{ end }}`,
+	})
+	_, err = tpl.Execute(&ExecuteInput{Brain: b})
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "hvs.CAESIHXfaLongVaultToken")
+	require.NotContains(t, err.Error(), "accessor-value-xyz")
+	require.NotContains(t, err.Error(), "hvs.WRAPINFOTokenLong")
+	require.Contains(t, err.Error(), "[redacted]")
+}
+
+// TestTemplate_error_explodeMap_noOracle verifies that the explodeMap oracle
+// attack is closed: the error must not quote a field the template never named.
+func TestTemplate_error_explodeMap_noOracle(t *testing.T) {
+	b := NewBrain()
+	b.RWMutex = sync.RWMutex{}
+	d, err := dep.NewVaultReadQuery("secret/app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// attacker injects "password/x" — sort.Strings guarantees "password" is
+	// placed first, so the collision and the value disclosure are deterministic.
+	b.Remember(d, &dep.Secret{
+		Data: map[string]interface{}{
+			"data": map[string]interface{}{
+				"password": "s3cr3tVICTIM-PASSWORD", "password/x": "1",
+			},
+		},
+	})
+	tpl, _ := NewTemplate(&NewTemplateInput{
+		Contents: `{{ with secret "secret/app" }}{{ .Data.data | explodeMap }}{{ end }}`,
+	})
+	_, err = tpl.Execute(&ExecuteInput{Brain: b})
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "s3cr3tVICTIM-PASSWORD")
+}
+
 func Test_writeToFile(t *testing.T) {
 	// Use current user and its primary group for input
 	currentUser, err := user.Current()
@@ -3062,4 +3193,101 @@ func TestIdenticalTemplateContentsDifferentHash(t *testing.T) {
 	if tpl1.ID() == tpl2.ID() {
 		t.Fatal("expected these templates to have different IDs")
 	}
+}
+
+// TestTemplate_error_secret_leak_AuthMetadata verifies that values in
+// SecretAuth.Metadata (e.g. LDAP username, AWS ARN) are redacted from errors.
+func TestTemplate_error_secret_leak_AuthMetadata(t *testing.T) {
+	b := NewBrain()
+	b.RWMutex = sync.RWMutex{}
+	// secret "path" with no extra args creates a NewVaultReadQuery — match that here.
+	d, err := dep.NewVaultReadQuery("auth/ldap/login/user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.Remember(d, &dep.Secret{
+		Auth: &dep.SecretAuth{
+			ClientToken: "hvs.ValidTokenString",
+			Metadata:    map[string]string{"username": "s3cr3tLDAPuser", "org": "s3cr3tORGvalue"},
+		},
+	})
+	tpl, _ := NewTemplate(&NewTemplateInput{
+		Contents: `{{ with secret "auth/ldap/login/user" }}{{ printf "%s %s" .Auth.Metadata.username .Auth.Metadata.org | parseInt }}{{ end }}`,
+	})
+	_, err = tpl.Execute(&ExecuteInput{Brain: b})
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "s3cr3tLDAPuser")
+	require.NotContains(t, err.Error(), "s3cr3tORGvalue")
+	require.Contains(t, err.Error(), "[redacted]")
+}
+
+// TestTemplate_error_secret_leak_WrappedAccessor verifies that
+// SecretWrapInfo.WrappedAccessor is redacted from error messages.
+func TestTemplate_error_secret_leak_WrappedAccessor(t *testing.T) {
+	b := NewBrain()
+	b.RWMutex = sync.RWMutex{}
+	d, err := dep.NewVaultReadQuery("secret/wrapped")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.Remember(d, &dep.Secret{
+		WrapInfo: &dep.SecretWrapInfo{
+			Token:           "hvs.WRAPTokenLongVal",
+			WrappedAccessor: "s3cr3tWrappedAccessorID",
+		},
+	})
+	tpl, _ := NewTemplate(&NewTemplateInput{
+		Contents: `{{ with secret "secret/wrapped" }}{{ printf "%s %s" .WrapInfo.Token .WrapInfo.WrappedAccessor | parseInt }}{{ end }}`,
+	})
+	_, err = tpl.Execute(&ExecuteInput{Brain: b})
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "s3cr3tWrappedAccessorID")
+	require.Contains(t, err.Error(), "[redacted]")
+}
+
+// TestTemplate_error_secret_leak_PKI verifies that PemEncoded fields from
+// VaultPKIQuery (Key, Cert, CA, CAChain) are redacted from error messages.
+func TestTemplate_error_secret_leak_PKI(t *testing.T) {
+	b := NewBrain()
+	b.RWMutex = sync.RWMutex{}
+	// pkiCertFunc uses i.destination as destPath; in tests destination is "".
+	d, err := dep.NewVaultPKIQuery("pki/issue/role", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.Remember(d, dep.PemEncoded{
+		Cert:    "s3cr3tCERTmaterial--long",
+		Key:     "s3cr3tKEYmaterial---long",
+		CA:      "s3cr3tCAmaterial----long",
+		CAChain: []string{"s3cr3tCAChain1--long", "s3cr3tCAChain2--long"},
+	})
+	tpl, _ := NewTemplate(&NewTemplateInput{
+		Contents: `{{ with pkiCert "pki/issue/role" }}{{ printf "%s %s %s %s %s" .Key .Cert .CA (index .CAChain 0) (index .CAChain 1) | parseInt }}{{ end }}`,
+	})
+	_, err = tpl.Execute(&ExecuteInput{Brain: b})
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "s3cr3tKEYmaterial---long")
+	require.NotContains(t, err.Error(), "s3cr3tCERTmaterial--long")
+	require.NotContains(t, err.Error(), "s3cr3tCAmaterial----long")
+	require.NotContains(t, err.Error(), "s3cr3tCAChain1--long")
+	require.NotContains(t, err.Error(), "s3cr3tCAChain2--long")
+}
+
+// TestTemplate_error_secret_leak_ConnectLeaf verifies that api.LeafCert fields
+// (PrivateKeyPEM, CertPEM) from caLeaf are redacted from error messages.
+func TestTemplate_error_secret_leak_ConnectLeaf(t *testing.T) {
+	b := NewBrain()
+	b.RWMutex = sync.RWMutex{}
+	d := dep.NewConnectLeafQuery("web")
+	b.Remember(d, &api.LeafCert{
+		CertPEM:       "s3cr3tCERTPEM---long",
+		PrivateKeyPEM: "s3cr3tPRIVATEKEY-long",
+	})
+	tpl, _ := NewTemplate(&NewTemplateInput{
+		Contents: `{{ with caLeaf "web" }}{{ printf "%s %s" .PrivateKeyPEM .CertPEM | parseInt }}{{ end }}`,
+	})
+	_, err := tpl.Execute(&ExecuteInput{Brain: b})
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "s3cr3tPRIVATEKEY-long")
+	require.NotContains(t, err.Error(), "s3cr3tCERTPEM---long")
 }


### PR DESCRIPTION
## Summary

Fixes a security vulnerability where Vault secret values stored in KV v2 escaped redaction and appeared verbatim in template error messages, log files, and Nomad task events.

## Root Cause

`redactinator()` in `template/template.go` iterated only the top level of `Secret.Data`. For KV v2 secrets the Vault API wraps the response one level deeper:

```
Data = {
  "data":     { "password": "hunter2" },   ← actual fields here
  "metadata": { "version": 1, ... }
}
```

The flat loop registered the string `"map[password:hunter2]"` and never registered `"hunter2"` itself, so `strings.NewReplacer` matched nothing and the secret went out verbatim in errors like:

```
[ERR] parseInt: strconv.ParseInt: parsing "s3cr3tROTATED-VALUE": invalid syntax
```

Under Nomad this error becomes a task event `SetDisplayMessage` — persisted in cluster state, served over the API to anyone with `read-job`, broadcast on the event stream, and included in operator snapshots. Both the `error_fatal=true` (default) and `error_fatal=false` log paths are affected since `redactinator` is called before the error returns to the runner.

Additionally, several Vault/PKI/Connect fields outside `Data` were entirely absent from redaction, leaking live tokens and private key material.

## Changes

### `template/template.go` — recursive walk in `redactinator`

Replaces the flat `range vd.Data` loop with a recursive `collect` closure that descends into nested `map[string]interface{}` and `[]interface{}` values and registers every scalar leaf. Redaction now also covers fields that live outside `Data`:

- `Auth.ClientToken`, `Auth.Accessor`, and `Auth.Metadata` (e.g. LDAP username, AWS ARN)
- `WrapInfo.Token` and `WrapInfo.WrappedAccessor`
- `PemEncoded` PKI material (`Key`, `Cert`, `CA`, `CAChain`) from `pkiCert`
- `*api.LeafCert` `PrivateKeyPEM` and `CertPEM` from `caLeaf`

Non-empty `string`/`[]byte` values are redacted regardless of length so short secrets (e.g. `"1234"`, short usernames or access keys) are not leaked. Empty strings are skipped so `strings.NewReplacer` is not poisoned by a `""` key (which would insert `[redacted]` between every character), and a length threshold is applied only to non-string scalars so short numbers (e.g. metadata `version: 1`) don't corrupt line/column numbers. `nil` and `bool` are skipped. Nomad variable values are routed through the same `collect` path so empty values are skipped too.

### `template/funcs.go` — remove value from `explodeHelper` error

The old format string embedded `m[top]` — the value of a **different** field than the one that failed. Combined with `explodeMap`'s deterministic `sort.Strings` ordering, this allowed an attacker holding only Vault `patch` capability (not `read`) to enumerate secret field values one at a time by injecting slash-suffixed keys (e.g. `vault kv patch secret/app password/x=1`). The value is removed from the error string entirely.

## Tests

Regression tests added to `template/template_test.go`. Each test embeds the asserted values directly in the failing expression so the `NotContains` checks would fail if any field regressed:

| Test | What it covers |
|---|---|
| `TestTemplate_error_secret_leak_KVv2` | KV v2 nested shape — `parseInt` error must not contain nested secret fields; also asserts the `parseInt` prefix survives so empty-string poisoning is detectable |
| `TestTemplate_error_secret_leak_ShortValue` | Short secret strings (<5 chars) are still redacted |
| `TestTemplate_error_secret_leak_SV_emptyValue` | Empty Nomad variable value does not corrupt the error message |
| `TestTemplate_error_secret_leak_AuthAndWrap` | `Auth.ClientToken`, `Auth.Accessor`, and `WrapInfo.Token` are redacted |
| `TestTemplate_error_secret_leak_AuthMetadata` | `Auth.Metadata` values are redacted |
| `TestTemplate_error_secret_leak_WrappedAccessor` | `WrapInfo.WrappedAccessor` is redacted |
| `TestTemplate_error_secret_leak_PKI` | `PemEncoded` `Key`/`Cert`/`CA`/`CAChain` are redacted |
| `TestTemplate_error_secret_leak_ConnectLeaf` | `LeafCert` `PrivateKeyPEM`/`CertPEM` are redacted |
| `TestTemplate_error_explodeMap_noOracle` | `explodeMap` oracle attack closed — attacker-injected slash-key must not expose sibling field value |
